### PR TITLE
Fix potential command injection in tunnel creation

### DIFF
--- a/doc/tunnel-command-injection-poc.rst
+++ b/doc/tunnel-command-injection-poc.rst
@@ -1,0 +1,28 @@
+Tunnel Command Injection PoC
+============================
+
+This document describes a proof-of-concept demonstrating the
+command injection vulnerability that existed in `vncviewer`'s
+SSH tunnel handling prior to commit 7541601f.
+
+Background
+---------
+
+`createTunnel()` constructed an SSH command using environment
+variables for the gateway and remote host values. These were
+expanded by the shell when running `system()`. Because the
+parameters were not validated, special shell syntax such as
+command substitution could be injected via the `-via` parameter.
+
+Proof of concept
+----------------
+
+Build `vncviewer` from a commit prior to 7541601f and run:
+
+.. code-block:: bash
+
+   vncviewer -via '$(touch /tmp/vuln)' localhost:1
+
+During tunnel setup the `touch` command executes, creating the
+file `/tmp/vuln`. The fixed version rejects this argument and
+prints ``Unsafe characters in host specification``.

--- a/vncviewer/vncviewer.cxx
+++ b/vncviewer/vncviewer.cxx
@@ -593,6 +593,21 @@ createTunnel(const char *gatewayHost, const char *remoteHost,
              int remotePort, int localPort)
 {
   const char *cmd = getenv("VNC_VIA_CMD");
+  auto isSafeArg = [](const char *arg) {
+    if (!arg)
+      return false;
+    while (*arg) {
+      if (!isalnum((unsigned char)*arg) && !strchr("._:-@[]", *arg))
+        return false;
+      arg++;
+    }
+    return true;
+  };
+
+  if (!isSafeArg(gatewayHost) || !isSafeArg(remoteHost)) {
+    fprintf(stderr, "Unsafe characters in host specification\n");
+    return;
+  }
   char *cmd2, *percent;
   char lport[10], rport[10];
   sprintf(lport, "%d", localPort);


### PR DESCRIPTION
## Summary
- sanitize gateway and remote host strings used for SSH tunnel creation
- document proof-of-concept demonstrating the previous vulnerability

## Testing
- `cmake ..` *(fails: Could not find Pixman)*

------
https://chatgpt.com/codex/tasks/task_e_6847e50c44e0832ab757dd09db2757ee