### PR TITLE
Add translator context to OptionsDialog strings

### DIFF
--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.14.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2025-01-14 16:15+0100\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2025-01-22 11:46+0100\n"
 "Last-Translator: Alexander Shopov <ash@kambanaria.org>\n"
 "Language-Team: Bulgarian <dict@ludost.net>\n"
@@ -18,17 +18,17 @@ msgstr ""
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: vncviewer/CConn.cxx:102
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "Връзка към гнездо „%s“"
 
-#: vncviewer/CConn.cxx:109
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "Връзка към машина „%s“, порт %d"
 
-#: vncviewer/CConn.cxx:114
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -39,66 +39,64 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:151
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Име на работен плот: %.80s"
 
-#: vncviewer/CConn.cxx:154
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Машина: %.80s, порт: %d"
 
-#: vncviewer/CConn.cxx:158
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Размер: %d ✕ %d"
 
-#: vncviewer/CConn.cxx:165
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Формат на пикселите: %s"
 
-#: vncviewer/CConn.cxx:170
-#, c-format
-msgid "(server default %s)"
-msgstr "(стандартното за сървъра %s)"
-
-#: vncviewer/CConn.cxx:173
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Заявено кодиране: %s"
 
-#: vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Последно ползвано кодиране: %s"
 
-#: vncviewer/CConn.cxx:181
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Оценка на скоростта на линията: %d kbit/s"
 
-#: vncviewer/CConn.cxx:185
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Версия на протокола: %d.%d"
 
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Вид сигурност: %s"
 
-#: vncviewer/CConn.cxx:250 vncviewer/CConn.cxx:252
-msgid "The connection was dropped by the server before the session could be established."
-msgstr "Връзката бе прекъсната от страната на сървъра, преди да се установи сесия."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
+msgstr ""
+"Връзката бе прекъсната от страната на сървъра, преди да се установи сесия."
 
-#: vncviewer/CConn.cxx:262
+#: vncviewer/CConn.cxx:258
 #, c-format
 msgid "Authentication failed: %s"
 msgstr "Неуспешна идентификация: %s"
 
-#: vncviewer/CConn.cxx:263
+#: vncviewer/CConn.cxx:259
 #, c-format
 msgid ""
 "Failed to authenticate with the server. Reason given by the server:\n"
@@ -109,31 +107,22 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:335
-#, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "Неуспешно задаване на размер на плота чрез SetDesktopSize: %d"
-
-#: vncviewer/CConn.cxx:408
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "Неправилна палитра SetColourMapEntries от сървъра!"
-
-#: vncviewer/CConn.cxx:516
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Скорост %d kbit/s — преминаване към качество %d"
 
-#: vncviewer/CConn.cxx:538
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "Скорост %d kbit/s — пълният цвят е включен"
 
-#: vncviewer/CConn.cxx:541
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "Скорост %d kbit/s — пълният цвят е изключен"
 
-#: vncviewer/CConn.cxx:567
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Ползва се формат на пикселите %s"
@@ -146,136 +135,129 @@ msgstr "Указани са неправилни размери!"
 msgid "Reducing window size to fit on current monitor"
 msgstr "Намаляване на размера на прозореца, за да се побере на текущия монитор"
 
-#: vncviewer/DesktopWindow.cxx:646
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
 msgstr "Преоразмеряване на екрана за избягване на случайна заявка за цял екран"
 
-#: vncviewer/DesktopWindow.cxx:694
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "За контекстното меню натиснете клавиша „%s“"
 
-#: vncviewer/DesktopWindow.cxx:1094 vncviewer/DesktopWindow.cxx:1102
-#: vncviewer/DesktopWindow.cxx:1122
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Неуспешно прихващане на клавиатурата"
 
-#: vncviewer/DesktopWindow.cxx:1411
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
-msgstr "Изчислено е неправилно разположение на екрана според заявката за преоразмеряване!"
+msgstr ""
+"Изчислено е неправилно разположение на екрана според заявката за "
+"преоразмеряване!"
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "Неправилно състояние за емулиране на 3 бутона"
 
-#: vncviewer/KeyboardWin32.cxx:242
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "Липсва код за разширения виртуален клавиш 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:244
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "Липсва код за виртуалния клавиш 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:250
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "Неправилен код 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:262
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "Липсва знак за разширения виртуален клавиш 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:264
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "Липсва знак за виртуалния клавиш 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:423
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
 msgid "Failed to update keyboard LED state: %lu"
-msgstr "Неуспешно обновяване на състоянието на светодиодите на клавиатурата: %lu"
+msgstr ""
+"Неуспешно обновяване на състоянието на светодиодите на клавиатурата: %lu"
 
-#: vncviewer/KeyboardX11.cxx:104
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "Липсва знак за кода за клавиш %d (в текущото състояние)"
 
-#: vncviewer/KeyboardX11.cxx:129
+#: vncviewer/KeyboardX11.cxx:148
 #, c-format
 msgid "Failed to get keyboard LED state: %d"
-msgstr "Неуспешно получаване на състоянието на светодиодите на клавиатурата: %d"
+msgstr ""
+"Неуспешно получаване на състоянието на светодиодите на клавиатурата: %d"
 
-#: vncviewer/KeyboardX11.cxx:174
+#: vncviewer/KeyboardX11.cxx:193
 msgid "Failed to update keyboard LED state"
 msgstr "Неуспешно обновяване на състоянието на светодиодите на клавиатурата"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:100
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "Неуспешно получаване на настройките на монитора"
 
-#: vncviewer/MonitorIndicesParameter.cxx:79
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "Указани са неправилни настройки за „%s“"
-
-#: vncviewer/MonitorIndicesParameter.cxx:86
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "Монитор с индекс %d не съществува"
 
-#: vncviewer/MonitorIndicesParameter.cxx:162
-#: vncviewer/MonitorIndicesParameter.cxx:182
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "Неправилен индекс на монитор „%s“"
-
-#: vncviewer/MonitorIndicesParameter.cxx:170
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "Неочакван знак „%c“"
-
-#: vncviewer/OptionsDialog.cxx:64
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
 msgid "TigerVNC options"
 msgstr "Настройки на TigerVNC"
 
-#: vncviewer/OptionsDialog.cxx:97 vncviewer/ServerDialog.cxx:107
-#: vncviewer/vncviewer.cxx:397
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "Отмяна"
 
-#: vncviewer/OptionsDialog.cxx:102 vncviewer/vncviewer.cxx:396
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "Добре"
 
-#: vncviewer/OptionsDialog.cxx:514
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "Компресия"
 
-#: vncviewer/OptionsDialog.cxx:530
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "Автоматичен избор"
 
-#: vncviewer/OptionsDialog.cxx:541
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "Предпочитано кодиране"
 
-#: vncviewer/OptionsDialog.cxx:602
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "Цвят"
 
-#: vncviewer/OptionsDialog.cxx:614
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "Пълен"
 
-#: vncviewer/OptionsDialog.cxx:621
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "Среден"
 
-#: vncviewer/OptionsDialog.cxx:628
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "Беден"
 
@@ -283,166 +265,177 @@ msgstr "Беден"
 msgid "Very low"
 msgstr "Съвсем беден"
 
-#: vncviewer/OptionsDialog.cxx:657
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "Ниво на компресия:"
 
-#: vncviewer/OptionsDialog.cxx:664
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "ниво (0≡бързо, 9≡най-добро)"
 
-#: vncviewer/OptionsDialog.cxx:671
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "Ползване на компресия JPEG:"
 
-#: vncviewer/OptionsDialog.cxx:678
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "качество (0≡лошо, 9≡най-добро)"
 
-#: vncviewer/OptionsDialog.cxx:689
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "Сигурност"
 
-#: vncviewer/OptionsDialog.cxx:703
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "Шифриране"
 
-#: vncviewer/OptionsDialog.cxx:715 vncviewer/OptionsDialog.cxx:782
-#: vncviewer/OptionsDialog.cxx:905
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "Без"
 
-#: vncviewer/OptionsDialog.cxx:722
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "TLS + анонимен сертификат"
 
-#: vncviewer/OptionsDialog.cxx:728
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "TLS + сертификат X509"
 
-#: vncviewer/OptionsDialog.cxx:735
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "Път към сертификата на удостоверителя по X509"
 
-#: vncviewer/OptionsDialog.cxx:742
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "Път към файла CPL по X509"
 
-#: vncviewer/OptionsDialog.cxx:770
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "Идентификация"
 
-#: vncviewer/OptionsDialog.cxx:788
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "Стандартна за VNC (несигурна без шифриране)"
 
-#: vncviewer/OptionsDialog.cxx:794
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "Име и парола (несигурна без шифриране)"
 
-#: vncviewer/OptionsDialog.cxx:822
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "Права̀"
 
-#: vncviewer/OptionsDialog.cxx:835
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "Визуализация (без вход от мишка и клавиатура)"
 
-#: vncviewer/OptionsDialog.cxx:842
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "Мишка"
 
-#: vncviewer/OptionsDialog.cxx:854
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "Емулация на среден бутон на мишката"
 
-#: vncviewer/OptionsDialog.cxx:860
+#: vncviewer/OptionsDialog.cxx:880
 msgid "Show local cursor when not provided by server"
 msgstr "Показване на локален курсор, когато сървърът не предоставя такъв"
 
-#: vncviewer/OptionsDialog.cxx:865
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
 msgid "Cursor type"
 msgstr "Вид курсор"
 
-#: vncviewer/OptionsDialog.cxx:867
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
 msgid "Dot"
 msgstr "Точка"
 
-#: vncviewer/OptionsDialog.cxx:868
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
 msgid "System"
 msgstr "Системен"
 
-#: vncviewer/OptionsDialog.cxx:888
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "Клавиатура"
 
-#: vncviewer/OptionsDialog.cxx:900
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
 msgstr "Изпращане на системните клавиши директно към сървъра (при цял екран)"
 
-#: vncviewer/OptionsDialog.cxx:903
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "Клавиш за контекстното меню"
 
-#: vncviewer/OptionsDialog.cxx:926
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "Буфер за обмен"
 
-#: vncviewer/OptionsDialog.cxx:938
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "Приемане на буфера за обмен от сървъра"
 
-#: vncviewer/OptionsDialog.cxx:946
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "Задаване и на основния избор"
 
-#: vncviewer/OptionsDialog.cxx:953
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "Изпращане на буфера за обмен към сървъра"
 
-#: vncviewer/OptionsDialog.cxx:961
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "Изпращане на основния избор като буфер за обмен"
 
-#: vncviewer/OptionsDialog.cxx:982
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "Визуализация"
 
-#: vncviewer/OptionsDialog.cxx:996
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "Режим на визуализация"
 
-#: vncviewer/OptionsDialog.cxx:1009
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "В прозорец"
 
-#: vncviewer/OptionsDialog.cxx:1017
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "На цял екран на текущия монитор"
 
-#: vncviewer/OptionsDialog.cxx:1025
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "На цял екран на всички монитори"
 
-#: vncviewer/OptionsDialog.cxx:1033
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "На цял екран на избрания монитор/и"
 
-#: vncviewer/OptionsDialog.cxx:1062
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
 msgid "Miscellaneous"
 msgstr "Разни"
 
-#: vncviewer/OptionsDialog.cxx:1070
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "Споделена (без прекъсване на връзката към останалите визуализатори)"
 
-#: vncviewer/OptionsDialog.cxx:1076
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "Запитване на повторно свързване при грешка"
-
-#: vncviewer/ServerDialog.cxx:63
-msgid "VNC viewer: Connection details"
-msgstr "Визуализатор: информация за връзката"
 
 #: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
@@ -487,7 +480,7 @@ msgstr "Настройки на връзка за TigerVNC (*.tigervnc)"
 msgid "Select a TigerVNC configuration file"
 msgstr "Избор на файл с настройки на връзка за TigerVNC"
 
-#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:517
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -507,7 +500,7 @@ msgstr "Запазване на настройките на връзката в�
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "Файлът „%s“ вече съществува, да се презапише ли"
 
-#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:394
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "Не"
 
@@ -548,169 +541,172 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:351 vncviewer/ServerDialog.cxx:429
-#: vncviewer/vncviewer.cxx:580
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
 msgid "Could not determine VNC state directory path"
 msgstr "Пътят до папката за състоянието на VNC не може да бъде получен"
 
-#: vncviewer/ServerDialog.cxx:363 vncviewer/ServerDialog.cxx:437
-#: vncviewer/parameters.cxx:671 vncviewer/parameters.cxx:752
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
 msgid "Could not open \"%s\""
 msgstr "„%s“ не може да се отвори"
 
-#: vncviewer/ServerDialog.cxx:378 vncviewer/ServerDialog.cxx:387
-#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:773
-#: vncviewer/parameters.cxx:807 vncviewer/parameters.cxx:837
-#: vncviewer/parameters.cxx:844
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
 msgid "Failed to read line %d in file \"%s\""
 msgstr "Ред %d от файл „%s“ не може да се прочете"
 
-#: vncviewer/ServerDialog.cxx:390 vncviewer/parameters.cxx:776
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "Прекалено дълъг ред"
 
-#: vncviewer/UserDialog.cxx:123
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "Файлът с паролата не може да се отвори"
 
-#: vncviewer/UserDialog.cxx:143
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "Идентификация за VNC"
 
-#: vncviewer/UserDialog.cxx:150
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "Тази връзка е сигурна"
 
-#: vncviewer/UserDialog.cxx:154
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "Тази връзка не е сигурна"
 
-#: vncviewer/UserDialog.cxx:176
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "Име:"
 
-#: vncviewer/UserDialog.cxx:189
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "Парола:"
 
-#: vncviewer/UserDialog.cxx:197
+#: vncviewer/UserDialog.cxx:204
 msgid "Keep password for reconnect"
 msgstr "Запазване на паролата за повторно свързване"
 
-#: vncviewer/Viewport.cxx:695
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
 msgid "Disconn&ect"
 msgstr "&Прекъсване на връзка"
 
-#: vncviewer/Viewport.cxx:698
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "&Цял екран"
 
-#: vncviewer/Viewport.cxx:701
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "&Минимизиране"
 
-#: vncviewer/Viewport.cxx:703
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "&Преоразмеряване на прозореца към сесията"
 
-#: vncviewer/Viewport.cxx:708
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "„&Ctrl“"
 
-#: vncviewer/Viewport.cxx:711
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "„&Alt“"
 
-#: vncviewer/Viewport.cxx:717
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "Изпращане на „%s“"
 
-#: vncviewer/Viewport.cxx:724
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Изпращане на „Ctrl-Alt-&Del“"
 
-#: vncviewer/Viewport.cxx:727
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "Опресняване на &екрана"
 
-#: vncviewer/Viewport.cxx:730
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&Настройки…"
 
-#: vncviewer/Viewport.cxx:732
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "&Информация за връзката…"
 
-#: vncviewer/Viewport.cxx:734
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "&Относно TigerVNC…"
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:830
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "Информация за връзката по VNC"
 
-#: vncviewer/Win32TouchHandler.cxx:48
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "Прозорецът е регистриран за докосване, а не за жестове"
 
-#: vncviewer/Win32TouchHandler.cxx:83
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "Настройките на жестовете не може да се зададат (грешка 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:95
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "Неуспешно получаване на информацията за жестове (грешка 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:360
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr "Неправилен бутон на мишка: %d — трябва да е от 1 до 7, включително."
 
-#: vncviewer/Win32TouchHandler.cxx:425
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
-msgstr "Неподдържан клавиш 0x%x — не може да се генерира събитие от клавиатурата."
+msgstr ""
+"Неподдържан клавиш 0x%x — не може да се генерира събитие от клавиатурата."
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:107
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
-msgstr "Не може да се получи маската за събития по X Input 2 за прозорец 0x%08lx"
+msgstr ""
+"Не може да се получи маската за събития по X Input 2 за прозорец 0x%08lx"
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr "Прозорец 0x%08lx няма маска за събития по X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:114
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr "Прозорец 0x%08lx има поне две маски за събития по X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "Неуспешно прихващане на устройство %i"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-msgid "TigerVNC Viewer"
-msgstr "Визуализатор на TigerVNC"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -718,100 +714,127 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr "Свързване към сървър за VNC и визуализация на отдалечено работно място"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
-msgstr "Virtual Network Computing (VNC — виртуални компютри по мрежата) е система за отдалечена визуализация, която позволява да работите с виртуална работна среда, която е стартирана на друг компютър в мрежата. С VNC може да стартирате графични приложения на отдалечени машини, а да ги визуализирате на собственото си устройство. Пакетът съдържа клиент, с който може да се свържете към отдалечени работни среди, които ползват сървър за VNC. Самата система VNC е платформено независима и поддържа различни операционни системи и хардуерни архитектури както за сървъри, така и за клиенти."
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+"Virtual Network Computing (VNC — виртуални компютри по мрежата) е система за "
+"отдалечена визуализация, която позволява да работите с виртуална работна "
+"среда, която е стартирана на друг компютър в мрежата. С VNC може да "
+"стартирате графични приложения на отдалечени машини, а да ги визуализирате "
+"на собственото си устройство. Пакетът съдържа клиент, с който може да се "
+"свържете към отдалечени работни среди, които ползват сървър за VNC. Самата "
+"система VNC е платформено независима и поддържа различни операционни системи "
+"и хардуерни архитектури както за сървъри, така и за клиенти."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
-msgstr "TigerVNC е високоскоростна версия на VNC, която произлиза от RealVNC 4 и X.org. TigerVNC се появява като версия на TightVNC за разработчици под Unix и Linux, но се отделя от родителския проект още през 2009, за да може проектът TightVNC да се концентрира върху Windows. TigerVNC поддържа вариант на кодирането Tight, което е ускорено чрез ползването на кодера за JPEG „libjpeg-turbo“."
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+"TigerVNC е високоскоростна версия на VNC, която произлиза от RealVNC 4 и X."
+"org. TigerVNC се появява като версия на TightVNC за разработчици под Unix и "
+"Linux, но се отделя от родителския проект още през 2009, за да може проектът "
+"TightVNC да се концентрира върху Windows. TigerVNC поддържа вариант на "
+"кодирането Tight, което е ускорено чрез ползването на кодера за JPEG "
+"„libjpeg-turbo“."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC viewer connection to a CentOS machine"
-msgstr "Визуализатор на TigerVNC: връзка към CentOS"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC viewer connection to a macOS machine"
-msgstr "Визуализатор на TigerVNC: връзка към MacOS"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC viewer connection to a Windows machine"
-msgstr "Визуализатор на TigerVNC: връзка към Windows"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
 #. developer_name tag deprecated with Appstream 1.0
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
-#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:48
 msgid "The TigerVNC team"
 msgstr "Екипът на TigerVNC"
 
-#: vncviewer/parameters.cxx:319 vncviewer/parameters.cxx:344
-#: vncviewer/parameters.cxx:361 vncviewer/parameters.cxx:401
-#: vncviewer/parameters.cxx:421
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "Името на опцията е прекалено дълго"
 
-#: vncviewer/parameters.cxx:323 vncviewer/parameters.cxx:328
-#: vncviewer/parameters.cxx:379
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "Стойността на опцията е прекалено голяма"
 
-#: vncviewer/parameters.cxx:386 vncviewer/parameters.cxx:712
-#: vncviewer/parameters.cxx:822
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "Неправилен формат или прекалено голяма стойност"
 
-#: vncviewer/parameters.cxx:440 vncviewer/parameters.cxx:473
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "Ключът за регистъра не може да се създаде"
 
-#: vncviewer/parameters.cxx:461 vncviewer/parameters.cxx:528
-#: vncviewer/parameters.cxx:571 vncviewer/parameters.cxx:638
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "Ключът за регистъра не може да се затвори"
 
-#: vncviewer/parameters.cxx:479 vncviewer/parameters.cxx:506
-#: vncviewer/parameters.cxx:680 vncviewer/parameters.cxx:692
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "„%s“ не може да се запише: %s"
 
-#: vncviewer/parameters.cxx:489 vncviewer/parameters.cxx:520
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "„%s“ не може да се изтрие: %s"
 
-#: vncviewer/parameters.cxx:544 vncviewer/parameters.cxx:616
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "Ключът за регистъра не може да си отвори"
 
-#: vncviewer/parameters.cxx:561
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "Запис №%d в историята на сървърите не може да си прочете: %s"
 
-#: vncviewer/parameters.cxx:597 vncviewer/parameters.cxx:627
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "Неуспешно прочитане на опцията „%s“: %s"
 
-#: vncviewer/parameters.cxx:661 vncviewer/parameters.cxx:740
-#: vncviewer/vncviewer.cxx:546
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
 msgid "Could not determine VNC config directory path"
 msgstr "Пътят до папката за настройките на VNC не може да се получи"
 
-#: vncviewer/parameters.cxx:682 vncviewer/parameters.cxx:694
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "Опцията не може да си кодира"
 
-#: vncviewer/parameters.cxx:785
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "Неправилен формат на файла с настройки „%s“"
 
-#: vncviewer/parameters.cxx:809
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "Неправилен формат"
 
-#: vncviewer/parameters.cxx:846
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "Непозната опция"
 
@@ -828,12 +851,15 @@ msgstr "Посочен е неправилен прозорец 0x%08lx за п�
 #: vncviewer/touch.cxx:183 vncviewer/touch.cxx:184
 #, c-format
 msgid "Failed to create touch handler: %s"
-msgstr "Функционалността за обработка на събития докосване не може да се създаде: %s"
+msgstr ""
+"Функционалността за обработка на събития докосване не може да се създаде: %s"
 
 #: vncviewer/touch.cxx:188
 #, c-format
 msgid "Couldn't attach event handler to window (error 0x%x)"
-msgstr "Не може да се закачи функция за обработка на събития към прозорец (грешка 0x%x)"
+msgstr ""
+"Не може да се закачи функция за обработка на събития към прозорец (грешка "
+"0x%x)"
 
 #: vncviewer/touch.cxx:215
 msgid "Failed to get event data for X Input event"
@@ -852,25 +878,23 @@ msgid "X Input 2 (or newer) is not available."
 msgstr "Липсва версия 2 или по-нова на разширението X Input."
 
 #: vncviewer/touch.cxx:266
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
-msgstr "Липсва версия 2.2 или по-нова на разширението X Input. Събитията жестове не се поддържат."
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+"Липсва версия 2.2 или по-нова на разширението X Input. Събитията жестове не "
+"се поддържат."
 
-#: vncviewer/vncviewer.cxx:104
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
 "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"Визуализатор на TigerVNC, версия: %s\n"
-"Компилиран на: %s\n"
-"Авторски права © 1999-%d екипът на TigerVNC и мн. др.\n"
-"(погледнете файла README.rst)\n"
-"За повече информация за TigerVNC: http://www.tigervnc.org\n"
-"Превод на български: Александър Шопов"
 
-#: vncviewer/vncviewer.cxx:158
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -881,15 +905,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:174
-msgid "About TigerVNC Viewer"
-msgstr "Относно визуализатора на TigerVNC"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:195
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "Вътрешна грешка на FLTK. Спиране на програмата."
 
-#: vncviewer/vncviewer.cxx:214
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -900,63 +924,59 @@ msgstr ""
 "\n"
 "Нов опит за връзка?"
 
-#: vncviewer/vncviewer.cxx:245 vncviewer/vncviewer.cxx:257
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Грешка при стартирането на нов визуализатор на TigerVNC: %s"
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:266
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC viewer will now exit."
-msgstr "Получен е сигнал %d. Визуализаторът на TigerVNC ще спре работа."
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:391 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC viewer"
-msgstr "Визуализатор на TigerVNC"
-
-#: vncviewer/vncviewer.cxx:395
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "Да"
 
-#: vncviewer/vncviewer.cxx:398
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "Затваряне"
 
-#: vncviewer/vncviewer.cxx:403
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "Относно"
 
-#: vncviewer/vncviewer.cxx:406
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "Скриване"
 
-#: vncviewer/vncviewer.cxx:409
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "Спиране"
 
-#: vncviewer/vncviewer.cxx:413
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "Услуги"
 
-#: vncviewer/vncviewer.cxx:414
+#: vncviewer/vncviewer.cxx:413
 msgid "Hide others"
 msgstr "Скриване на другите"
 
-#: vncviewer/vncviewer.cxx:415
+#: vncviewer/vncviewer.cxx:414
 msgid "Show all"
 msgstr "Показване на всички"
 
-#: vncviewer/vncviewer.cxx:424
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "&Файл"
 
-#: vncviewer/vncviewer.cxx:427
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "Нова &връзка"
 
-#: vncviewer/vncviewer.cxx:450
+#: vncviewer/vncviewer.cxx:449
 #, c-format
 msgid ""
 "\n"
@@ -973,24 +993,19 @@ msgstr ""
 "          %s [ОПЦИЯ…] -listen [ПОРТ]\n"
 "          %s [ОПЦИЯ…] [ФАЙЛ_.tigervnc]\n"
 
-#: vncviewer/vncviewer.cxx:465
+#: vncviewer/vncviewer.cxx:464
 #, c-format
 msgid ""
 "\n"
 "Options:\n"
 "\n"
 "  -display Xdisplay  - Specifies the X display for the viewer window\n"
-"  -geometry geometry - Initial position of the main VNC viewer window. See the\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
 "                       man page for details.\n"
 msgstr ""
-"\n"
-"Опции:\n"
-"\n"
-"  -display ДИСПЛЕЙ    — указва дисплей на X сървър за прозореца на визуализатора\n"
-"  -geometry ГЕОМЕТРИЯ — първоначална позиция на основния прозорец на визуализатора.\n"
-"                        За повече информация вижте страницата от ръководството.\n"
 
-#: vncviewer/vncviewer.cxx:472
+#: vncviewer/vncviewer.cxx:471
 #, c-format
 msgid ""
 "\n"
@@ -1003,78 +1018,92 @@ msgstr ""
 "\n"
 "Опциите се задават с -ОПЦИЯ, а се изключват с -ОПЦИЯ=0\n"
 "Ако опция приема стойност, тя може да се зададе с -ОПЦИЯ СТОЙНОСТ\n"
-"Други варианти на изписване са ОПЦИЯ=СТОЙНОСТ -ОПЦИЯ=СТОЙНОСТ --ОПЦИЯ=СТОЙНОСТ\n"
+"Други варианти на изписване са ОПЦИЯ=СТОЙНОСТ -ОПЦИЯ=СТОЙНОСТ --"
+"ОПЦИЯ=СТОЙНОСТ\n"
 "Опциите може да се изписват с малки или главни букви, или смесено.\n"
 "Опциите са:\n"
 "\n"
 
-#: vncviewer/vncviewer.cxx:527
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
-msgstr "Настройката „FullScreenAllMonitors“ е остаряла, вместо това задайте „FullScreenMode“ да е „all“"
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+"Настройката „FullScreenAllMonitors“ е остаряла, вместо това задайте "
+"„FullScreenMode“ да е „all“"
 
-#: vncviewer/vncviewer.cxx:532
-msgid "DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' instead"
-msgstr "Настройката „DotWhenNoCursor“ е остаряла: задайте „AlwaysCursor“ да е 1, а „CursorType“ да е „Dot“"
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+"Настройката „DotWhenNoCursor“ е остаряла: задайте „AlwaysCursor“ да е 1, а "
+"„CursorType“ да е „Dot“"
 
-#: vncviewer/vncviewer.cxx:553
-msgid "~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
-msgstr "Папката „~/.vnc“ е остаряла. Вижте ръководството „man vncviewer“ кои папки се ползват."
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+"Папката „~/.vnc“ е остаряла. Вижте ръководството „man vncviewer“ кои папки "
+"се ползват."
 
-#: vncviewer/vncviewer.cxx:557
+#: vncviewer/vncviewer.cxx:556
 #, c-format
-msgid "%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC location."
-msgstr "Папката „%%APPDATA%%\\vnc“ е остаряла. Ползвайте „%%APPDATA%%\\TigerVNC“."
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+"Папката „%%APPDATA%%\\vnc“ е остаряла. Ползвайте „%%APPDATA%%\\TigerVNC“."
 
-#: vncviewer/vncviewer.cxx:562
+#: vncviewer/vncviewer.cxx:561
 #, c-format
 msgid "Could not create VNC config directory \"%s\": %s"
 msgstr "Папката за настройки на VNC не може да се създаде „%s“: %s"
 
-#: vncviewer/vncviewer.cxx:568
+#: vncviewer/vncviewer.cxx:567
 msgid "Could not determine VNC data directory path"
 msgstr "Папката за данни на VNC не може да се създаде"
 
-#: vncviewer/vncviewer.cxx:574
+#: vncviewer/vncviewer.cxx:573
 #, c-format
 msgid "Could not create VNC data directory \"%s\": %s"
 msgstr "Папката за данни на VNC не може да се създаде „%s“: %s"
 
-#: vncviewer/vncviewer.cxx:586
+#: vncviewer/vncviewer.cxx:585
 #, c-format
 msgid "Could not create VNC state directory \"%s\": %s"
 msgstr "Папката за състояние на VNC не може да се създаде „%s“: %s"
 
-#: vncviewer/vncviewer.cxx:703
+#: vncviewer/vncviewer.cxx:704
 #, c-format
 msgid "%s: Unrecognized option '%s'\n"
 msgstr "%s: Непозната опция „%s“\n"
 
-#: vncviewer/vncviewer.cxx:705 vncviewer/vncviewer.cxx:713
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
 #, c-format
 msgid "See '%s --help' for more information.\n"
 msgstr "За повече информация вижте изхода от „%s --help“\n"
 
-#: vncviewer/vncviewer.cxx:712
+#: vncviewer/vncviewer.cxx:713
 #, c-format
 msgid "%s: Extra argument '%s'\n"
 msgstr "%s: Допълнителен аргумент „%s“\n"
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:748 vncviewer/vncviewer.cxx:749
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "„-listen“ и „-via“ са несъвместими"
 
-#: vncviewer/vncviewer.cxx:763
+#: vncviewer/vncviewer.cxx:764
 msgid "Unable to listen for incoming connections"
 msgstr "Не може да се слуша за входящи връзки"
 
-#: vncviewer/vncviewer.cxx:765
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "Слуша се на порт %d"
 
-#: vncviewer/vncviewer.cxx:794
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -1085,7 +1114,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:815
+#: vncviewer/vncviewer.cxx:816
 #, c-format
 msgid ""
 "Failure setting up encrypted tunnel:\n"
@@ -1099,3 +1128,94 @@ msgstr ""
 #: vncviewer/vncviewer.desktop.in.in:4
 msgid "Remote desktop viewer"
 msgstr "Визуализатор на отдалечени работни места"
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(стандартното за сървъра %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "Неуспешно задаване на размер на плота чрез SetDesktopSize: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "Неправилна палитра SetColourMapEntries от сървъра!"
+
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "Указани са неправилни настройки за „%s“"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "Неправилен индекс на монитор „%s“"
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "Неочакван знак „%c“"
+
+#~ msgid "VNC viewer: Connection details"
+#~ msgstr "Визуализатор: информация за връзката"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "&Относно TigerVNC…"
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "Визуализатор на TigerVNC"
+
+#~ msgid "TigerVNC viewer connection to a CentOS machine"
+#~ msgstr "Визуализатор на TigerVNC: връзка към CentOS"
+
+#~ msgid "TigerVNC viewer connection to a macOS machine"
+#~ msgstr "Визуализатор на TigerVNC: връзка към MacOS"
+
+#~ msgid "TigerVNC viewer connection to a Windows machine"
+#~ msgstr "Визуализатор на TigerVNC: връзка към Windows"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "Визуализатор на TigerVNC, версия: %s\n"
+#~ "Компилиран на: %s\n"
+#~ "Авторски права © 1999-%d екипът на TigerVNC и мн. др.\n"
+#~ "(погледнете файла README.rst)\n"
+#~ "За повече информация за TigerVNC: http://www.tigervnc.org\n"
+#~ "Превод на български: Александър Шопов"
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "Относно визуализатора на TigerVNC"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Грешка при стартирането на нов визуализатор на TigerVNC: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC viewer will now exit."
+#~ msgstr "Получен е сигнал %d. Визуализаторът на TigerVNC ще спре работа."
+
+#~ msgid "TigerVNC viewer"
+#~ msgstr "Визуализатор на TigerVNC"
+
+#, c-format
+#~ msgid ""
+#~ "\n"
+#~ "Options:\n"
+#~ "\n"
+#~ "  -display Xdisplay  - Specifies the X display for the viewer window\n"
+#~ "  -geometry geometry - Initial position of the main VNC viewer window. "
+#~ "See the\n"
+#~ "                       man page for details.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Опции:\n"
+#~ "\n"
+#~ "  -display ДИСПЛЕЙ    — указва дисплей на X сървър за прозореца на "
+#~ "визуализатора\n"
+#~ "  -geometry ГЕОМЕТРИЯ — първоначална позиция на основния прозорец на "
+#~ "визуализатора.\n"
+#~ "                        За повече информация вижте страницата от "
+#~ "ръководството.\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.14.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2025-01-14 16:15+0100\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2025-01-23 21:10+01:00\n"
 "Last-Translator: Petr Pisar <petr.pisar@atlas.cz>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -17,17 +17,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 
-#: vncviewer/CConn.cxx:102
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "Připojeno na socket %s"
 
-#: vncviewer/CConn.cxx:109
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "Připojeno na stroj %s port %d"
 
-#: vncviewer/CConn.cxx:114
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -38,66 +38,63 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:151
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Název plochy: %.80s"
 
-#: vncviewer/CConn.cxx:154
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Stroj: %.80s port: %d"
 
-#: vncviewer/CConn.cxx:158
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Velikost: %d×%d"
 
-#: vncviewer/CConn.cxx:165
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Formát pixelu: %s"
 
-#: vncviewer/CConn.cxx:170
-#, c-format
-msgid "(server default %s)"
-msgstr "(výchozí serveru %s)"
-
-#: vncviewer/CConn.cxx:173
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Požadované kódování: %s"
 
-#: vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Poslední použité kódování: %s"
 
-#: vncviewer/CConn.cxx:181
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Odhad rychlosti linky: %d kb/s"
 
-#: vncviewer/CConn.cxx:185
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Verze protokolu: %d.%d"
 
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Způsob zabezpečení: %s"
 
-#: vncviewer/CConn.cxx:250 vncviewer/CConn.cxx:252
-msgid "The connection was dropped by the server before the session could be established."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
 msgstr "Spojení bylo serverem zahozeno dříve, než mohla být ustanovena relace."
 
-#: vncviewer/CConn.cxx:262
+#: vncviewer/CConn.cxx:258
 #, c-format
 msgid "Authentication failed: %s"
 msgstr "Autentizace selhala: %s"
 
-#: vncviewer/CConn.cxx:263
+#: vncviewer/CConn.cxx:259
 #, c-format
 msgid ""
 "Failed to authenticate with the server. Reason given by the server:\n"
@@ -108,31 +105,22 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:335
-#, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "Požadavek SetDesktopSize selhal: %d"
-
-#: vncviewer/CConn.cxx:408
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "Neplatná zpráva SetColourMapEntries od serveru!"
-
-#: vncviewer/CConn.cxx:516
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Tok %d kb/S – kvalita se mění na %d"
 
-#: vncviewer/CConn.cxx:538
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "Tok %d kb/s – plný počet barev je nyní zapnut"
 
-#: vncviewer/CConn.cxx:541
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "Tok %d kb/s – plný počet barev je nyní vypnut"
 
-#: vncviewer/CConn.cxx:567
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Používá se formát pixelu %s"
@@ -145,137 +133,129 @@ msgstr "Zadána neplatná geometrie!"
 msgid "Reducing window size to fit on current monitor"
 msgstr "Velikost okna se zmenšuje, aby se vešlo na současný monitor"
 
-#: vncviewer/DesktopWindow.cxx:646
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
-msgstr "Upravuje se velikost okna, by se předešlo nechtěnému požadavku na režim celé obrazovky"
+msgstr ""
+"Upravuje se velikost okna, by se předešlo nechtěnému požadavku na režim celé "
+"obrazovky"
 
-#: vncviewer/DesktopWindow.cxx:694
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Kontextovou nabídku otevřete stisknutím %s"
 
-#: vncviewer/DesktopWindow.cxx:1094 vncviewer/DesktopWindow.cxx:1102
-#: vncviewer/DesktopWindow.cxx:1122
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Zabrání klávesnice se nezdařilo"
 
-#: vncviewer/DesktopWindow.cxx:1411
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
-msgstr "Pro požadavek na změnu velikosti bylo vypočteno neplatné rozložení obrazovky!"
+msgstr ""
+"Pro požadavek na změnu velikosti bylo vypočteno neplatné rozložení obrazovky!"
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "Neplatný stav 3-tlačítkové emulace"
 
-#: vncviewer/KeyboardWin32.cxx:242
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "Žádný scan kód pro rozšířenou virtuální klávesu 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:244
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "Žádný scan kód pro virtuální klávesu 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:250
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "Neplatný scan kód 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:262
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "Žádný symbol pro rozšířenou virtuální klávesu 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:264
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "Žádný symbol pro virtuální klávesu 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:423
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
 msgid "Failed to update keyboard LED state: %lu"
 msgstr "Aktualizace stavu diod klávesnice se nezdařila: %lu"
 
-#: vncviewer/KeyboardX11.cxx:104
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "Žádný symbol pro kód klávesy %d (v současném stavu)"
 
-#: vncviewer/KeyboardX11.cxx:129
+#: vncviewer/KeyboardX11.cxx:148
 #, c-format
 msgid "Failed to get keyboard LED state: %d"
 msgstr "Získaní stavu diod klávesnice se nezdařilo: %d"
 
-#: vncviewer/KeyboardX11.cxx:174
+#: vncviewer/KeyboardX11.cxx:193
 msgid "Failed to update keyboard LED state"
 msgstr "Aktualizace stavu diod klávesnice se nezdařila"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:100
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "Získání nastavení systémového monitoru selhalo"
 
-#: vncviewer/MonitorIndicesParameter.cxx:79
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "Zadáno neplatné nastavení pro %s"
-
-#: vncviewer/MonitorIndicesParameter.cxx:86
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "Monitor číslo %d neexistuje"
 
-#: vncviewer/MonitorIndicesParameter.cxx:162
-#: vncviewer/MonitorIndicesParameter.cxx:182
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "Neplatné číslo monitoru „%s“"
-
-#: vncviewer/MonitorIndicesParameter.cxx:170
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "Nečekaný znak „%c“"
-
-#: vncviewer/OptionsDialog.cxx:64
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
 msgid "TigerVNC options"
 msgstr "Volby TigerVNC"
 
-#: vncviewer/OptionsDialog.cxx:97 vncviewer/ServerDialog.cxx:107
-#: vncviewer/vncviewer.cxx:397
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: vncviewer/OptionsDialog.cxx:102 vncviewer/vncviewer.cxx:396
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "OK"
 
-#: vncviewer/OptionsDialog.cxx:514
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "Komprese"
 
-#: vncviewer/OptionsDialog.cxx:530
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "Automaticky vybrat"
 
-#: vncviewer/OptionsDialog.cxx:541
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "Upřednostňované kódování"
 
-#: vncviewer/OptionsDialog.cxx:602
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "Barevnost"
 
 # Attributes for "Color level"
-#: vncviewer/OptionsDialog.cxx:614
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "Plná"
 
-#: vncviewer/OptionsDialog.cxx:621
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "Střední"
 
-#: vncviewer/OptionsDialog.cxx:628
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "Nízká"
 
@@ -283,167 +263,178 @@ msgstr "Nízká"
 msgid "Very low"
 msgstr "Velmi nízká"
 
-#: vncviewer/OptionsDialog.cxx:657
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "Uživatelská úroveň komprese"
 
-#: vncviewer/OptionsDialog.cxx:664
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "úroveň (0 = rychlá, 9 = nejlepší)"
 
-#: vncviewer/OptionsDialog.cxx:671
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "Povolit kompresi JPEG:"
 
-#: vncviewer/OptionsDialog.cxx:678
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "kvalita (0 = špatná, 9 = nejlepší)"
 
-#: vncviewer/OptionsDialog.cxx:689
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "Zabezpečení"
 
-#: vncviewer/OptionsDialog.cxx:703
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "Šifrování"
 
 # TODO: Conext for gender
-#: vncviewer/OptionsDialog.cxx:715 vncviewer/OptionsDialog.cxx:782
-#: vncviewer/OptionsDialog.cxx:905
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "Ne"
 
-#: vncviewer/OptionsDialog.cxx:722
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "TLS s anonymními certifikáty"
 
-#: vncviewer/OptionsDialog.cxx:728
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "TLS s certifikáty X509"
 
-#: vncviewer/OptionsDialog.cxx:735
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "Cesta k X509 certifikátu autority"
 
-#: vncviewer/OptionsDialog.cxx:742
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "Cesta k souboru se seznamem odvolaných certifikátů"
 
-#: vncviewer/OptionsDialog.cxx:770
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "Autentizace"
 
-#: vncviewer/OptionsDialog.cxx:788
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "Standardní VNC (bez šifrování, nezabezpečené)"
 
-#: vncviewer/OptionsDialog.cxx:794
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "Uživatelské jméno a heslo (bez šifrování, nezabezpečené)"
 
-#: vncviewer/OptionsDialog.cxx:822
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "Vstup"
 
-#: vncviewer/OptionsDialog.cxx:835
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "Pouze se dívat (ignoruje myš a klávesnici)"
 
-#: vncviewer/OptionsDialog.cxx:842
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "Myš"
 
-#: vncviewer/OptionsDialog.cxx:854
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "Emulovat prostřední tlačítko myši"
 
-#: vncviewer/OptionsDialog.cxx:860
+#: vncviewer/OptionsDialog.cxx:880
 msgid "Show local cursor when not provided by server"
 msgstr "Zobrazovat místní ukazatel, když sever žádný nedodá"
 
-#: vncviewer/OptionsDialog.cxx:865
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
 msgid "Cursor type"
 msgstr "Druh ukazatele"
 
-#: vncviewer/OptionsDialog.cxx:867
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
 msgid "Dot"
 msgstr "Puntík"
 
-#: vncviewer/OptionsDialog.cxx:868
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
 msgid "System"
 msgstr "Systémový"
 
-#: vncviewer/OptionsDialog.cxx:888
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "Klávesnice"
 
-#: vncviewer/OptionsDialog.cxx:900
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
 msgstr "Předávat systémové klávesy přímo serveru (režim celé obrazovky)"
 
-#: vncviewer/OptionsDialog.cxx:903
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "Klávesa pro vyvolání nabídky"
 
-#: vncviewer/OptionsDialog.cxx:926
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "Schránka"
 
-#: vncviewer/OptionsDialog.cxx:938
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "Přijímat schránku ze serveru"
 
-#: vncviewer/OptionsDialog.cxx:946
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "Rovněž nastavovat primární výběr"
 
-#: vncviewer/OptionsDialog.cxx:953
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "Posílat schránku serveru"
 
-#: vncviewer/OptionsDialog.cxx:961
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "Posílat primární výběr jako schránku"
 
-#: vncviewer/OptionsDialog.cxx:982
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "Zobrazení"
 
-#: vncviewer/OptionsDialog.cxx:996
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "Režim zobrazení"
 
-#: vncviewer/OptionsDialog.cxx:1009
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "V okně"
 
-#: vncviewer/OptionsDialog.cxx:1017
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "Přes celou obrazovku současného monitoru"
 
-#: vncviewer/OptionsDialog.cxx:1025
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "Přes celou obrazovku na všech monitorech"
 
-#: vncviewer/OptionsDialog.cxx:1033
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "Přes celou obrazovku na vybraných monitorech"
 
-#: vncviewer/OptionsDialog.cxx:1062
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
 msgid "Miscellaneous"
 msgstr "Ostatní"
 
-#: vncviewer/OptionsDialog.cxx:1070
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "Sdílené (neodpojit ostatní diváky)"
 
-#: vncviewer/OptionsDialog.cxx:1076
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "Při chybách spojení se dotázat na nové"
-
-#: vncviewer/ServerDialog.cxx:63
-msgid "VNC viewer: Connection details"
-msgstr "Prohlížeč VNC: Podrobnosti o připojení"
 
 #: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
@@ -488,7 +479,7 @@ msgstr "Nastavení TigerVNC (*.tigervnc)"
 msgid "Select a TigerVNC configuration file"
 msgstr "Vybrat konfigurační souboru TigerVNC"
 
-#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:517
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -508,7 +499,7 @@ msgstr "Uložit nastavení TigerVNC do souboru"
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "%s již existuje. Chcete přepsat?"
 
-#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:394
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "Ne"
 
@@ -549,169 +540,170 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:351 vncviewer/ServerDialog.cxx:429
-#: vncviewer/vncviewer.cxx:580
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
 msgid "Could not determine VNC state directory path"
 msgstr "Cestu ke stavovému adresáři VNC nebylo možné určit"
 
-#: vncviewer/ServerDialog.cxx:363 vncviewer/ServerDialog.cxx:437
-#: vncviewer/parameters.cxx:671 vncviewer/parameters.cxx:752
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
 msgid "Could not open \"%s\""
 msgstr "„%s“ nebylo možné otevřít"
 
-#: vncviewer/ServerDialog.cxx:378 vncviewer/ServerDialog.cxx:387
-#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:773
-#: vncviewer/parameters.cxx:807 vncviewer/parameters.cxx:837
-#: vncviewer/parameters.cxx:844
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
 msgid "Failed to read line %d in file \"%s\""
 msgstr "Přečtení řádku %d v souboru „%s“ selhalo"
 
-#: vncviewer/ServerDialog.cxx:390 vncviewer/parameters.cxx:776
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "Příliš dlouhý řádek"
 
-#: vncviewer/UserDialog.cxx:123
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "Otevření souboru s heslem selhalo"
 
-#: vncviewer/UserDialog.cxx:143
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "Autentizace VNC"
 
-#: vncviewer/UserDialog.cxx:150
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "Toto spojení je zabezpečené"
 
-#: vncviewer/UserDialog.cxx:154
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "Toto spojení není zabezpečené"
 
-#: vncviewer/UserDialog.cxx:176
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "Jméno:"
 
-#: vncviewer/UserDialog.cxx:189
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "Heslo:"
 
-#: vncviewer/UserDialog.cxx:197
+#: vncviewer/UserDialog.cxx:204
 msgid "Keep password for reconnect"
 msgstr "Zapamatovat heslo pro případ obnovení spojení"
 
-#: vncviewer/Viewport.cxx:695
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
 msgid "Disconn&ect"
 msgstr "Od&pojit"
 
-#: vncviewer/Viewport.cxx:698
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "Přes celou o&brazovku"
 
-#: vncviewer/Viewport.cxx:701
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "Minimali&zovat"
 
-#: vncviewer/Viewport.cxx:703
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "Přizpůsobit &velikost okna relaci"
 
-#: vncviewer/Viewport.cxx:708
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:711
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:717
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "Poslat %s"
 
-#: vncviewer/Viewport.cxx:724
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Poslat Ctrl-Alt-&Del"
 
-#: vncviewer/Viewport.cxx:727
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "Obnovit ob&razovku"
 
-#: vncviewer/Viewport.cxx:730
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "V&olby…"
 
-#: vncviewer/Viewport.cxx:732
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "Úda&je o spojení…"
 
-#: vncviewer/Viewport.cxx:734
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "O prohlížeči &TigerVNC…"
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:830
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "Údaje o spojení VNC"
 
-#: vncviewer/Win32TouchHandler.cxx:48
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "Okno je registrováno k dotykům namísto ke gestům"
 
-#: vncviewer/Win32TouchHandler.cxx:83
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "Nastavení gest selhalo (chyba 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:95
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "Získání údajů o gestech selhalo (chyba 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:360
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr "Neplatné číslo tlačítka myši %d. Musí se jednat o číslo mezi 1 a 7."
 
-#: vncviewer/Win32TouchHandler.cxx:425
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
 msgstr "Neobsluhovaná klávesa 0x%x – nelze vytvořit událost klávesnice."
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:107
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
 msgstr "Masku událostí X Input 2 pro okno 0x%08lx nelze získat"
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr "Okno 0x%08lx nemá žádnou masku událostí X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:114
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr "Okno 0x%08lx má více než jednu masku událostí X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "Zabrání zařízení %i se nezdařilo"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-msgid "TigerVNC Viewer"
-msgstr "Prohlížeč TigerVNC"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -719,100 +711,127 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr "Připojí se k severu VNC a zobrazí vzdálenou plochu"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
-msgstr "Virtual Network Computing (VNC) je systém vzdáleného displeje, který umožňuje přes síť zobrazit a ovládat virtuální desktopové prostředí běžící na jiném počítači. Pomocí VNC můžete spouštět grafické aplikace na vzdáleném stroji a poslat výstup těchto aplikací na vaše místní zařízení. Tento balík obsahuje klient, který umožňuje se připojit na jiné desktopové prostředí provozující VNC server. VNC je platformě nezávislé a podporuje celou řadu operačních systémů a architektur, jak na straně serveru, tak na straně klientu."
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+"Virtual Network Computing (VNC) je systém vzdáleného displeje, který "
+"umožňuje přes síť zobrazit a ovládat virtuální desktopové prostředí běžící "
+"na jiném počítači. Pomocí VNC můžete spouštět grafické aplikace na vzdáleném "
+"stroji a poslat výstup těchto aplikací na vaše místní zařízení. Tento balík "
+"obsahuje klient, který umožňuje se připojit na jiné desktopové prostředí "
+"provozující VNC server. VNC je platformě nezávislé a podporuje celou řadu "
+"operačních systémů a architektur, jak na straně serveru, tak na straně "
+"klientu."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
-msgstr "TigerVNC je vysokorychlostní verze VNC založená na kódu RealVNC 4 a X.org. TigerVNC začalo jako úsilí o vývoj nové generace TightVNC pro Unix a Linux, ale na počátku roku 2009 se oddělilo od rodičovského projektu, aby se TightVNC mohlo soustředit na platformu Windows. TigerVNC podporuje variantu kódování Tight, která je značně urychlena použitím libjpeg-turbo, kodéru a dekodéru formátu JPEG."
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+"TigerVNC je vysokorychlostní verze VNC založená na kódu RealVNC 4 a X.org. "
+"TigerVNC začalo jako úsilí o vývoj nové generace TightVNC pro Unix a Linux, "
+"ale na počátku roku 2009 se oddělilo od rodičovského projektu, aby se "
+"TightVNC mohlo soustředit na platformu Windows. TigerVNC podporuje variantu "
+"kódování Tight, která je značně urychlena použitím libjpeg-turbo, kodéru a "
+"dekodéru formátu JPEG."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC viewer connection to a CentOS machine"
-msgstr "Spojení prohlížeče TigerVNC ke stroji s CentOS"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC viewer connection to a macOS machine"
-msgstr "Spojení prohlížeče TigerVNC ke stroji s macOS"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC viewer connection to a Windows machine"
-msgstr "Spojení prohlížeče TigerVNC ke stroji s Windows"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
 #. developer_name tag deprecated with Appstream 1.0
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
-#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:48
 msgid "The TigerVNC team"
 msgstr "Tým TigerVNC"
 
-#: vncviewer/parameters.cxx:319 vncviewer/parameters.cxx:344
-#: vncviewer/parameters.cxx:361 vncviewer/parameters.cxx:401
-#: vncviewer/parameters.cxx:421
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "Název parametru %s je příliš dlouhý"
 
-#: vncviewer/parameters.cxx:323 vncviewer/parameters.cxx:328
-#: vncviewer/parameters.cxx:379
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "Parametr je příliš dlouhý"
 
-#: vncviewer/parameters.cxx:386 vncviewer/parameters.cxx:712
-#: vncviewer/parameters.cxx:822
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "Neplatný formát nebo příliš velká hodnota"
 
-#: vncviewer/parameters.cxx:440 vncviewer/parameters.cxx:473
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "Vytvoření klíče v registru selhalo"
 
-#: vncviewer/parameters.cxx:461 vncviewer/parameters.cxx:528
-#: vncviewer/parameters.cxx:571 vncviewer/parameters.cxx:638
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "Uzavření klíče v registru selhalo"
 
-#: vncviewer/parameters.cxx:479 vncviewer/parameters.cxx:506
-#: vncviewer/parameters.cxx:680 vncviewer/parameters.cxx:692
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "Uložení „%s“ selhalo: %s"
 
-#: vncviewer/parameters.cxx:489 vncviewer/parameters.cxx:520
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "Odstranění „%s“ selhalo: %s"
 
-#: vncviewer/parameters.cxx:544 vncviewer/parameters.cxx:616
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "Otevření klíče v registru selhalo"
 
-#: vncviewer/parameters.cxx:561
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "Položku historie serverů %d se nepodařilo přečíst: %s"
 
-#: vncviewer/parameters.cxx:597 vncviewer/parameters.cxx:627
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "Přečtení parametru „%s“ selhalo: %s"
 
-#: vncviewer/parameters.cxx:661 vncviewer/parameters.cxx:740
-#: vncviewer/vncviewer.cxx:546
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
 msgid "Could not determine VNC config directory path"
 msgstr "Cestu ke konfiguračnímu adresáři VNC nebylo možné určit"
 
-#: vncviewer/parameters.cxx:682 vncviewer/parameters.cxx:694
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "Parametr nebylo možné zakódovat"
 
-#: vncviewer/parameters.cxx:785
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "Konfigurační soubor %s je v neplatném formátu"
 
-#: vncviewer/parameters.cxx:809
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "Neplatný formát"
 
-#: vncviewer/parameters.cxx:846
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "Neznámý parametr"
 
@@ -853,23 +872,23 @@ msgid "X Input 2 (or newer) is not available."
 msgstr "Rozšíření X Input 2 (nebo novější) není dostupné."
 
 #: vncviewer/touch.cxx:266
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
-msgstr "Rozšíření X Input 2.2 (nebo novější) není dostupné. Dotyková gesta nebudou podporována."
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+"Rozšíření X Input 2.2 (nebo novější) není dostupné. Dotyková gesta nebudou "
+"podporována."
 
-#: vncviewer/vncviewer.cxx:104
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
 "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"Prohlížeč TigerVNC v%s\n"
-"Sestaven v: %s\n"
-"Copyright © 1999–%d tým TigerVNC a mnozí další (vizte README.rst)\n"
-"Podrobnosti o TigerVNC naleznete na https://www.tigervnc.org/."
 
-#: vncviewer/vncviewer.cxx:158
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -880,15 +899,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:174
-msgid "About TigerVNC Viewer"
-msgstr "O prohlížeči TigerVNC"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:195
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "Vnitřní chyba FLTK. Končí se."
 
-#: vncviewer/vncviewer.cxx:214
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -899,63 +918,59 @@ msgstr ""
 "\n"
 "Zkusit se znovu připojit?"
 
-#: vncviewer/vncviewer.cxx:245 vncviewer/vncviewer.cxx:257
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Chyba při spouštění prohlížeče TigerVNC: %s"
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:266
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC viewer will now exit."
-msgstr "Byl přijat ukončovací signál %d. Prohlížeč TigerVNC se nyní ukončí."
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:391 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC viewer"
-msgstr "Prohlížeč TigerVNC"
-
-#: vncviewer/vncviewer.cxx:395
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "Ano"
 
-#: vncviewer/vncviewer.cxx:398
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "Zavřít"
 
-#: vncviewer/vncviewer.cxx:403
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "O aplikaci"
 
-#: vncviewer/vncviewer.cxx:406
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "Skrýt"
 
-#: vncviewer/vncviewer.cxx:409
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "Ukončit"
 
-#: vncviewer/vncviewer.cxx:413
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "Služby"
 
-#: vncviewer/vncviewer.cxx:414
+#: vncviewer/vncviewer.cxx:413
 msgid "Hide others"
 msgstr "Skrýt ostatní"
 
-#: vncviewer/vncviewer.cxx:415
+#: vncviewer/vncviewer.cxx:414
 msgid "Show all"
 msgstr "Ukázat všechny"
 
-#: vncviewer/vncviewer.cxx:424
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "&Soubor"
 
-#: vncviewer/vncviewer.cxx:427
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "&Nové spojení"
 
-#: vncviewer/vncviewer.cxx:450
+#: vncviewer/vncviewer.cxx:449
 #, c-format
 msgid ""
 "\n"
@@ -972,24 +987,19 @@ msgstr ""
 "       %s [parametry] -listen [port]\n"
 "       %s [parametry] [soubor_.tigervnc]\n"
 
-#: vncviewer/vncviewer.cxx:465
+#: vncviewer/vncviewer.cxx:464
 #, c-format
 msgid ""
 "\n"
 "Options:\n"
 "\n"
 "  -display Xdisplay  - Specifies the X display for the viewer window\n"
-"  -geometry geometry - Initial position of the main VNC viewer window. See the\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
 "                       man page for details.\n"
 msgstr ""
-"\n"
-"Přepínače:\n"
-"\n"
-"  -display displej    − Určuje displej X pro okno prohlížeče\n"
-"  -geometry geometrie − Počáteční umístění hlavního okna prohlížeče VNC. Pro\n"
-"                        podrobnosti nahlédněte to manuálu.\n"
 
-#: vncviewer/vncviewer.cxx:472
+#: vncviewer/vncviewer.cxx:471
 #, c-format
 msgid ""
 "\n"
@@ -1007,73 +1017,87 @@ msgstr ""
 "Názvy parametrů nerozlišují velikost písmen. Parametry jsou:\n"
 "\n"
 
-#: vncviewer/vncviewer.cxx:527
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
-msgstr "Volba FullScreenAllMonitors je zastaralá, místo ní nastavte FullScreenMode na „all“"
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+"Volba FullScreenAllMonitors je zastaralá, místo ní nastavte FullScreenMode "
+"na „all“"
 
-#: vncviewer/vncviewer.cxx:532
-msgid "DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' instead"
-msgstr "DotWhenNoCursor je zastaralý, místo toho nastavte AlwaysCursor na 1 a CursorType na „Dot“"
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+"DotWhenNoCursor je zastaralý, místo toho nastavte AlwaysCursor na 1 a "
+"CursorType na „Dot“"
 
-#: vncviewer/vncviewer.cxx:553
-msgid "~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
-msgstr "Cesta ~/.vnc je zastaralá. Cestu, kam přejít, naleznete popsanou v „man vncviewer“."
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+"Cesta ~/.vnc je zastaralá. Cestu, kam přejít, naleznete popsanou v „man "
+"vncviewer“."
 
-#: vncviewer/vncviewer.cxx:557
+#: vncviewer/vncviewer.cxx:556
 #, c-format
-msgid "%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC location."
-msgstr "Cesta %%APPDATA%%\\vnc je zastaralá. Prosím, cestu změňte na %%APPDATA%%\\TigerVNC."
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+"Cesta %%APPDATA%%\\vnc je zastaralá. Prosím, cestu změňte na %%APPDATA%%"
+"\\TigerVNC."
 
-#: vncviewer/vncviewer.cxx:562
+#: vncviewer/vncviewer.cxx:561
 #, c-format
 msgid "Could not create VNC config directory \"%s\": %s"
 msgstr "Nebylo možné vytvořit konfigurační adresář pro VNC „%s“: %s"
 
-#: vncviewer/vncviewer.cxx:568
+#: vncviewer/vncviewer.cxx:567
 msgid "Could not determine VNC data directory path"
 msgstr "Nebylo možné určit datový adresář pro VNC"
 
-#: vncviewer/vncviewer.cxx:574
+#: vncviewer/vncviewer.cxx:573
 #, c-format
 msgid "Could not create VNC data directory \"%s\": %s"
 msgstr "Nebylo možné vytvořit datový adresář pro VNC „%s“: %s"
 
-#: vncviewer/vncviewer.cxx:586
+#: vncviewer/vncviewer.cxx:585
 #, c-format
 msgid "Could not create VNC state directory \"%s\": %s"
 msgstr "Nebylo možné vytvořit stavový adresář pro VNC „%s“: %s"
 
-#: vncviewer/vncviewer.cxx:703
+#: vncviewer/vncviewer.cxx:704
 #, c-format
 msgid "%s: Unrecognized option '%s'\n"
 msgstr "%s: Nerozpoznaný přepínač „%s\n"
 
-#: vncviewer/vncviewer.cxx:705 vncviewer/vncviewer.cxx:713
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
 #, c-format
 msgid "See '%s --help' for more information.\n"
 msgstr "Podrobnosti získáte příkazem „%s --help“.\n"
 
-#: vncviewer/vncviewer.cxx:712
+#: vncviewer/vncviewer.cxx:713
 #, c-format
 msgid "%s: Extra argument '%s'\n"
 msgstr "%s: Nadbytečný argument „%s“\n"
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:748 vncviewer/vncviewer.cxx:749
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "Parametry -listen a -via se vzájemně vylučují"
 
-#: vncviewer/vncviewer.cxx:763
+#: vncviewer/vncviewer.cxx:764
 msgid "Unable to listen for incoming connections"
 msgstr "Nelze začít čekat na příchozí spojení"
 
-#: vncviewer/vncviewer.cxx:765
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "Poslouchá se na portu %d"
 
-#: vncviewer/vncviewer.cxx:794
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -1084,7 +1108,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:815
+#: vncviewer/vncviewer.cxx:816
 #, c-format
 msgid ""
 "Failure setting up encrypted tunnel:\n"
@@ -1098,6 +1122,93 @@ msgstr ""
 #: vncviewer/vncviewer.desktop.in.in:4
 msgid "Remote desktop viewer"
 msgstr "Prohlížeč vzdálené plochy"
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(výchozí serveru %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "Požadavek SetDesktopSize selhal: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "Neplatná zpráva SetColourMapEntries od serveru!"
+
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "Zadáno neplatné nastavení pro %s"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "Neplatné číslo monitoru „%s“"
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "Nečekaný znak „%c“"
+
+#~ msgid "VNC viewer: Connection details"
+#~ msgstr "Prohlížeč VNC: Podrobnosti o připojení"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "O prohlížeči &TigerVNC…"
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "Prohlížeč TigerVNC"
+
+#~ msgid "TigerVNC viewer connection to a CentOS machine"
+#~ msgstr "Spojení prohlížeče TigerVNC ke stroji s CentOS"
+
+#~ msgid "TigerVNC viewer connection to a macOS machine"
+#~ msgstr "Spojení prohlížeče TigerVNC ke stroji s macOS"
+
+#~ msgid "TigerVNC viewer connection to a Windows machine"
+#~ msgstr "Spojení prohlížeče TigerVNC ke stroji s Windows"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "Prohlížeč TigerVNC v%s\n"
+#~ "Sestaven v: %s\n"
+#~ "Copyright © 1999–%d tým TigerVNC a mnozí další (vizte README.rst)\n"
+#~ "Podrobnosti o TigerVNC naleznete na https://www.tigervnc.org/."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "O prohlížeči TigerVNC"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Chyba při spouštění prohlížeče TigerVNC: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC viewer will now exit."
+#~ msgstr "Byl přijat ukončovací signál %d. Prohlížeč TigerVNC se nyní ukončí."
+
+#~ msgid "TigerVNC viewer"
+#~ msgstr "Prohlížeč TigerVNC"
+
+#, c-format
+#~ msgid ""
+#~ "\n"
+#~ "Options:\n"
+#~ "\n"
+#~ "  -display Xdisplay  - Specifies the X display for the viewer window\n"
+#~ "  -geometry geometry - Initial position of the main VNC viewer window. "
+#~ "See the\n"
+#~ "                       man page for details.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Přepínače:\n"
+#~ "\n"
+#~ "  -display displej    − Určuje displej X pro okno prohlížeče\n"
+#~ "  -geometry geometrie − Počáteční umístění hlavního okna prohlížeče VNC. "
+#~ "Pro\n"
+#~ "                        podrobnosti nahlédněte to manuálu.\n"
 
 #~ msgid "Show dot when no cursor"
 #~ msgstr "Zobrazovat puntík, když chybí kurzor"
@@ -1123,7 +1234,9 @@ msgstr "Prohlížeč vzdálené plochy"
 #~ msgstr "Ostatní"
 
 #~ msgid "Failed to get monitor name because X11 RandR could not be found"
-#~ msgstr "Nebylo možné získat název monitoru, protože rozšíření X11 RandR nebylo nalezeno"
+#~ msgstr ""
+#~ "Nebylo možné získat název monitoru, protože rozšíření X11 RandR nebylo "
+#~ "nalezeno"
 
 #~ msgid "Failed to get information about CRTC %d"
 #~ msgstr "Získání údajů o CRTC %d selhalo"
@@ -1178,20 +1291,28 @@ msgstr "Prohlížeč vzdálené plochy"
 #~ msgid "The parameter %s was too large to read from the registry"
 #~ msgstr "Parametr %s byl příliš dlouhý na přečtení z registru"
 
-#~ msgid "Failed to write configuration file, can't obtain home directory path."
-#~ msgstr "Zapsaní konfiguračního souboru selhalo, nelze získat cestu k domovskému adresáři."
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Zapsaní konfiguračního souboru selhalo, nelze získat cestu k domovskému "
+#~ "adresáři."
 
 #~ msgid "Failed to write configuration file, can't open %s: %s"
 #~ msgstr "Zapsání konfiguračního souboru selhalo, %s nelze otevřít: %s"
 
 #~ msgid "Failed to read configuration file, can't obtain home directory path."
-#~ msgstr "Přečtení konfiguračního souboru selhalo, nelze získat cestu k domovskému adresáři."
+#~ msgstr ""
+#~ "Přečtení konfiguračního souboru selhalo, nelze získat cestu k domovskému "
+#~ "adresáři."
 
 #~ msgid "Unknown parameter %s on line %d in file %s"
 #~ msgstr "Neznámý parametr %s na řádku %d v souboru %s"
 
-#~ msgid "Could not create VNC home directory: can't obtain home directory path."
-#~ msgstr "Nebylo možné vytvořit domovský adresář pro VNC: nelze získat cestu k domovskému adresáři."
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
+#~ msgstr ""
+#~ "Nebylo možné vytvořit domovský adresář pro VNC: nelze získat cestu "
+#~ "k domovskému adresáři."
 
 # This is a proper name of an icon file
 #~ msgid "tigervnc"

--- a/po/da.po
+++ b/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.8.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2018-06-13 14:22+0000\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2018-08-12 13:22+0200\n"
 "Last-Translator: joe Hansen <joedalton2@yahoo.dk>\n"
 "Language-Team: Danish <dansk@dansk-gruppen.dk>\n"
@@ -19,715 +19,1267 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.11\n"
 
-#: vncviewer/CConn.cxx:116
+#: vncviewer/CConn.cxx:103
 #, c-format
-msgid "connected to socket %s"
-msgstr "forbundet til soklen %s"
+msgid "Connected to socket %s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:123
+#: vncviewer/CConn.cxx:110
 #, c-format
-msgid "connected to host %s port %d"
-msgstr "forbundet til værten %s på port %d"
+msgid "Connected to host %s port %d"
+msgstr ""
 
-#: vncviewer/CConn.cxx:184
+#: vncviewer/CConn.cxx:115
+#, c-format
+msgid ""
+"Failed to connect to \"%s\":\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Skrivebordsnavn: %.80s"
 
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Vært: %.80s port: %d"
 
-#: vncviewer/CConn.cxx:194
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Størrelse: %d x %d"
 
-#: vncviewer/CConn.cxx:202
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Billedformat: %s"
 
-#: vncviewer/CConn.cxx:209
-#, c-format
-msgid "(server default %s)"
-msgstr "(serverstandard %s)"
-
-#: vncviewer/CConn.cxx:214
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Anmodt kodning: %s"
 
-#: vncviewer/CConn.cxx:219
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Sidst anvendt kodning: %s"
 
-#: vncviewer/CConn.cxx:224
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Linjehastighedsestimat: %d kbit/s"
 
-#: vncviewer/CConn.cxx:229
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Protokolversion: %d.%d"
 
-#: vncviewer/CConn.cxx:234
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Sikkerhedsmetode: %s"
 
-#: vncviewer/CConn.cxx:358
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
+msgstr ""
+
+#: vncviewer/CConn.cxx:258
 #, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "SetDesktopSize fejlede: %d"
+msgid "Authentication failed: %s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:428
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "Ugyldig SetColourMapEntries fra server!"
+#: vncviewer/CConn.cxx:259
+#, c-format
+msgid ""
+"Failed to authenticate with the server. Reason given by the server:\n"
+"\n"
+"%s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:479
-msgid "Enabling continuous updates"
-msgstr "Aktiverer fortsættende opdateringer"
-
-#: vncviewer/CConn.cxx:556
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Gennemløb %d kbit/s - ændrer til kvalitet %d"
 
-#: vncviewer/CConn.cxx:578
+#: vncviewer/CConn.cxx:521
 #, c-format
-msgid "Throughput %d kbit/s - full color is now %s"
-msgstr "Gennemløb %d kbit/s - fuld farve er nu %s"
+msgid "Throughput %d kbit/s - full color is now enabled"
+msgstr ""
 
-#: vncviewer/CConn.cxx:580
-msgid "disabled"
-msgstr "deaktiveret"
-
-#: vncviewer/CConn.cxx:580
-msgid "enabled"
-msgstr "aktiveret"
-
-#: vncviewer/CConn.cxx:590
+#: vncviewer/CConn.cxx:524
 #, c-format
-msgid "Using %s encoding"
-msgstr "Bruger %s-kodning"
+msgid "Throughput %d kbit/s - full color is now disabled"
+msgstr ""
 
-#: vncviewer/CConn.cxx:637
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Bruger billedpunktsformat %s"
 
-#: vncviewer/DesktopWindow.cxx:122
+#: vncviewer/DesktopWindow.cxx:146
 msgid "Invalid geometry specified!"
 msgstr "Ugyldig geometri angivet!"
 
-#: vncviewer/DesktopWindow.cxx:451
-msgid "Adjusting window size to avoid accidental full screen request"
-msgstr "Justerer vinduesstørrelse for at undgå utilsigtet anmodning om fuld skærm"
+#: vncviewer/DesktopWindow.cxx:167
+msgid "Reducing window size to fit on current monitor"
+msgstr ""
 
-#: vncviewer/DesktopWindow.cxx:495
+#: vncviewer/DesktopWindow.cxx:681
+msgid "Adjusting window size to avoid accidental full-screen request"
+msgstr ""
+
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Tryk %s for at åbne kontekstmenuen"
 
-#: vncviewer/DesktopWindow.cxx:794 vncviewer/DesktopWindow.cxx:802
-#: vncviewer/DesktopWindow.cxx:822
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Kunne ikke fange tastatur"
 
-#: vncviewer/DesktopWindow.cxx:896
-msgid "Failure grabbing mouse"
-msgstr "Kunne ikke fange mus"
-
-#: vncviewer/DesktopWindow.cxx:1120
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
 msgstr "Ugyldig skærmlayout beregnet for anmodning om ny størrelse!"
 
-#: vncviewer/OptionsDialog.cxx:57
-msgid "VNC Viewer: Connection Options"
-msgstr "VNC-fremviser: Forbindelsesindstillinger"
-
-#: vncviewer/OptionsDialog.cxx:83 vncviewer/ServerDialog.cxx:91
-#: vncviewer/vncviewer.cxx:282
-msgid "Cancel"
-msgstr "Afbryd"
-
-#: vncviewer/OptionsDialog.cxx:88 vncviewer/vncviewer.cxx:281
-msgid "OK"
-msgstr "O.k."
-
-#: vncviewer/OptionsDialog.cxx:423
-msgid "Compression"
-msgstr "Komprimering"
-
-#: vncviewer/OptionsDialog.cxx:439
-msgid "Auto select"
-msgstr "Vælg automatisk"
-
-#: vncviewer/OptionsDialog.cxx:451
-msgid "Preferred encoding"
-msgstr "Foretrukken kodning"
-
-#: vncviewer/OptionsDialog.cxx:499
-msgid "Color level"
-msgstr "Farveniveau"
-
-#: vncviewer/OptionsDialog.cxx:510
-msgid "Full (all available colors)"
-msgstr "Fuld (alle tilgængelige farver)"
-
-#: vncviewer/OptionsDialog.cxx:517
-msgid "Medium (256 colors)"
-msgstr "Mellem (256 farver)"
-
-#: vncviewer/OptionsDialog.cxx:524
-msgid "Low (64 colors)"
-msgstr "Lav (64 farver)"
-
-#: vncviewer/OptionsDialog.cxx:531
-msgid "Very low (8 colors)"
-msgstr "Meget lav (8 farver)"
-
-#: vncviewer/OptionsDialog.cxx:548
-msgid "Custom compression level:"
-msgstr "Tilpasset komprimeringsniveau:"
-
-#: vncviewer/OptionsDialog.cxx:554
-msgid "level (1=fast, 6=best [4-6 are rarely useful])"
-msgstr "niveau (1=hurtig, 6=bedst [4-6 bruges sjældent])"
-
-#: vncviewer/OptionsDialog.cxx:561
-msgid "Allow JPEG compression:"
-msgstr "Tillad JPEG-komprimering:"
-
-#: vncviewer/OptionsDialog.cxx:567
-msgid "quality (0=poor, 9=best)"
-msgstr "kvalitet (0=dårlig, 9=bedst)"
-
-#: vncviewer/OptionsDialog.cxx:578
-msgid "Security"
-msgstr "Sikkerhed"
-
-#: vncviewer/OptionsDialog.cxx:593
-msgid "Encryption"
-msgstr "Kryptering"
-
-#: vncviewer/OptionsDialog.cxx:604 vncviewer/OptionsDialog.cxx:657
-#: vncviewer/OptionsDialog.cxx:737
-msgid "None"
-msgstr "Ingen"
-
-#: vncviewer/OptionsDialog.cxx:610
-msgid "TLS with anonymous certificates"
-msgstr "TLS med anonyme certifikater"
-
-#: vncviewer/OptionsDialog.cxx:616
-msgid "TLS with X509 certificates"
-msgstr "TLS med X509-certifikater"
-
-#: vncviewer/OptionsDialog.cxx:623
-msgid "Path to X509 CA certificate"
-msgstr "Sti til X509 CA-certifikat"
-
-#: vncviewer/OptionsDialog.cxx:630
-msgid "Path to X509 CRL file"
-msgstr "Sti til X509 CRL-fil"
-
-#: vncviewer/OptionsDialog.cxx:646
-msgid "Authentication"
-msgstr "Godkendelse"
-
-#: vncviewer/OptionsDialog.cxx:663
-msgid "Standard VNC (insecure without encryption)"
-msgstr "Standard-VNC (usikker uden kryptering)"
-
-#: vncviewer/OptionsDialog.cxx:669
-msgid "Username and password (insecure without encryption)"
-msgstr "Bruernavn og adgangskode (usikker uden kryptering)"
-
-#: vncviewer/OptionsDialog.cxx:688
-msgid "Input"
-msgstr "Inddata"
-
-#: vncviewer/OptionsDialog.cxx:696
-msgid "View only (ignore mouse and keyboard)"
-msgstr "Vis kun (ignorer mus og tastatur)"
-
-#: vncviewer/OptionsDialog.cxx:702
-msgid "Accept clipboard from server"
-msgstr "Accepter udklipsholderen fra serveren"
-
-#: vncviewer/OptionsDialog.cxx:710
-msgid "Also set primary selection"
-msgstr "Angiv også primær markering"
-
-#: vncviewer/OptionsDialog.cxx:717
-msgid "Send clipboard to server"
-msgstr "Send udklipsholderen til serveren"
-
-#: vncviewer/OptionsDialog.cxx:725
-msgid "Send primary selection as clipboard"
-msgstr "Send primær markering som udklipsholder"
-
-#: vncviewer/OptionsDialog.cxx:732
-msgid "Pass system keys directly to server (full screen)"
-msgstr "Videresend systemnøgler direkte til serveren (fuld skærm)"
-
-#: vncviewer/OptionsDialog.cxx:735
-msgid "Menu key"
-msgstr "Menutast"
-
-#: vncviewer/OptionsDialog.cxx:751
-msgid "Screen"
-msgstr "Skærm"
-
-#: vncviewer/OptionsDialog.cxx:759
-msgid "Resize remote session on connect"
-msgstr "Ændr størrelse for ekstern session ved forbind"
-
-#: vncviewer/OptionsDialog.cxx:772
-msgid "Resize remote session to the local window"
-msgstr "Ændr størrelse for ekstern session til det lokale vindue"
-
-#: vncviewer/OptionsDialog.cxx:778
-msgid "Full-screen mode"
-msgstr "Tilstand for fuld skærm"
-
-#: vncviewer/OptionsDialog.cxx:784
-msgid "Enable full-screen mode over all monitors"
-msgstr "Aktiver tilstand for fuld skærm over alle skærme"
-
-#: vncviewer/OptionsDialog.cxx:793
-msgid "Misc."
-msgstr "Div."
-
-#: vncviewer/OptionsDialog.cxx:801
-msgid "Shared (don't disconnect other viewers)"
-msgstr "Delt (afbryd ikke andre fremvisere)"
-
-#: vncviewer/OptionsDialog.cxx:807
-msgid "Show dot when no cursor"
-msgstr "Vis punktum når ingen markør"
-
-#: vncviewer/ServerDialog.cxx:42
-msgid "VNC Viewer: Connection Details"
-msgstr "VNC-fremviser: Forbindelsesdetaljer"
-
-#: vncviewer/ServerDialog.cxx:49 vncviewer/ServerDialog.cxx:54
-msgid "VNC server:"
-msgstr "VNC-server:"
-
-#: vncviewer/ServerDialog.cxx:64
-msgid "Options..."
-msgstr "Tilvalg ..."
-
-#: vncviewer/ServerDialog.cxx:69
-msgid "Load..."
-msgstr "Indlæs ..."
-
-#: vncviewer/ServerDialog.cxx:74
-msgid "Save As..."
-msgstr "Gem som ..."
-
-#: vncviewer/ServerDialog.cxx:86
-msgid "About..."
-msgstr "Om ..."
-
-#: vncviewer/ServerDialog.cxx:96
-msgid "Connect"
-msgstr "Forbind"
-
-#: vncviewer/ServerDialog.cxx:137 vncviewer/ServerDialog.cxx:171
-msgid "TigerVNC configuration (*.tigervnc)"
-msgstr "TigerVNC-konfiguration (*.tigervnc)"
-
-#: vncviewer/ServerDialog.cxx:138
-msgid "Select a TigerVNC configuration file"
-msgstr "Vælg en TigerVNC-konfigurationsfil"
-
-#: vncviewer/ServerDialog.cxx:172
-msgid "Save the TigerVNC configuration to file"
-msgstr "Gem TigerVNC-konfigurationen til fil"
-
-#: vncviewer/ServerDialog.cxx:197
-#, c-format
-msgid "%s already exists. Do you want to overwrite?"
-msgstr "%s findes allerede. Ønsker du at overskrive?"
-
-#: vncviewer/ServerDialog.cxx:198 vncviewer/vncviewer.cxx:279
-msgid "No"
-msgstr "Nej"
-
-#: vncviewer/ServerDialog.cxx:198
-msgid "Overwrite"
-msgstr "Overskriv"
-
-#: vncviewer/UserDialog.cxx:85
-msgid "Opening password file failed"
-msgstr "Åbning af adgangskodefil mislykkedes"
-
-#: vncviewer/UserDialog.cxx:105
-msgid "VNC authentication"
-msgstr "VNC-godkendelse"
-
-#: vncviewer/UserDialog.cxx:112
-msgid "This connection is secure"
-msgstr "Denne forbindelse er sikker"
-
-#: vncviewer/UserDialog.cxx:116
-msgid "This connection is not secure"
-msgstr "Denne forbindelse er ikke sikker"
-
-#: vncviewer/UserDialog.cxx:133
-msgid "Username:"
-msgstr "Brugernavn:"
-
-#: vncviewer/UserDialog.cxx:140
-msgid "Password:"
-msgstr "Adgangskode:"
-
-#: vncviewer/UserDialog.cxx:179
-msgid "Authentication cancelled"
-msgstr "Godkendelse afbrudt"
-
-#: vncviewer/Viewport.cxx:377
-#, c-format
-msgid "Failed to update keyboard LED state: %lu"
-msgstr "Kunne ikke opdatere tastatur-LED-tilstand: %lu"
-
-#: vncviewer/Viewport.cxx:383 vncviewer/Viewport.cxx:389
-#, c-format
-msgid "Failed to update keyboard LED state: %d"
-msgstr "Kunne ikke opdatere tastatur-LED-tilstand: %d"
-
-#: vncviewer/Viewport.cxx:419
-msgid "Failed to update keyboard LED state"
-msgstr "Kunne ikke opdatere tastatur-LED-tilstand"
-
-#: vncviewer/Viewport.cxx:446 vncviewer/Viewport.cxx:454
-#: vncviewer/Viewport.cxx:471
-#, c-format
-msgid "Failed to get keyboard LED state: %d"
-msgstr "Kunne ikke indhente tastatur-LED-tilstand: %d"
-
-#: vncviewer/Viewport.cxx:817
-msgid "No key code specified on key press"
-msgstr "Ingen nøglekode angivet ved tastaturtryk"
-
-#: vncviewer/Viewport.cxx:959
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
+msgid "Invalid state for 3 button emulation"
+msgstr ""
+
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "Ingen skanningskode for udvidet virtuel nøgle 0x%02x"
 
-#: vncviewer/Viewport.cxx:961
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "Ingen skanningskode for virtuel nøgle 0x%02x"
 
-#: vncviewer/Viewport.cxx:967
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "Ugyldig skanningskode 0x%02x"
 
-#: vncviewer/Viewport.cxx:997
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "Intet symbol for udvidet virtuel nøgle 0x%02x"
 
-#: vncviewer/Viewport.cxx:999
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "Intet symbol for virtuel nøgle 0x%02x"
 
-#: vncviewer/Viewport.cxx:1086
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
-msgid "No symbol for key code 0x%02x (in the current state)"
-msgstr "Intet symbol for nøglekode 0x%02x (i den nuværende tilstand)"
+msgid "Failed to update keyboard LED state: %lu"
+msgstr "Kunne ikke opdatere tastatur-LED-tilstand: %lu"
 
-#: vncviewer/Viewport.cxx:1119
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "Intet symbol for nøglekode %d (i den nuværende tilstand)"
 
-#: vncviewer/Viewport.cxx:1170
-msgctxt "ContextMenu|"
-msgid "E&xit viewer"
-msgstr "&Afslut fremviser"
+#: vncviewer/KeyboardX11.cxx:148
+#, c-format
+msgid "Failed to get keyboard LED state: %d"
+msgstr "Kunne ikke indhente tastatur-LED-tilstand: %d"
 
-#: vncviewer/Viewport.cxx:1173
+#: vncviewer/KeyboardX11.cxx:193
+msgid "Failed to update keyboard LED state"
+msgstr "Kunne ikke opdatere tastatur-LED-tilstand"
+
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
+msgid "Failed to get system monitor configuration"
+msgstr ""
+
+#: vncviewer/MonitorIndicesParameter.cxx:73
+#, c-format
+msgid "Monitor index %d does not exist"
+msgstr ""
+
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
+msgid "TigerVNC options"
+msgstr ""
+
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
+msgid "Cancel"
+msgstr "Afbryd"
+
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
+msgid "OK"
+msgstr "O.k."
+
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
+msgid "Compression"
+msgstr "Komprimering"
+
+#: vncviewer/OptionsDialog.cxx:524
+msgid "Auto select"
+msgstr "Vælg automatisk"
+
+#: vncviewer/OptionsDialog.cxx:536
+msgid "Preferred encoding"
+msgstr "Foretrukken kodning"
+
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
+msgid "Color level"
+msgstr "Farveniveau"
+
+#: vncviewer/OptionsDialog.cxx:611
+msgid "Full"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:619
+msgid "Medium"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:627
+msgid "Low"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:635
+msgid "Very low"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:658
+msgid "Custom compression level:"
+msgstr "Tilpasset komprimeringsniveau:"
+
+#: vncviewer/OptionsDialog.cxx:666
+msgid "level (0=fast, 9=best)"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:674
+msgid "Allow JPEG compression:"
+msgstr "Tillad JPEG-komprimering:"
+
+#: vncviewer/OptionsDialog.cxx:682
+msgid "quality (0=poor, 9=best)"
+msgstr "kvalitet (0=dårlig, 9=bedst)"
+
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
+msgid "Security"
+msgstr "Sikkerhed"
+
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
+msgid "Encryption"
+msgstr "Kryptering"
+
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
+msgid "None"
+msgstr "Ingen"
+
+#: vncviewer/OptionsDialog.cxx:730
+msgid "TLS with anonymous certificates"
+msgstr "TLS med anonyme certifikater"
+
+#: vncviewer/OptionsDialog.cxx:737
+msgid "TLS with X509 certificates"
+msgstr "TLS med X509-certifikater"
+
+#: vncviewer/OptionsDialog.cxx:745
+msgid "Path to X509 CA certificate"
+msgstr "Sti til X509 CA-certifikat"
+
+#: vncviewer/OptionsDialog.cxx:753
+msgid "Path to X509 CRL file"
+msgstr "Sti til X509 CRL-fil"
+
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
+msgid "Authentication"
+msgstr "Godkendelse"
+
+#: vncviewer/OptionsDialog.cxx:802
+msgid "Standard VNC (insecure without encryption)"
+msgstr "Standard-VNC (usikker uden kryptering)"
+
+#: vncviewer/OptionsDialog.cxx:809
+msgid "Username and password (insecure without encryption)"
+msgstr "Bruernavn og adgangskode (usikker uden kryptering)"
+
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
+msgid "Input"
+msgstr "Inddata"
+
+#: vncviewer/OptionsDialog.cxx:852
+msgid "View only (ignore mouse and keyboard)"
+msgstr "Vis kun (ignorer mus og tastatur)"
+
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
+msgid "Mouse"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:873
+msgid "Emulate middle mouse button"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:880
+msgid "Show local cursor when not provided by server"
+msgstr ""
+
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
+msgid "Cursor type"
+msgstr ""
+
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
+msgid "Dot"
+msgstr ""
+
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
+msgid "System"
+msgstr ""
+
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
+msgid "Keyboard"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:925
+msgid "Pass system keys directly to server (full screen)"
+msgstr "Videresend systemnøgler direkte til serveren (fuld skærm)"
+
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
+msgid "Menu key"
+msgstr "Menutast"
+
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
+msgid "Clipboard"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:968
+msgid "Accept clipboard from server"
+msgstr "Accepter udklipsholderen fra serveren"
+
+#: vncviewer/OptionsDialog.cxx:977
+msgid "Also set primary selection"
+msgstr "Angiv også primær markering"
+
+#: vncviewer/OptionsDialog.cxx:985
+msgid "Send clipboard to server"
+msgstr "Send udklipsholderen til serveren"
+
+#: vncviewer/OptionsDialog.cxx:994
+msgid "Send primary selection as clipboard"
+msgstr "Send primær markering som udklipsholder"
+
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
+msgid "Display"
+msgstr ""
+
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
+msgid "Display mode"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1045
+msgid "Windowed"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1054
+msgid "Full screen on current monitor"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1063
+msgid "Full screen on all monitors"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1072
+msgid "Full screen on selected monitor(s)"
+msgstr ""
+
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
+msgid "Miscellaneous"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1111
+msgid "Shared (don't disconnect other viewers)"
+msgstr "Delt (afbryd ikke andre fremvisere)"
+
+#: vncviewer/OptionsDialog.cxx:1118
+msgid "Ask to reconnect on connection errors"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:73
+msgid "VNC server:"
+msgstr "VNC-server:"
+
+#: vncviewer/ServerDialog.cxx:80
+msgid "Options..."
+msgstr "Tilvalg ..."
+
+#: vncviewer/ServerDialog.cxx:84
+msgid "Load..."
+msgstr "Indlæs ..."
+
+#: vncviewer/ServerDialog.cxx:88
+msgid "Save as..."
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:102
+msgid "About..."
+msgstr "Om ..."
+
+#: vncviewer/ServerDialog.cxx:111
+msgid "Connect"
+msgstr "Forbind"
+
+#: vncviewer/ServerDialog.cxx:147
+#, c-format
+msgid ""
+"Unable to load the server history:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:176 vncviewer/ServerDialog.cxx:216
+msgid "TigerVNC configuration (*.tigervnc)"
+msgstr "TigerVNC-konfiguration (*.tigervnc)"
+
+#: vncviewer/ServerDialog.cxx:177
+msgid "Select a TigerVNC configuration file"
+msgstr "Vælg en TigerVNC-konfigurationsfil"
+
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
+#, c-format
+msgid ""
+"Unable to load the specified configuration file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:217
+msgid "Save the TigerVNC configuration to file"
+msgstr "Gem TigerVNC-konfigurationen til fil"
+
+#: vncviewer/ServerDialog.cxx:243
+#, c-format
+msgid "%s already exists. Do you want to overwrite?"
+msgstr "%s findes allerede. Ønsker du at overskrive?"
+
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
+msgid "No"
+msgstr "Nej"
+
+#: vncviewer/ServerDialog.cxx:244
+msgid "Overwrite"
+msgstr "Overskriv"
+
+#: vncviewer/ServerDialog.cxx:260
+#, c-format
+msgid ""
+"Unable to save the specified configuration file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:294
+#, c-format
+msgid ""
+"Unable to save the default configuration:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:306
+#, c-format
+msgid ""
+"Unable to save the server history:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
+msgid "Could not determine VNC state directory path"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
+#, c-format
+msgid "Could not open \"%s\""
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
+#, c-format
+msgid "Failed to read line %d in file \"%s\""
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
+msgid "Line too long"
+msgstr "Linjen er for lang"
+
+#: vncviewer/UserDialog.cxx:130
+msgid "Opening password file failed"
+msgstr "Åbning af adgangskodefil mislykkedes"
+
+#: vncviewer/UserDialog.cxx:150
+msgid "VNC authentication"
+msgstr "VNC-godkendelse"
+
+#: vncviewer/UserDialog.cxx:157
+msgid "This connection is secure"
+msgstr "Denne forbindelse er sikker"
+
+#: vncviewer/UserDialog.cxx:161
+msgid "This connection is not secure"
+msgstr "Denne forbindelse er ikke sikker"
+
+#: vncviewer/UserDialog.cxx:183
+msgid "Username:"
+msgstr "Brugernavn:"
+
+#: vncviewer/UserDialog.cxx:196
+msgid "Password:"
+msgstr "Adgangskode:"
+
+#: vncviewer/UserDialog.cxx:204
+msgid "Keep password for reconnect"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:749
+msgctxt "ContextMenu|"
+msgid "Disconn&ect"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "&Fuld skærm"
 
-#: vncviewer/Viewport.cxx:1176
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "&Minimer"
 
-#: vncviewer/Viewport.cxx:1178
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "Ændr størrelse for &vindue til session"
 
-#: vncviewer/Viewport.cxx:1183
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:1186
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:1192
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "Send %s"
 
-#: vncviewer/Viewport.cxx:1198
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Send Ctrl-Alt-&Slet"
 
-#: vncviewer/Viewport.cxx:1201
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "&Opdater skærm"
 
-#: vncviewer/Viewport.cxx:1204
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&Indstillinger ..."
 
-#: vncviewer/Viewport.cxx:1206
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "Forbindelses&info ..."
 
-#: vncviewer/Viewport.cxx:1208
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "Om &TigerVNC-fremviseren ..."
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:1211
-msgctxt "ContextMenu|"
-msgid "Dismiss &menu"
-msgstr "Fjern &menu"
-
-#: vncviewer/Viewport.cxx:1300
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "VNC-forbindelsesinfo"
 
-#: vncviewer/parameters.cxx:279 vncviewer/parameters.cxx:313
-#, c-format
-msgid "The name of the parameter %s was too large to write to the registry"
-msgstr "Navnet på parameteren %s var for lang til at kunne skrives til registret"
-
-#: vncviewer/parameters.cxx:285 vncviewer/parameters.cxx:292
-#, c-format
-msgid "The parameter %s was too large to write to the registry"
-msgstr "Parameteren %s var for lang til at kunne skrives til registret"
-
-#: vncviewer/parameters.cxx:298 vncviewer/parameters.cxx:319
-#, c-format
-msgid "Failed to write parameter %s of type %s to the registry: %ld"
-msgstr "Kunne ikke skrive parameteren %s af typen %s til registret: %ld"
-
-#: vncviewer/parameters.cxx:334 vncviewer/parameters.cxx:373
-#, c-format
-msgid "The name of the parameter %s was too large to read from the registry"
-msgstr "Navnet for parameteren %s var for lang til at kunne læses fra registret"
-
-#: vncviewer/parameters.cxx:343 vncviewer/parameters.cxx:382
-#, c-format
-msgid "Failed to read parameter %s from the registry: %ld"
-msgstr "Kunne ikke læse parameteren %s fra registret: %ld"
-
-#: vncviewer/parameters.cxx:352
-#, c-format
-msgid "The parameter %s was too large to read from the registry"
-msgstr "Parameteren %s var for lang til at kunne læses fra registret"
-
-#: vncviewer/parameters.cxx:402
-#, c-format
-msgid "Failed to create registry key: %ld"
-msgstr "Kunne ikke oprette registernøgle: %ld"
-
-#: vncviewer/parameters.cxx:416 vncviewer/parameters.cxx:465
-#: vncviewer/parameters.cxx:527 vncviewer/parameters.cxx:660
-#, c-format
-msgid "Unknown parameter type for parameter %s"
-msgstr "Ukendt parametertype for parameteren %s"
-
-#: vncviewer/parameters.cxx:423 vncviewer/parameters.cxx:472
-#, c-format
-msgid "Failed to close registry key: %ld"
-msgstr "Kunne ikke lukke registernøgle: %ld"
-
-#: vncviewer/parameters.cxx:439
-#, c-format
-msgid "Failed to open registry key: %ld"
-msgstr "Kunne ikke åbne registernøgle: %ld"
-
-#: vncviewer/parameters.cxx:496
-msgid "Failed to write configuration file, can't obtain home directory path."
-msgstr "Kunne ikke skrive konfigurationsfil, kan ikke indhente hjemmemappens sti."
-
-#: vncviewer/parameters.cxx:509
-#, c-format
-msgid "Failed to write configuration file, can't open %s: %s"
-msgstr "Kunne ikke skrive konfigurationsfil, kan ikke åbne %s: %s"
-
-#: vncviewer/parameters.cxx:554
-msgid "Failed to read configuration file, can't obtain home directory path."
-msgstr "Kunne ikke læse konfigurationsfil, kan ikke indhente hjemmemappens sti."
-
-#: vncviewer/parameters.cxx:567
-#, c-format
-msgid "Failed to read configuration file, can't open %s: %s"
-msgstr "Kunne ikke læse konfigurationsfil, kan ikke åbne %s: %s"
-
-#: vncviewer/parameters.cxx:580 vncviewer/parameters.cxx:585
-#: vncviewer/parameters.cxx:610 vncviewer/parameters.cxx:623
-#: vncviewer/parameters.cxx:639
-#, c-format
-msgid "Failed to read line %d in file %s: %s"
-msgstr "Kunne ikke læse linje %d i filen %s: %s"
-
-#: vncviewer/parameters.cxx:586
-msgid "Line too long"
-msgstr "Linjen er for lang"
-
-#: vncviewer/parameters.cxx:593
-#, c-format
-msgid "Configuration file %s is in an invalid format"
-msgstr "Konfigurationsfilen %s er i et ugyldigt format"
-
-#: vncviewer/parameters.cxx:611
-msgid "Invalid format"
-msgstr "Ugyldigt format"
-
-#: vncviewer/parameters.cxx:624 vncviewer/parameters.cxx:640
-msgid "Invalid format or too large value"
-msgstr "Ugyldigt format eller for stor værdi"
-
-#: vncviewer/parameters.cxx:667
-#, c-format
-msgid "Unknown parameter %s on line %d in file %s"
-msgstr "Ukendt parameter %s på linje %d i filen %s"
-
-#: vncviewer/vncviewer.cxx:100
-#, c-format
-msgid ""
-"TigerVNC Viewer %d-bit v%s\n"
-"Built on: %s\n"
-"Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
-"See http://www.tigervnc.org for information on TigerVNC."
+#: vncviewer/Win32TouchHandler.cxx:49
+msgid "Window is registered for touch instead of gestures"
 msgstr ""
-"TigerVNC-fremviser %d-bit v%s\n"
-"Bygget på: %s\n"
-"Ophavsret 1999-%d TigerVNC-holdet og mange andre (se README.rst)\n"
-"Se http://www.tigervnc.org for information om TigerVNC."
 
-#: vncviewer/vncviewer.cxx:127
-msgid "About TigerVNC Viewer"
-msgstr "Om TigerVNC-fremviseren"
-
-#: vncviewer/vncviewer.cxx:140
-msgid "Internal FLTK error. Exiting."
-msgstr "Intern FLTK-fejl. Afbryder."
-
-#: vncviewer/vncviewer.cxx:158 vncviewer/vncviewer.cxx:170
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Fejl ved start af ny TigerVNC-fremviser: %s"
+msgid "Failed to set gesture configuration (error 0x%x)"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:179
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC Viewer will now exit."
-msgstr "Opsigelsessignalet %d er blevet modtaget. TigerVNC-fremviseren vil nu afslutte."
+msgid "Failed to get gesture information (error 0x%x)"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:271 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC Viewer"
-msgstr "TigerVNC-fremviser"
-
-#: vncviewer/vncviewer.cxx:280
-msgid "Yes"
-msgstr "Ja"
-
-#: vncviewer/vncviewer.cxx:283
-msgid "Close"
-msgstr "Luk"
-
-#: vncviewer/vncviewer.cxx:288
-msgid "About"
-msgstr "Om"
-
-#: vncviewer/vncviewer.cxx:291
-msgid "Hide"
-msgstr "Skjul"
-
-#: vncviewer/vncviewer.cxx:294
-msgid "Quit"
-msgstr "Afslut"
-
-#: vncviewer/vncviewer.cxx:298
-msgid "Services"
-msgstr "Tjenester"
-
-#: vncviewer/vncviewer.cxx:299
-msgid "Hide Others"
-msgstr "Skjul andre"
-
-#: vncviewer/vncviewer.cxx:300
-msgid "Show All"
-msgstr "Vis alle"
-
-#: vncviewer/vncviewer.cxx:309
-msgctxt "SysMenu|"
-msgid "&File"
-msgstr "&Fil"
-
-#: vncviewer/vncviewer.cxx:312
-msgctxt "SysMenu|File|"
-msgid "&New Connection"
-msgstr "&Ny forbindelse"
-
-#: vncviewer/vncviewer.cxx:324
-msgid "Could not create VNC home directory: can't obtain home directory path."
-msgstr "Kunne ikke oprette VNC-hjemmemappen: Kan ikke indhente hjemmemappens sti."
-
-#: vncviewer/vncviewer.cxx:329
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
-msgid "Could not create VNC home directory: %s."
-msgstr "Kunne ikke oprette VNC-hjemmemappe: %s."
+msgid "Invalid mouse button %d, must be a number between 1 and 7."
+msgstr ""
 
-#. TRANSLATORS: "Parameters" are command line arguments, or settings
-#. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:581 vncviewer/vncviewer.cxx:583
-msgid "Parameters -listen and -via are incompatible"
-msgstr "Parameterne -listen og -via er ikke kompatible"
-
-#: vncviewer/vncviewer.cxx:598
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
-msgid "Listening on port %d"
-msgstr "Lytter på port %d"
+msgid "Unhandled key 0x%x - can't generate keyboard event."
+msgstr ""
 
-#: vncviewer/vncviewer.desktop.in.in:4
-msgid "Remote Desktop Viewer"
-msgstr "Ekstern skrivebordsviser"
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
+#, c-format
+msgid "Unable to get X Input 2 event mask for window 0x%08lx"
+msgstr ""
 
+#: vncviewer/XInputTouchHandler.cxx:105
+#, c-format
+msgid "Window 0x%08lx has no X Input 2 event mask"
+msgstr ""
+
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
+#, c-format
+msgid "Window 0x%08lx has more than one X Input 2 event mask"
+msgstr ""
+
+#: vncviewer/XInputTouchHandler.cxx:144
+#, c-format
+msgid "Failure grabbing device %i"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
 msgid "Connect to VNC server and display remote desktop"
 msgstr "Forbind til VNC-server og vis eksternt skrivebord"
 
-#: vncviewer/vncviewer.desktop.in.in:7
-msgid "tigervnc"
-msgstr "tigervnc"
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
+
+#. developer_name tag deprecated with Appstream 1.0
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
+msgid "The TigerVNC team"
+msgstr ""
+
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
+msgid "The name of the parameter is too large"
+msgstr ""
+
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
+msgid "The parameter is too large"
+msgstr ""
+
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
+msgid "Invalid format or too large value"
+msgstr "Ugyldigt format eller for stor værdi"
+
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
+msgid "Failed to create registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
+msgid "Failed to close registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
+#, c-format
+msgid "Failed to save \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
+#, c-format
+msgid "Failed to remove \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
+msgid "Failed to open registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:635
+#, c-format
+msgid "Failed to read server history entry %d: %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
+#, c-format
+msgid "Failed to read parameter \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
+msgid "Could not determine VNC config directory path"
+msgstr ""
+
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
+msgid "Could not encode parameter"
+msgstr ""
+
+#: vncviewer/parameters.cxx:872
+#, c-format
+msgid "Configuration file %s is in an invalid format"
+msgstr "Konfigurationsfilen %s er i et ugyldigt format"
+
+#: vncviewer/parameters.cxx:895
+msgid "Invalid format"
+msgstr "Ugyldigt format"
+
+#: vncviewer/parameters.cxx:939
+msgid "Unknown parameter"
+msgstr ""
+
+#: vncviewer/touch.cxx:75
+#, c-format
+msgid "Got message (0x%x) for an unhandled window"
+msgstr ""
+
+#: vncviewer/touch.cxx:138 vncviewer/touch.cxx:160
+#, c-format
+msgid "Invalid window 0x%08lx specified for pointer grab"
+msgstr ""
+
+#: vncviewer/touch.cxx:183 vncviewer/touch.cxx:184
+#, c-format
+msgid "Failed to create touch handler: %s"
+msgstr ""
+
+#: vncviewer/touch.cxx:188
+#, c-format
+msgid "Couldn't attach event handler to window (error 0x%x)"
+msgstr ""
+
+#: vncviewer/touch.cxx:215
+msgid "Failed to get event data for X Input event"
+msgstr ""
+
+#: vncviewer/touch.cxx:228
+msgid "X Input event for unknown window"
+msgstr ""
+
+#: vncviewer/touch.cxx:254
+msgid "X Input extension not available."
+msgstr ""
+
+#: vncviewer/touch.cxx:261
+msgid "X Input 2 (or newer) is not available."
+msgstr ""
+
+#: vncviewer/touch.cxx:266
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:103
+#, c-format
+msgid ""
+"TigerVNC v%s\n"
+"Built on: %s\n"
+"Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+"See https://www.tigervnc.org for information on TigerVNC."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:157
+#, c-format
+msgid ""
+"An unexpected error occurred when communicating with the server:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:194
+msgid "Internal FLTK error. Exiting."
+msgstr "Intern FLTK-fejl. Afbryder."
+
+#: vncviewer/vncviewer.cxx:213
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"Attempt to reconnect?"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
+#, c-format
+msgid "Error starting new connection: %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:265
+#, c-format
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:394
+msgid "Yes"
+msgstr "Ja"
+
+#: vncviewer/vncviewer.cxx:397
+msgid "Close"
+msgstr "Luk"
+
+#: vncviewer/vncviewer.cxx:402
+msgid "About"
+msgstr "Om"
+
+#: vncviewer/vncviewer.cxx:405
+msgid "Hide"
+msgstr "Skjul"
+
+#: vncviewer/vncviewer.cxx:408
+msgid "Quit"
+msgstr "Afslut"
+
+#: vncviewer/vncviewer.cxx:412
+msgid "Services"
+msgstr "Tjenester"
+
+#: vncviewer/vncviewer.cxx:413
+msgid "Hide others"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:414
+msgid "Show all"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:423
+msgctxt "SysMenu|"
+msgid "&File"
+msgstr "&Fil"
+
+#: vncviewer/vncviewer.cxx:426
+msgctxt "SysMenu|File|"
+msgid "&New Connection"
+msgstr "&Ny forbindelse"
+
+#: vncviewer/vncviewer.cxx:449
+#, c-format
+msgid ""
+"\n"
+"Usage: %s [parameters] [host][:displayNum]\n"
+"       %s [parameters] [host][::port]\n"
+"       %s [parameters] [unix socket]\n"
+"       %s [parameters] -listen [port]\n"
+"       %s [parameters] [.tigervnc file]\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:464
+#, c-format
+msgid ""
+"\n"
+"Options:\n"
+"\n"
+"  -display Xdisplay  - Specifies the X display for the viewer window\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
+"                       man page for details.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:471
+#, c-format
+msgid ""
+"\n"
+"Parameters can be turned on with -<param> or off with -<param>=0\n"
+"Parameters which take a value can be specified as -<param> <value>\n"
+"Other valid forms are <param>=<value> -<param>=<value> --<param>=<value>\n"
+"Parameter names are case-insensitive.  The parameters are:\n"
+"\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:556
+#, c-format
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:561
+#, c-format
+msgid "Could not create VNC config directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:567
+msgid "Could not determine VNC data directory path"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:573
+#, c-format
+msgid "Could not create VNC data directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:585
+#, c-format
+msgid "Could not create VNC state directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:704
+#, c-format
+msgid "%s: Unrecognized option '%s'\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
+#, c-format
+msgid "See '%s --help' for more information.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:713
+#, c-format
+msgid "%s: Extra argument '%s'\n"
+msgstr ""
+
+#. TRANSLATORS: "Parameters" are command line arguments, or settings
+#. from a file or the Windows registry.
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
+msgid "Parameters -listen and -via are incompatible"
+msgstr "Parameterne -listen og -via er ikke kompatible"
+
+#: vncviewer/vncviewer.cxx:764
+msgid "Unable to listen for incoming connections"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:766
+#, c-format
+msgid "Listening on port %d"
+msgstr "Lytter på port %d"
+
+#: vncviewer/vncviewer.cxx:795
+#, c-format
+msgid ""
+"Failure waiting for incoming VNC connection:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:816
+#, c-format
+msgid ""
+"Failure setting up encrypted tunnel:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.desktop.in.in:4
+msgid "Remote desktop viewer"
+msgstr ""
+
+#, c-format
+#~ msgid "connected to socket %s"
+#~ msgstr "forbundet til soklen %s"
+
+#, c-format
+#~ msgid "connected to host %s port %d"
+#~ msgstr "forbundet til værten %s på port %d"
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(serverstandard %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "SetDesktopSize fejlede: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "Ugyldig SetColourMapEntries fra server!"
+
+#~ msgid "Enabling continuous updates"
+#~ msgstr "Aktiverer fortsættende opdateringer"
+
+#, c-format
+#~ msgid "Throughput %d kbit/s - full color is now %s"
+#~ msgstr "Gennemløb %d kbit/s - fuld farve er nu %s"
+
+#~ msgid "disabled"
+#~ msgstr "deaktiveret"
+
+#~ msgid "enabled"
+#~ msgstr "aktiveret"
+
+#, c-format
+#~ msgid "Using %s encoding"
+#~ msgstr "Bruger %s-kodning"
+
+#~ msgid "Adjusting window size to avoid accidental full screen request"
+#~ msgstr ""
+#~ "Justerer vinduesstørrelse for at undgå utilsigtet anmodning om fuld skærm"
+
+#~ msgid "Failure grabbing mouse"
+#~ msgstr "Kunne ikke fange mus"
+
+#~ msgid "VNC Viewer: Connection Options"
+#~ msgstr "VNC-fremviser: Forbindelsesindstillinger"
+
+#~ msgid "Full (all available colors)"
+#~ msgstr "Fuld (alle tilgængelige farver)"
+
+#~ msgid "Medium (256 colors)"
+#~ msgstr "Mellem (256 farver)"
+
+#~ msgid "Low (64 colors)"
+#~ msgstr "Lav (64 farver)"
+
+#~ msgid "Very low (8 colors)"
+#~ msgstr "Meget lav (8 farver)"
+
+#~ msgid "level (1=fast, 6=best [4-6 are rarely useful])"
+#~ msgstr "niveau (1=hurtig, 6=bedst [4-6 bruges sjældent])"
+
+#~ msgid "Screen"
+#~ msgstr "Skærm"
+
+#~ msgid "Resize remote session on connect"
+#~ msgstr "Ændr størrelse for ekstern session ved forbind"
+
+#~ msgid "Resize remote session to the local window"
+#~ msgstr "Ændr størrelse for ekstern session til det lokale vindue"
+
+#~ msgid "Full-screen mode"
+#~ msgstr "Tilstand for fuld skærm"
+
+#~ msgid "Enable full-screen mode over all monitors"
+#~ msgstr "Aktiver tilstand for fuld skærm over alle skærme"
+
+#~ msgid "Misc."
+#~ msgstr "Div."
+
+#~ msgid "Show dot when no cursor"
+#~ msgstr "Vis punktum når ingen markør"
+
+#~ msgid "VNC Viewer: Connection Details"
+#~ msgstr "VNC-fremviser: Forbindelsesdetaljer"
+
+#~ msgid "Save As..."
+#~ msgstr "Gem som ..."
+
+#~ msgid "Authentication cancelled"
+#~ msgstr "Godkendelse afbrudt"
+
+#, c-format
+#~ msgid "Failed to update keyboard LED state: %d"
+#~ msgstr "Kunne ikke opdatere tastatur-LED-tilstand: %d"
+
+#~ msgid "No key code specified on key press"
+#~ msgstr "Ingen nøglekode angivet ved tastaturtryk"
+
+#, c-format
+#~ msgid "No symbol for key code 0x%02x (in the current state)"
+#~ msgstr "Intet symbol for nøglekode 0x%02x (i den nuværende tilstand)"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "E&xit viewer"
+#~ msgstr "&Afslut fremviser"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "Om &TigerVNC-fremviseren ..."
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "Dismiss &menu"
+#~ msgstr "Fjern &menu"
+
+#, c-format
+#~ msgid "The name of the parameter %s was too large to write to the registry"
+#~ msgstr ""
+#~ "Navnet på parameteren %s var for lang til at kunne skrives til registret"
+
+#, c-format
+#~ msgid "The parameter %s was too large to write to the registry"
+#~ msgstr "Parameteren %s var for lang til at kunne skrives til registret"
+
+#, c-format
+#~ msgid "Failed to write parameter %s of type %s to the registry: %ld"
+#~ msgstr "Kunne ikke skrive parameteren %s af typen %s til registret: %ld"
+
+#, c-format
+#~ msgid "The name of the parameter %s was too large to read from the registry"
+#~ msgstr ""
+#~ "Navnet for parameteren %s var for lang til at kunne læses fra registret"
+
+#, c-format
+#~ msgid "Failed to read parameter %s from the registry: %ld"
+#~ msgstr "Kunne ikke læse parameteren %s fra registret: %ld"
+
+#, c-format
+#~ msgid "The parameter %s was too large to read from the registry"
+#~ msgstr "Parameteren %s var for lang til at kunne læses fra registret"
+
+#, c-format
+#~ msgid "Failed to create registry key: %ld"
+#~ msgstr "Kunne ikke oprette registernøgle: %ld"
+
+#, c-format
+#~ msgid "Unknown parameter type for parameter %s"
+#~ msgstr "Ukendt parametertype for parameteren %s"
+
+#, c-format
+#~ msgid "Failed to close registry key: %ld"
+#~ msgstr "Kunne ikke lukke registernøgle: %ld"
+
+#, c-format
+#~ msgid "Failed to open registry key: %ld"
+#~ msgstr "Kunne ikke åbne registernøgle: %ld"
+
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Kunne ikke skrive konfigurationsfil, kan ikke indhente hjemmemappens sti."
+
+#, c-format
+#~ msgid "Failed to write configuration file, can't open %s: %s"
+#~ msgstr "Kunne ikke skrive konfigurationsfil, kan ikke åbne %s: %s"
+
+#~ msgid "Failed to read configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Kunne ikke læse konfigurationsfil, kan ikke indhente hjemmemappens sti."
+
+#, c-format
+#~ msgid "Failed to read configuration file, can't open %s: %s"
+#~ msgstr "Kunne ikke læse konfigurationsfil, kan ikke åbne %s: %s"
+
+#, c-format
+#~ msgid "Failed to read line %d in file %s: %s"
+#~ msgstr "Kunne ikke læse linje %d i filen %s: %s"
+
+#, c-format
+#~ msgid "Unknown parameter %s on line %d in file %s"
+#~ msgstr "Ukendt parameter %s på linje %d i filen %s"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC Viewer %d-bit v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+#~ "See http://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "TigerVNC-fremviser %d-bit v%s\n"
+#~ "Bygget på: %s\n"
+#~ "Ophavsret 1999-%d TigerVNC-holdet og mange andre (se README.rst)\n"
+#~ "Se http://www.tigervnc.org for information om TigerVNC."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "Om TigerVNC-fremviseren"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Fejl ved start af ny TigerVNC-fremviser: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC Viewer will now exit."
+#~ msgstr ""
+#~ "Opsigelsessignalet %d er blevet modtaget. TigerVNC-fremviseren vil nu "
+#~ "afslutte."
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "TigerVNC-fremviser"
+
+#~ msgid "Hide Others"
+#~ msgstr "Skjul andre"
+
+#~ msgid "Show All"
+#~ msgstr "Vis alle"
+
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
+#~ msgstr ""
+#~ "Kunne ikke oprette VNC-hjemmemappen: Kan ikke indhente hjemmemappens sti."
+
+#, c-format
+#~ msgid "Could not create VNC home directory: %s."
+#~ msgstr "Kunne ikke oprette VNC-hjemmemappe: %s."
+
+#~ msgid "Remote Desktop Viewer"
+#~ msgstr "Ekstern skrivebordsviser"
+
+#~ msgid "tigervnc"
+#~ msgstr "tigervnc"
 
 #~ msgid "Not enough memory for framebuffer"
 #~ msgstr "Ikke nok hukommelse for framebuffer"

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.14.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2025-01-14 16:15+0100\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2025-01-21 18:42+0100\n"
 "Last-Translator: Mario Blättermann <mario.blaettermann@gmail.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -20,17 +20,17 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Lokalize 24.12.1\n"
 
-#: vncviewer/CConn.cxx:102
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "Verbunden mit Socket %s"
 
-#: vncviewer/CConn.cxx:109
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "Verbunden mit Rechner %s, Port %d"
 
-#: vncviewer/CConn.cxx:114
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -41,101 +41,92 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:151
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Desktop-Name: %.80s"
 
-#: vncviewer/CConn.cxx:154
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Rechner: %.80s Port: %d"
 
-#: vncviewer/CConn.cxx:158
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Größe: %d x %d"
 
-#: vncviewer/CConn.cxx:165
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Pixelformat: %s"
 
-#: vncviewer/CConn.cxx:170
-#, c-format
-msgid "(server default %s)"
-msgstr "(Server-Vorgabe %s)"
-
-#: vncviewer/CConn.cxx:173
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Angeforderte Zeichenkodierung: %s"
 
-#: vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Zuletzt verwendete Zeichenkodierung: %s"
 
-#: vncviewer/CConn.cxx:181
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Geschätzte Verbindungsgeschwindigkeit: %d kbit/s"
 
-#: vncviewer/CConn.cxx:185
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Protokollversion: %d.%d"
 
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Sicherheitsmethode: %s"
 
-#: vncviewer/CConn.cxx:250 vncviewer/CConn.cxx:252
-msgid "The connection was dropped by the server before the session could be established."
-msgstr "Die Verbindung wurde vom Server abgebrochen, bevor die Sitzung eingerichtet werden konnte."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
+msgstr ""
+"Die Verbindung wurde vom Server abgebrochen, bevor die Sitzung eingerichtet "
+"werden konnte."
 
-#: vncviewer/CConn.cxx:262
+#: vncviewer/CConn.cxx:258
 #, c-format
 msgid "Authentication failed: %s"
 msgstr "Authentifizierung fehlgeschlagen: %s"
 
-#: vncviewer/CConn.cxx:263
+#: vncviewer/CConn.cxx:259
 #, c-format
 msgid ""
 "Failed to authenticate with the server. Reason given by the server:\n"
 "\n"
 "%s"
 msgstr ""
-"Authentifizierung am Server ist fehlgeschlagen. Vom Server angegebener Grund:\n"
+"Authentifizierung am Server ist fehlgeschlagen. Vom Server angegebener "
+"Grund:\n"
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:335
-#, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "SetDesktopSize fehlgeschlagen: %d"
-
-#: vncviewer/CConn.cxx:408
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "Ungültige SetColourMapEntries vom Server!"
-
-#: vncviewer/CConn.cxx:516
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Durchsatz %d kbit/s - Qualität wird auf %d geändert"
 
-#: vncviewer/CConn.cxx:538
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "Durchsatz %d kbit/s - Vollfarbmodus ist jetzt aktiviert"
 
-#: vncviewer/CConn.cxx:541
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "Durchsatz %d kbit/s - Vollfarbmodus ist jetzt deaktiviert"
 
-#: vncviewer/CConn.cxx:567
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Pixelformat %s wird verwendet"
@@ -148,136 +139,127 @@ msgstr "Unzulässige Geometrie wurde angegeben!"
 msgid "Reducing window size to fit on current monitor"
 msgstr "Fenstergröße an den aktuellen Bildschirm anpassen"
 
-#: vncviewer/DesktopWindow.cxx:646
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
 msgstr "Fenstergröße anpassen, um zufällige Vollbild-Anforderung zu vermeiden"
 
-#: vncviewer/DesktopWindow.cxx:694
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Drücken Sie %s, um das Kontextmenü zu öffnen"
 
-#: vncviewer/DesktopWindow.cxx:1094 vncviewer/DesktopWindow.cxx:1102
-#: vncviewer/DesktopWindow.cxx:1122
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Fehler beim Erkennen der Tastatur"
 
-#: vncviewer/DesktopWindow.cxx:1411
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
-msgstr "Ungültige Bildschirmanordnung wurde für die Größenänderungsanforderung ermittelt!"
+msgstr ""
+"Ungültige Bildschirmanordnung wurde für die Größenänderungsanforderung "
+"ermittelt!"
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "Unzulässiger Status für 3-Tasten-Emulation"
 
-#: vncviewer/KeyboardWin32.cxx:242
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "Kein Scan-Code für erweiterte virtuelle Taste 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:244
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "Kein Scan-Code für virtuelle Taste 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:250
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "Ungültiger Scancode 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:262
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "Kein Symbol für erweiterte virtuelle Taste 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:264
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "Kein Symbol für virtuelle Taste 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:423
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
 msgid "Failed to update keyboard LED state: %lu"
 msgstr "Tastatur-LED-Status konnte nicht aktualisiert werden: %lu"
 
-#: vncviewer/KeyboardX11.cxx:104
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "Kein Symbol für Tastencode %d (im aktuellen Zustand)"
 
-#: vncviewer/KeyboardX11.cxx:129
+#: vncviewer/KeyboardX11.cxx:148
 #, c-format
 msgid "Failed to get keyboard LED state: %d"
 msgstr "Tastatur-LED-Status konnte nicht ermittelt werden: %d"
 
-#: vncviewer/KeyboardX11.cxx:174
+#: vncviewer/KeyboardX11.cxx:193
 msgid "Failed to update keyboard LED state"
 msgstr "Tastatur-LED-Status konnte nicht aktualisiert werden"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:100
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "Konfiguration des Systembildschirms konnte nicht ermittelt werden"
 
-#: vncviewer/MonitorIndicesParameter.cxx:79
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "Unzulässige Konfiguration für %s wurde angegeben"
-
-#: vncviewer/MonitorIndicesParameter.cxx:86
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "Bildschirm-Index %d existiert nicht"
 
-#: vncviewer/MonitorIndicesParameter.cxx:162
-#: vncviewer/MonitorIndicesParameter.cxx:182
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "Unzulässiger Bildschirm-Index »%s«"
-
-#: vncviewer/MonitorIndicesParameter.cxx:170
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "Unerwartetes Zeichen »%c«"
-
-#: vncviewer/OptionsDialog.cxx:64
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
 msgid "TigerVNC options"
 msgstr "TigerVNC-Optionen"
 
-#: vncviewer/OptionsDialog.cxx:97 vncviewer/ServerDialog.cxx:107
-#: vncviewer/vncviewer.cxx:397
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: vncviewer/OptionsDialog.cxx:102 vncviewer/vncviewer.cxx:396
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "OK"
 
-#: vncviewer/OptionsDialog.cxx:514
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "Kompression"
 
-#: vncviewer/OptionsDialog.cxx:530
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "Automatisch auswählen"
 
-#: vncviewer/OptionsDialog.cxx:541
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "Bevorzugte Kodierung"
 
-#: vncviewer/OptionsDialog.cxx:602
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "Farbstufe"
 
-#: vncviewer/OptionsDialog.cxx:614
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "Vollständig"
 
-#: vncviewer/OptionsDialog.cxx:621
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "Mittel"
 
-#: vncviewer/OptionsDialog.cxx:628
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "Niedrig"
 
@@ -285,166 +267,177 @@ msgstr "Niedrig"
 msgid "Very low"
 msgstr "Sehr niedrig"
 
-#: vncviewer/OptionsDialog.cxx:657
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "Individuelle Kompressionsstufe:"
 
-#: vncviewer/OptionsDialog.cxx:664
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "Stufe (0=schnellste, 9=beste)"
 
-#: vncviewer/OptionsDialog.cxx:671
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "JPEG-Kompression erlauben:"
 
-#: vncviewer/OptionsDialog.cxx:678
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "Qualität (0=schlechte, 9=beste)"
 
-#: vncviewer/OptionsDialog.cxx:689
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "Sicherheit"
 
-#: vncviewer/OptionsDialog.cxx:703
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "Verschlüsselung"
 
-#: vncviewer/OptionsDialog.cxx:715 vncviewer/OptionsDialog.cxx:782
-#: vncviewer/OptionsDialog.cxx:905
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "Keine"
 
-#: vncviewer/OptionsDialog.cxx:722
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "TLS mit anonymen Zertifikaten"
 
-#: vncviewer/OptionsDialog.cxx:728
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "TLS mit X509-Zertifikaten"
 
-#: vncviewer/OptionsDialog.cxx:735
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "Pfad zum X509-CA-Zertifikat"
 
-#: vncviewer/OptionsDialog.cxx:742
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "Pfad zur X509-CRL-Datei"
 
-#: vncviewer/OptionsDialog.cxx:770
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "Authentifizierung"
 
-#: vncviewer/OptionsDialog.cxx:788
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "Standard-VNC (unsicher ohne Verschlüsselung)"
 
-#: vncviewer/OptionsDialog.cxx:794
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "Benutzername und Passwort (unsicher ohne Verschlüsselung)"
 
-#: vncviewer/OptionsDialog.cxx:822
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "Eingabe"
 
-#: vncviewer/OptionsDialog.cxx:835
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "Nur Ansicht (Maus und Tastatur ignorieren)"
 
-#: vncviewer/OptionsDialog.cxx:842
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "Maus"
 
-#: vncviewer/OptionsDialog.cxx:854
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "Mittlere Maustaste emulieren"
 
-#: vncviewer/OptionsDialog.cxx:860
+#: vncviewer/OptionsDialog.cxx:880
 msgid "Show local cursor when not provided by server"
 msgstr "Lokalen Cursor anzeigen, wenn der Server keinen bereitstellt"
 
-#: vncviewer/OptionsDialog.cxx:865
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
 msgid "Cursor type"
 msgstr "Cursortyp"
 
-#: vncviewer/OptionsDialog.cxx:867
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
 msgid "Dot"
 msgstr "Dot"
 
-#: vncviewer/OptionsDialog.cxx:868
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
 msgid "System"
 msgstr "System"
 
-#: vncviewer/OptionsDialog.cxx:888
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "Tastatur"
 
-#: vncviewer/OptionsDialog.cxx:900
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
 msgstr "Systemtasten direkt an den Server übergeben (Vollbild)"
 
-#: vncviewer/OptionsDialog.cxx:903
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "Menü-Taste"
 
-#: vncviewer/OptionsDialog.cxx:926
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "Zwischenablage"
 
-#: vncviewer/OptionsDialog.cxx:938
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "Zwischenablage vom Server akzeptieren"
 
-#: vncviewer/OptionsDialog.cxx:946
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "Primäre Auswahl ebenfalls setzen"
 
-#: vncviewer/OptionsDialog.cxx:953
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "Zwischenablage zum Server senden"
 
-#: vncviewer/OptionsDialog.cxx:961
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "Primäre Auswahl als Zwischenablage senden"
 
-#: vncviewer/OptionsDialog.cxx:982
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "Anzeige"
 
-#: vncviewer/OptionsDialog.cxx:996
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "Anzeigemodus"
 
-#: vncviewer/OptionsDialog.cxx:1009
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "Fenster anpassen"
 
-#: vncviewer/OptionsDialog.cxx:1017
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "Vollbild auf dem aktuellen Bildschirm"
 
-#: vncviewer/OptionsDialog.cxx:1025
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "Vollbild auf allen Bildschirmen"
 
-#: vncviewer/OptionsDialog.cxx:1033
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "Vollbild auf ausgewählte(n) Bildschirm(en)"
 
-#: vncviewer/OptionsDialog.cxx:1062
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
 msgid "Miscellaneous"
 msgstr "Verschiedenes"
 
-#: vncviewer/OptionsDialog.cxx:1070
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "Gemeinsamer Zugriff (andere VNC-Viewer nicht trennen)"
 
-#: vncviewer/OptionsDialog.cxx:1076
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "Bei Verbindungsfehlern um erneute Verbindung nachfragen"
-
-#: vncviewer/ServerDialog.cxx:63
-msgid "VNC viewer: Connection details"
-msgstr "VNC-Betrachter: Verbindungsdetails"
 
 #: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
@@ -489,7 +482,7 @@ msgstr "TigerVNC-Konfiguration (*.tigervnc)"
 msgid "Select a TigerVNC configuration file"
 msgstr "Eine TigerVNC-Konfigurationsdatei wählen"
 
-#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:517
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -509,7 +502,7 @@ msgstr "Eine TigerVNC-Konfigurationsdatei speichern"
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "%s existiert bereits. Wollen Sie es überschreiben?"
 
-#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:394
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "Nein"
 
@@ -550,169 +543,172 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:351 vncviewer/ServerDialog.cxx:429
-#: vncviewer/vncviewer.cxx:580
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
 msgid "Could not determine VNC state directory path"
 msgstr "Pfad zum VNC-Statusverzeichnis konnte nicht ermittelt werden"
 
-#: vncviewer/ServerDialog.cxx:363 vncviewer/ServerDialog.cxx:437
-#: vncviewer/parameters.cxx:671 vncviewer/parameters.cxx:752
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
 msgid "Could not open \"%s\""
 msgstr "»%s« konnte nicht geöffnet werden"
 
-#: vncviewer/ServerDialog.cxx:378 vncviewer/ServerDialog.cxx:387
-#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:773
-#: vncviewer/parameters.cxx:807 vncviewer/parameters.cxx:837
-#: vncviewer/parameters.cxx:844
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
 msgid "Failed to read line %d in file \"%s\""
 msgstr "Zeile %d in Datei %s konnte nicht gelesen werden"
 
-#: vncviewer/ServerDialog.cxx:390 vncviewer/parameters.cxx:776
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "Zeile ist zu lang"
 
-#: vncviewer/UserDialog.cxx:123
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "Öffnen der Passwortdatei fehlgeschlagen"
 
-#: vncviewer/UserDialog.cxx:143
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "VNC-Autorisierung"
 
-#: vncviewer/UserDialog.cxx:150
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "Diese Verbindung ist sicher"
 
-#: vncviewer/UserDialog.cxx:154
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "Diese Verbindung ist nicht sicher"
 
-#: vncviewer/UserDialog.cxx:176
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "Benutzername:"
 
-#: vncviewer/UserDialog.cxx:189
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "Passwort:"
 
-#: vncviewer/UserDialog.cxx:197
+#: vncviewer/UserDialog.cxx:204
 msgid "Keep password for reconnect"
 msgstr "Passwort für Wiederverbinden merken"
 
-#: vncviewer/Viewport.cxx:695
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
 msgid "Disconn&ect"
 msgstr "Verbindung &trennen"
 
-#: vncviewer/Viewport.cxx:698
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "&Vollbildmodus"
 
-#: vncviewer/Viewport.cxx:701
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "M&inimieren"
 
-#: vncviewer/Viewport.cxx:703
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "&Fenster an Sitzung anpassen"
 
-#: vncviewer/Viewport.cxx:708
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Strg"
 
-#: vncviewer/Viewport.cxx:711
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:717
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "%s senden"
 
-#: vncviewer/Viewport.cxx:724
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Strg-Alt-E&ntf senden"
 
-#: vncviewer/Viewport.cxx:727
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "Bildschirm &aktualisieren"
 
-#: vncviewer/Viewport.cxx:730
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&Optionen …"
 
-#: vncviewer/Viewport.cxx:732
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "Verbindungs&informationen …"
 
-#: vncviewer/Viewport.cxx:734
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "Info zu &TigerVNC-Betrachter …"
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:830
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "VNC-Verbindungsinformation"
 
-#: vncviewer/Win32TouchHandler.cxx:48
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "Fenster ist für Touch-Bedienung anstelle von Gesten registriert"
 
-#: vncviewer/Win32TouchHandler.cxx:83
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "Gesten-Konfiguration konnte nicht gesetzt werden (Fehler 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:95
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "Gesten-Konfiguration konnte nicht ermittelt werden (Fehler 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:360
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr "Unzulässige Maustaste %d; muss eine Zahl von 1 bis 7 sein."
 
-#: vncviewer/Win32TouchHandler.cxx:425
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
-msgstr "Nicht verarbeitbare Taste 0x%x - Tastaturereignis kann nicht erstellt werden."
+msgstr ""
+"Nicht verarbeitbare Taste 0x%x - Tastaturereignis kann nicht erstellt werden."
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:107
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
-msgstr "Für Fenster 0x%08lx konnte die X-Input2-Ereignismaske nicht erhalten werden"
+msgstr ""
+"Für Fenster 0x%08lx konnte die X-Input2-Ereignismaske nicht erhalten werden"
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr "Window 0x%08lx hat keine X-Input2-Ereignismaske"
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:114
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr "Window 0x%08lx hat mehrere X-Input2-Ereignismasken"
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "Fehler beim Erkennen des Geräts %i"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-msgid "TigerVNC Viewer"
-msgstr "TigerVNC-Betrachter"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -720,100 +716,129 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr "Mite einem VNC-Server verbinden und einen fernen Desktop anzeigen"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
-msgstr "Virtual Network Computing (VNC) ist ein Anzeigesystem für ferne Rechner, dass es Ihnen ermöglicht, eine Arbeitsumgebung auf einem anderen Rechner im Netzwerk zu betrachten und damit zu interagieren. Mit VNC können Sie auf dem fernen Rechner grafische Anwendungen ausführen und lediglich die Anzeige dieser Anwendungen auf Ihr lokales Gerät holen. Dieses Paket enthält einen Client, mit dem Sie sich mit über einen laufenden VNC-Server mit anderen Arbeitsumgebungen verbinden können. VNC ist plattformunabhängig und unterstützt verschiedene Betriebssysteme und Architekturen als sowohl Server als auch Client."
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+"Virtual Network Computing (VNC) ist ein Anzeigesystem für ferne Rechner, "
+"dass es Ihnen ermöglicht, eine Arbeitsumgebung auf einem anderen Rechner im "
+"Netzwerk zu betrachten und damit zu interagieren. Mit VNC können Sie auf dem "
+"fernen Rechner grafische Anwendungen ausführen und lediglich die Anzeige "
+"dieser Anwendungen auf Ihr lokales Gerät holen. Dieses Paket enthält einen "
+"Client, mit dem Sie sich mit über einen laufenden VNC-Server mit anderen "
+"Arbeitsumgebungen verbinden können. VNC ist plattformunabhängig und "
+"unterstützt verschiedene Betriebssysteme und Architekturen als sowohl Server "
+"als auch Client."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
-msgstr "TigerVNC ist eine Hochgeschwindigkeitsversion von VNC, basierend auf den Codebasen von RealVNC 4 und X.org. TigerVNC begann als Weiterentwicklung von TightVNC auf Unix- und Linux-Plattformen und trennte sich Anfang 2009 von seinem Vorgängerprojekt, so dass sich TightVNC auf Windows-Plattformen konzentrieren konnte. TigerVNC unterstützt eine Variante von Tight Encoding, das durch die Verwendung des JPEG-Codecs »libjpeg-turbo« erheblich beschleunigt wird."
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+"TigerVNC ist eine Hochgeschwindigkeitsversion von VNC, basierend auf den "
+"Codebasen von RealVNC 4 und X.org. TigerVNC begann als Weiterentwicklung von "
+"TightVNC auf Unix- und Linux-Plattformen und trennte sich Anfang 2009 von "
+"seinem Vorgängerprojekt, so dass sich TightVNC auf Windows-Plattformen "
+"konzentrieren konnte. TigerVNC unterstützt eine Variante von Tight Encoding, "
+"das durch die Verwendung des JPEG-Codecs »libjpeg-turbo« erheblich "
+"beschleunigt wird."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC viewer connection to a CentOS machine"
-msgstr "TigerVNC-Betrachter-Verbindung zu einem CentOS-Rechner"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC viewer connection to a macOS machine"
-msgstr "TigerVNC-Betrachter-Verbindung zu einem macOS-Rechner"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC viewer connection to a Windows machine"
-msgstr "TigerVNC-Betrachter-Verbindung zu einem Windows-Rechner"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
 #. developer_name tag deprecated with Appstream 1.0
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
-#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:48
 msgid "The TigerVNC team"
 msgstr "Das TigerVNC-Team"
 
-#: vncviewer/parameters.cxx:319 vncviewer/parameters.cxx:344
-#: vncviewer/parameters.cxx:361 vncviewer/parameters.cxx:401
-#: vncviewer/parameters.cxx:421
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "Der Parametername ist zu lang"
 
-#: vncviewer/parameters.cxx:323 vncviewer/parameters.cxx:328
-#: vncviewer/parameters.cxx:379
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "Der Parameter ist zu groß"
 
-#: vncviewer/parameters.cxx:386 vncviewer/parameters.cxx:712
-#: vncviewer/parameters.cxx:822
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "Ungültiges Format oder zu großer Wert"
 
-#: vncviewer/parameters.cxx:440 vncviewer/parameters.cxx:473
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "Registrierungsschlüssel konnte nicht erzeugt werden"
 
-#: vncviewer/parameters.cxx:461 vncviewer/parameters.cxx:528
-#: vncviewer/parameters.cxx:571 vncviewer/parameters.cxx:638
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "Registrierungsschlüssel konnte nicht geschlossen werden"
 
-#: vncviewer/parameters.cxx:479 vncviewer/parameters.cxx:506
-#: vncviewer/parameters.cxx:680 vncviewer/parameters.cxx:692
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "»%s« konnte nicht gespeichert werden: %s"
 
-#: vncviewer/parameters.cxx:489 vncviewer/parameters.cxx:520
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "»%s« konnte nicht entfernt werden: %s"
 
-#: vncviewer/parameters.cxx:544 vncviewer/parameters.cxx:616
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "Registrierungsschlüssel konnte nicht geöffnet werden"
 
-#: vncviewer/parameters.cxx:561
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "Eintrag %d in der Server-Chronik konnte nicht gelesen werden: %s"
 
-#: vncviewer/parameters.cxx:597 vncviewer/parameters.cxx:627
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "Parameter »%s« konnte nicht gelesen werden: %s"
 
-#: vncviewer/parameters.cxx:661 vncviewer/parameters.cxx:740
-#: vncviewer/vncviewer.cxx:546
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
 msgid "Could not determine VNC config directory path"
 msgstr "Pfad zum VNC-Konfigurationsverzeichnis konnte nicht ermittelt werden"
 
-#: vncviewer/parameters.cxx:682 vncviewer/parameters.cxx:694
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "Parameter konnte nicht kodiert werden"
 
-#: vncviewer/parameters.cxx:785
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "Format der Konfigurationsdatei %s ist ungültig"
 
-#: vncviewer/parameters.cxx:809
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "Ungültiges Format"
 
-#: vncviewer/parameters.cxx:846
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "Unbekannter Parameter"
 
@@ -825,7 +850,8 @@ msgstr "Nachricht (0x%x) für ein nicht verarbeitbares Fenster erhalten"
 #: vncviewer/touch.cxx:138 vncviewer/touch.cxx:160
 #, c-format
 msgid "Invalid window 0x%08lx specified for pointer grab"
-msgstr "Für die Zeigerermittlung wurde das unzulässige Fenster 0x%08lx angegeben"
+msgstr ""
+"Für die Zeigerermittlung wurde das unzulässige Fenster 0x%08lx angegeben"
 
 #: vncviewer/touch.cxx:183 vncviewer/touch.cxx:184
 #, c-format
@@ -854,23 +880,23 @@ msgid "X Input 2 (or newer) is not available."
 msgstr "X-Input 2 (oder neuer) ist nicht verfügbar."
 
 #: vncviewer/touch.cxx:266
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
-msgstr "X-Input 2.2 (oder neuer) ist nicht verfügbar. Touch-Gesten werden nicht unterstützt."
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+"X-Input 2.2 (oder neuer) ist nicht verfügbar. Touch-Gesten werden nicht "
+"unterstützt."
 
-#: vncviewer/vncviewer.cxx:104
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
 "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"TigerVNC-Betrachter Version %s\n"
-"Erstellt auf: %s\n"
-"Copyright (C) 1999-%d TigerVNC-Team und viele andere (siehe README.rst)\n"
-"Siehe https://www.tigervnc.org für Informationen zu TigerVNC."
 
-#: vncviewer/vncviewer.cxx:158
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -881,15 +907,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:174
-msgid "About TigerVNC Viewer"
-msgstr "Info zu TigerVNC-Betrachter"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:195
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "Interner FLTK-Fehler. Abbruch."
 
-#: vncviewer/vncviewer.cxx:214
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -900,63 +926,59 @@ msgstr ""
 "\n"
 "Versuchen, die Verbindung erneut aufzubauen?"
 
-#: vncviewer/vncviewer.cxx:245 vncviewer/vncviewer.cxx:257
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Fehler beim Starten des neuen TigerVNC-Betrachters: %s"
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:266
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC viewer will now exit."
-msgstr "Terminierungssignal %d wurde empfangen. Der TigerVNC-Betrachter wird nun beendet."
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:391 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC viewer"
-msgstr "TigerVNC-Betrachter"
-
-#: vncviewer/vncviewer.cxx:395
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "Ja"
 
-#: vncviewer/vncviewer.cxx:398
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "Schließen"
 
-#: vncviewer/vncviewer.cxx:403
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "Info"
 
-#: vncviewer/vncviewer.cxx:406
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "Verbergen"
 
-#: vncviewer/vncviewer.cxx:409
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "Beenden"
 
-#: vncviewer/vncviewer.cxx:413
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "Dienste"
 
-#: vncviewer/vncviewer.cxx:414
+#: vncviewer/vncviewer.cxx:413
 msgid "Hide others"
 msgstr "Andere verbergen"
 
-#: vncviewer/vncviewer.cxx:415
+#: vncviewer/vncviewer.cxx:414
 msgid "Show all"
 msgstr "Alle zeigen"
 
-#: vncviewer/vncviewer.cxx:424
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "&Datei"
 
-#: vncviewer/vncviewer.cxx:427
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "&Neue Verbindung"
 
-#: vncviewer/vncviewer.cxx:450
+#: vncviewer/vncviewer.cxx:449
 #, c-format
 msgid ""
 "\n"
@@ -973,25 +995,19 @@ msgstr ""
 "        %s [Parameter] -listen [Port]\n"
 "        %s [Parameter] [.tigervnc-Datei]\n"
 
-#: vncviewer/vncviewer.cxx:465
+#: vncviewer/vncviewer.cxx:464
 #, c-format
 msgid ""
 "\n"
 "Options:\n"
 "\n"
 "  -display Xdisplay  - Specifies the X display for the viewer window\n"
-"  -geometry geometry - Initial position of the main VNC viewer window. See the\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
 "                       man page for details.\n"
 msgstr ""
-"\n"
-"Optionen:\n"
-"\n"
-"  -display X-Display  - Gibt das X-Display für das Betrachterfenster an\n"
-"  -geometry Geometrie - Anfängliche Position des Hauptfensters des VNC-\n"
-"                        Betrachters. In der Handbuchseite finden Sie weitere\n"
-"                        Details.\n"
 
-#: vncviewer/vncviewer.cxx:472
+#: vncviewer/vncviewer.cxx:471
 #, c-format
 msgid ""
 "\n"
@@ -1010,73 +1026,87 @@ msgstr ""
 "Die Parameter sind:\n"
 "\n"
 
-#: vncviewer/vncviewer.cxx:527
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
-msgstr "FullScreenAllMonitors ist veraltet, setzen Sie stattdessen FullScreenMode auf »all«"
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+"FullScreenAllMonitors ist veraltet, setzen Sie stattdessen FullScreenMode "
+"auf »all«"
 
-#: vncviewer/vncviewer.cxx:532
-msgid "DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' instead"
-msgstr "DotWhenNoCursor ist veraltet, setzen Sie stattdessen AlwaysCursor auf 1 und CursorType auf »Dot«"
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+"DotWhenNoCursor ist veraltet, setzen Sie stattdessen AlwaysCursor auf 1 und "
+"CursorType auf »Dot«"
 
-#: vncviewer/vncviewer.cxx:553
-msgid "~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
-msgstr "~/.vnc ist veraltet, bitte rufen Sie »man vncviewer« auf, um Informationen zu den Pfaden zu erhalten, auf die Sie migrieren können."
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+"~/.vnc ist veraltet, bitte rufen Sie »man vncviewer« auf, um Informationen "
+"zu den Pfaden zu erhalten, auf die Sie migrieren können."
 
-#: vncviewer/vncviewer.cxx:557
+#: vncviewer/vncviewer.cxx:556
 #, c-format
-msgid "%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC location."
-msgstr "%%APPDATA%%\\vnc ist veraltet, bitte wechseln Sie zum %%APPDATA%%\\TigerVNC-Ort."
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+"%%APPDATA%%\\vnc ist veraltet, bitte wechseln Sie zum %%APPDATA%%\\TigerVNC-"
+"Ort."
 
-#: vncviewer/vncviewer.cxx:562
+#: vncviewer/vncviewer.cxx:561
 #, c-format
 msgid "Could not create VNC config directory \"%s\": %s"
 msgstr "VNC-Konfigurationsverzeichnis »%s« konnte nicht erstellt werden: %s"
 
-#: vncviewer/vncviewer.cxx:568
+#: vncviewer/vncviewer.cxx:567
 msgid "Could not determine VNC data directory path"
 msgstr "Pfad zum VNC-Datenverzeichnis konnte nicht ermittelt werden"
 
-#: vncviewer/vncviewer.cxx:574
+#: vncviewer/vncviewer.cxx:573
 #, c-format
 msgid "Could not create VNC data directory \"%s\": %s"
 msgstr "VNC-Datenverzeichnis »%s« konnte nicht erstellt werden: %s"
 
-#: vncviewer/vncviewer.cxx:586
+#: vncviewer/vncviewer.cxx:585
 #, c-format
 msgid "Could not create VNC state directory \"%s\": %s"
 msgstr "VNC-Statusverzeichnis »%s« konnte nicht erstellt werden: %s"
 
-#: vncviewer/vncviewer.cxx:703
+#: vncviewer/vncviewer.cxx:704
 #, c-format
 msgid "%s: Unrecognized option '%s'\n"
 msgstr "%s: Nicht erkannte Option »%s«\n"
 
-#: vncviewer/vncviewer.cxx:705 vncviewer/vncviewer.cxx:713
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
 #, c-format
 msgid "See '%s --help' for more information.\n"
 msgstr "Siehe »%s --help« für weitere Informationen.\n"
 
-#: vncviewer/vncviewer.cxx:712
+#: vncviewer/vncviewer.cxx:713
 #, c-format
 msgid "%s: Extra argument '%s'\n"
 msgstr "%s: Zusätzliches Argument »%s«\n"
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:748 vncviewer/vncviewer.cxx:749
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "Die Parameter -listen und -via schließen sich gegenseitig aus"
 
-#: vncviewer/vncviewer.cxx:763
+#: vncviewer/vncviewer.cxx:764
 msgid "Unable to listen for incoming connections"
 msgstr "Warten auf eingehende Verbindungen ist nicht möglich"
 
-#: vncviewer/vncviewer.cxx:765
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "Am Port %d wird gelauscht"
 
-#: vncviewer/vncviewer.cxx:794
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -1087,7 +1117,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:815
+#: vncviewer/vncviewer.cxx:816
 #, c-format
 msgid ""
 "Failure setting up encrypted tunnel:\n"
@@ -1101,3 +1131,93 @@ msgstr ""
 #: vncviewer/vncviewer.desktop.in.in:4
 msgid "Remote desktop viewer"
 msgstr "Betrachter für ferne Bildschirme"
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(Server-Vorgabe %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "SetDesktopSize fehlgeschlagen: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "Ungültige SetColourMapEntries vom Server!"
+
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "Unzulässige Konfiguration für %s wurde angegeben"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "Unzulässiger Bildschirm-Index »%s«"
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "Unerwartetes Zeichen »%c«"
+
+#~ msgid "VNC viewer: Connection details"
+#~ msgstr "VNC-Betrachter: Verbindungsdetails"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "Info zu &TigerVNC-Betrachter …"
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "TigerVNC-Betrachter"
+
+#~ msgid "TigerVNC viewer connection to a CentOS machine"
+#~ msgstr "TigerVNC-Betrachter-Verbindung zu einem CentOS-Rechner"
+
+#~ msgid "TigerVNC viewer connection to a macOS machine"
+#~ msgstr "TigerVNC-Betrachter-Verbindung zu einem macOS-Rechner"
+
+#~ msgid "TigerVNC viewer connection to a Windows machine"
+#~ msgstr "TigerVNC-Betrachter-Verbindung zu einem Windows-Rechner"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "TigerVNC-Betrachter Version %s\n"
+#~ "Erstellt auf: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC-Team und viele andere (siehe README.rst)\n"
+#~ "Siehe https://www.tigervnc.org für Informationen zu TigerVNC."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "Info zu TigerVNC-Betrachter"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Fehler beim Starten des neuen TigerVNC-Betrachters: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC viewer will now exit."
+#~ msgstr ""
+#~ "Terminierungssignal %d wurde empfangen. Der TigerVNC-Betrachter wird nun "
+#~ "beendet."
+
+#~ msgid "TigerVNC viewer"
+#~ msgstr "TigerVNC-Betrachter"
+
+#, c-format
+#~ msgid ""
+#~ "\n"
+#~ "Options:\n"
+#~ "\n"
+#~ "  -display Xdisplay  - Specifies the X display for the viewer window\n"
+#~ "  -geometry geometry - Initial position of the main VNC viewer window. "
+#~ "See the\n"
+#~ "                       man page for details.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Optionen:\n"
+#~ "\n"
+#~ "  -display X-Display  - Gibt das X-Display für das Betrachterfenster an\n"
+#~ "  -geometry Geometrie - Anfängliche Position des Hauptfensters des VNC-\n"
+#~ "                        Betrachters. In der Handbuchseite finden Sie "
+#~ "weitere\n"
+#~ "                        Details.\n"

--- a/po/el.po
+++ b/po/el.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.9.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2019-10-18 10:14+0200\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2021-04-23 18:00+0300\n"
 "Last-Translator: Vangelis Skarmoutsos <skarmoutsosv@gmail.com>\n"
 "Language-Team: Greek <team@lists.gnome.gr>\n"
@@ -20,749 +20,1282 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.4.2\n"
 
-#: vncviewer/CConn.cxx:99
+#: vncviewer/CConn.cxx:103
 #, fuzzy, c-format
-#| msgid "connected to host %s port %d"
 msgid "Connected to socket %s"
 msgstr "σε σύνδεση με ξενιστή %s θύρα %d"
 
-#: vncviewer/CConn.cxx:106
+#: vncviewer/CConn.cxx:110
 #, fuzzy, c-format
-#| msgid "connected to host %s port %d"
 msgid "Connected to host %s port %d"
 msgstr "σε σύνδεση με ξενιστή %s θύρα %d"
 
-#: vncviewer/CConn.cxx:157
+#: vncviewer/CConn.cxx:115
+#, c-format
+msgid ""
+"Failed to connect to \"%s\":\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Όνομα επιφάνειας εργασίας: %.80s"
 
-#: vncviewer/CConn.cxx:162
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Ξενιστής: %.80s θύρα: %d"
 
-#: vncviewer/CConn.cxx:167
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Μέγεθος: %d x %d"
 
-#: vncviewer/CConn.cxx:175
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Μορφοποίηση pixel: %s"
 
-#: vncviewer/CConn.cxx:182
-#, c-format
-msgid "(server default %s)"
-msgstr "(προκαθορισμένο εξυπηρετητή %s)"
-
-#: vncviewer/CConn.cxx:187
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Αιτούμενη κωδικοποίηση: %s"
 
-#: vncviewer/CConn.cxx:192
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Τελευταία χρησιμοποιημένη κωδικοποίηση: %s"
 
-#: vncviewer/CConn.cxx:197
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Τελευταία εκτίμηση ταχύτητας: %d kbit/s"
 
-#: vncviewer/CConn.cxx:202
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Έκδοση πρωτοκόλλου:  %d.%d"
 
-#: vncviewer/CConn.cxx:207
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Μέθοδος ασφάλειας: %s"
 
-#: vncviewer/CConn.cxx:324
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
+msgstr ""
+
+#: vncviewer/CConn.cxx:258
 #, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "Απέτυχε το SetDesktopSize: %d"
+msgid "Authentication failed: %s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:372
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "Άκυρο SetColourMapEntries από τον εξυπηρετητή!"
+#: vncviewer/CConn.cxx:259
+#, c-format
+msgid ""
+"Failed to authenticate with the server. Reason given by the server:\n"
+"\n"
+"%s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:480
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Διαμεταγωγή %d kbit/s - αλλαγή στην ποιότητα %d"
 
-#: vncviewer/CConn.cxx:502
+#: vncviewer/CConn.cxx:521
 #, fuzzy, c-format
-#| msgid "Throughput %d kbit/s - full color is now %s"
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "Διαμεταγωγή %d kbit/s - το πλήρες χρώμα είναι τώρα %s"
 
-#: vncviewer/CConn.cxx:505
+#: vncviewer/CConn.cxx:524
 #, fuzzy, c-format
-#| msgid "Throughput %d kbit/s - full color is now %s"
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "Διαμεταγωγή %d kbit/s - το πλήρες χρώμα είναι τώρα %s"
 
-#: vncviewer/CConn.cxx:531
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Χρήση μορφής pixel %s"
 
-#: vncviewer/DesktopWindow.cxx:122
+#: vncviewer/DesktopWindow.cxx:146
 msgid "Invalid geometry specified!"
 msgstr "Καθορίστηκε άκυρη γεωμετρία!"
 
-#: vncviewer/DesktopWindow.cxx:495
-msgid "Adjusting window size to avoid accidental full screen request"
-msgstr "Προσαρμογή του μεγέθους παραθύρου για αποφυγή τυχαίου αιτήματος πλήρους οθόνης"
+#: vncviewer/DesktopWindow.cxx:167
+msgid "Reducing window size to fit on current monitor"
+msgstr ""
 
-#: vncviewer/DesktopWindow.cxx:539
+#: vncviewer/DesktopWindow.cxx:681
+msgid "Adjusting window size to avoid accidental full-screen request"
+msgstr ""
+
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Πατήστε %s για να ανοίξετε το αναδυόμενο μενού"
 
-#: vncviewer/DesktopWindow.cxx:836 vncviewer/DesktopWindow.cxx:844
-#: vncviewer/DesktopWindow.cxx:864
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Αποτυχία σύλληψης πληκτρολογίου"
 
-#: vncviewer/DesktopWindow.cxx:938
-msgid "Failure grabbing mouse"
-msgstr "Αποτυχία σύλληψης ποντικιού"
-
-#: vncviewer/DesktopWindow.cxx:1162
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
 msgstr "Άκυρη διάταξη οθόνης υπολογισμένη από αίτημα αλλαγής μεγέθους!"
 
-#: vncviewer/OptionsDialog.cxx:57
-msgid "VNC Viewer: Connection Options"
-msgstr "Θεατής VNC: Επιλογές σύνδεσης"
-
-#: vncviewer/OptionsDialog.cxx:83 vncviewer/ServerDialog.cxx:91
-#: vncviewer/vncviewer.cxx:282
-msgid "Cancel"
-msgstr "Άκυρο"
-
-#: vncviewer/OptionsDialog.cxx:88 vncviewer/vncviewer.cxx:281
-msgid "OK"
-msgstr "Εντάξει"
-
-#: vncviewer/OptionsDialog.cxx:423
-msgid "Compression"
-msgstr "Συμπίεση"
-
-#: vncviewer/OptionsDialog.cxx:439
-msgid "Auto select"
-msgstr "Αυτόματη επιλογή"
-
-#: vncviewer/OptionsDialog.cxx:451
-msgid "Preferred encoding"
-msgstr "Προτιμώμενη κωδικοποίηση"
-
-#: vncviewer/OptionsDialog.cxx:499
-#, fuzzy
-msgid "Color level"
-msgstr "Επίπεδο χρώματος"
-
-# Color level. Επίπεδο χρώματος.
-#: vncviewer/OptionsDialog.cxx:510
-msgid "Full (all available colors)"
-msgstr "Πλήρες (όλα τα διαθέσιμα χρώματα)"
-
-# Color level. Επίπεδο χρώματος.
-#: vncviewer/OptionsDialog.cxx:517
-msgid "Medium (256 colors)"
-msgstr "Ενδιάμεσο (256 χρώματα)"
-
-# Color level. Επίπεδο χρώματος.
-#: vncviewer/OptionsDialog.cxx:524
-msgid "Low (64 colors)"
-msgstr "Χαμηλό (64 χρώματα)"
-
-# Color level. Επίπεδο χρώματος.
-#: vncviewer/OptionsDialog.cxx:531
-msgid "Very low (8 colors)"
-msgstr "Πολύ χαμηλό (8 χρώματα)"
-
-#: vncviewer/OptionsDialog.cxx:548
-msgid "Custom compression level:"
-msgstr "Προσαρμοσμένο επίπεδο συμπίεσης:"
-
-#: vncviewer/OptionsDialog.cxx:554
-msgid "level (1=fast, 6=best [4-6 are rarely useful])"
-msgstr "επίπεδο (1=γρήγορο, 6=καλύτερο [4-6 είναι σπάνια χρήσιμα])"
-
-#: vncviewer/OptionsDialog.cxx:561
-msgid "Allow JPEG compression:"
-msgstr "Να επιτρέπεται η συμπίεση JPEG"
-
-#: vncviewer/OptionsDialog.cxx:567
-msgid "quality (0=poor, 9=best)"
-msgstr "ποιότητα (0=φτωχή, 9=καλύτερη)"
-
-#: vncviewer/OptionsDialog.cxx:578
-msgid "Security"
-msgstr "Ασφάλεια"
-
-#: vncviewer/OptionsDialog.cxx:593
-msgid "Encryption"
-msgstr "Κρυπτογράφηση"
-
-#: vncviewer/OptionsDialog.cxx:604 vncviewer/OptionsDialog.cxx:657
-#: vncviewer/OptionsDialog.cxx:737
-msgid "None"
-msgstr "Κανένα"
-
-#: vncviewer/OptionsDialog.cxx:610
-msgid "TLS with anonymous certificates"
-msgstr "TLS με ανώνυμα πιστοποιητικά"
-
-#: vncviewer/OptionsDialog.cxx:616
-msgid "TLS with X509 certificates"
-msgstr "TLS με πιστοποιητικά X509"
-
-#: vncviewer/OptionsDialog.cxx:623
-msgid "Path to X509 CA certificate"
-msgstr "Μονοπάτι στο πιστοποιητικό X509 CA"
-
-#: vncviewer/OptionsDialog.cxx:630
-msgid "Path to X509 CRL file"
-msgstr "Μονοπάτι στο αρχείο X509 CRL"
-
-#: vncviewer/OptionsDialog.cxx:646
-msgid "Authentication"
-msgstr "Πιστοποίηση"
-
-#: vncviewer/OptionsDialog.cxx:663
-msgid "Standard VNC (insecure without encryption)"
-msgstr "Τυπικό VNC (μη ασφαλές χωρίς κρυπτογράφηση)"
-
-#: vncviewer/OptionsDialog.cxx:669
-msgid "Username and password (insecure without encryption)"
-msgstr "Όνομα χρήστη και συνθηματικό"
-
-#: vncviewer/OptionsDialog.cxx:688
-msgid "Input"
-msgstr "Είσοδος"
-
-#: vncviewer/OptionsDialog.cxx:696
-msgid "View only (ignore mouse and keyboard)"
-msgstr "Μόνο προβολή (αγνόηση ποντικιού και πληκτρολογίου)"
-
-#: vncviewer/OptionsDialog.cxx:702
-msgid "Accept clipboard from server"
-msgstr "Αποδοχή πρόχειρου από τον εξηπηρετητή"
-
-#: vncviewer/OptionsDialog.cxx:710
-msgid "Also set primary selection"
-msgstr "Επίσης ορίζει την κύρια επιλογή"
-
-#: vncviewer/OptionsDialog.cxx:717
-msgid "Send clipboard to server"
-msgstr "Αποστολή του πρόχειρου στον εξηπηρετητή"
-
-#: vncviewer/OptionsDialog.cxx:725
-#, fuzzy
-msgid "Send primary selection as clipboard"
-msgstr "Αποστολή της κύριας επιλογής και αποκοπή της ενδιάμεσης μνήμης ως πρόχειρο"
-
-#: vncviewer/OptionsDialog.cxx:732
-msgid "Pass system keys directly to server (full screen)"
-msgstr "Πέρασμα των πλήκτρων συστήματος κατ' ευθείαν στον εξυπηρετητή (πλήρης οθόνη)"
-
-#: vncviewer/OptionsDialog.cxx:735
-msgid "Menu key"
-msgstr "Πλήκτρο μενού"
-
-#: vncviewer/OptionsDialog.cxx:751
-msgid "Screen"
-msgstr "Οθόνη"
-
-#: vncviewer/OptionsDialog.cxx:759
-msgid "Resize remote session on connect"
-msgstr "Αλλαγή μεγέθους απομακρυσμένης συνεδρίας κατά την σύνδεση"
-
-#: vncviewer/OptionsDialog.cxx:772
-msgid "Resize remote session to the local window"
-msgstr "Αλλαγή μεγέθους απομακρυσμένης συνεδρίας στο τοπικό παράθυρο"
-
-#: vncviewer/OptionsDialog.cxx:778
-msgid "Full-screen mode"
-msgstr "Κατάσταση πλήρους οθόνης"
-
-#: vncviewer/OptionsDialog.cxx:784
-msgid "Enable full-screen mode over all monitors"
-msgstr "Ενεργοποίηση κατάστασης πλήρους-οθόνης σε όλες τις οθόνες"
-
-#: vncviewer/OptionsDialog.cxx:793
-msgid "Misc."
-msgstr "Διάφορα"
-
-#: vncviewer/OptionsDialog.cxx:801
-msgid "Shared (don't disconnect other viewers)"
-msgstr "Κοινόχρηστο (να μην αποσυνδεθούν άλλοι θεατές)"
-
-#: vncviewer/OptionsDialog.cxx:807
-msgid "Show dot when no cursor"
-msgstr "Εμφάνιση κουκίδας όταν δεν υπάρχει δρομέας"
-
-#: vncviewer/ServerDialog.cxx:42
-msgid "VNC Viewer: Connection Details"
-msgstr "Θεατής VNC: Λεπτομέρειες σύνδεσης"
-
-#: vncviewer/ServerDialog.cxx:49 vncviewer/ServerDialog.cxx:54
-msgid "VNC server:"
-msgstr "Εξυπηρετητής VNC:"
-
-#: vncviewer/ServerDialog.cxx:64
-msgid "Options..."
-msgstr "Επιλογές..."
-
-#: vncviewer/ServerDialog.cxx:69
-msgid "Load..."
-msgstr "Φόρτωση..."
-
-#: vncviewer/ServerDialog.cxx:74
-msgid "Save As..."
-msgstr "Αποθήκευση ως..."
-
-#: vncviewer/ServerDialog.cxx:86
-msgid "About..."
-msgstr "Σχετικά..."
-
-#: vncviewer/ServerDialog.cxx:96
-msgid "Connect"
-msgstr "Σύνδεση"
-
-#: vncviewer/ServerDialog.cxx:137 vncviewer/ServerDialog.cxx:171
-msgid "TigerVNC configuration (*.tigervnc)"
-msgstr "Ρυθμίσεις TigerVNC (*.tigervnc)"
-
-#: vncviewer/ServerDialog.cxx:138
-msgid "Select a TigerVNC configuration file"
-msgstr "Επιλογή αρχείου ρυθμίσεων του TigerVNC"
-
-#: vncviewer/ServerDialog.cxx:172
-msgid "Save the TigerVNC configuration to file"
-msgstr "Αποθήκευση ρυθμίσεων του TigerVNC σε αρχείο"
-
-#: vncviewer/ServerDialog.cxx:197
-#, c-format
-msgid "%s already exists. Do you want to overwrite?"
-msgstr "%s ήδη υπάρχει. Θέλετε να το αντικαταστήσετε;"
-
-#: vncviewer/ServerDialog.cxx:198 vncviewer/vncviewer.cxx:279
-msgid "No"
-msgstr "Όχι"
-
-#: vncviewer/ServerDialog.cxx:198
-msgid "Overwrite"
-msgstr "Αντικατάσταση"
-
-#: vncviewer/UserDialog.cxx:85
-msgid "Opening password file failed"
-msgstr "Απέτυχε το άνοιγμα του αρχείου κωδικού"
-
-#: vncviewer/UserDialog.cxx:105
-msgid "VNC authentication"
-msgstr "Πιστοποίηση VNC"
-
-#: vncviewer/UserDialog.cxx:112
-msgid "This connection is secure"
-msgstr "Η σύνδεση είναι ασφαλής"
-
-#: vncviewer/UserDialog.cxx:116
-#, fuzzy
-#| msgid "VNC connection info"
-msgid "This connection is not secure"
-msgstr "Πληροφορίες σύνδεσης VNC"
-
-#: vncviewer/UserDialog.cxx:133
-msgid "Username:"
-msgstr "Όνομα χρήστη:"
-
-#: vncviewer/UserDialog.cxx:146
-msgid "Password:"
-msgstr "Συνθηματικό:"
-
-#: vncviewer/UserDialog.cxx:185
-msgid "Authentication cancelled"
-msgstr "Ακυρώθηκε η πιστοποίηση"
-
-#: vncviewer/Viewport.cxx:389
-#, c-format
-msgid "Failed to update keyboard LED state: %lu"
-msgstr "Αποτυχία ενημέρωσης κατάστασης LED πληκτρολογίου: %lu"
-
-#: vncviewer/Viewport.cxx:395 vncviewer/Viewport.cxx:401
-#, c-format
-msgid "Failed to update keyboard LED state: %d"
-msgstr "Αποτυχία ενημέρωσης κατάστασης LED πληκτρολογίου: %d"
-
-#: vncviewer/Viewport.cxx:431
-msgid "Failed to update keyboard LED state"
-msgstr "Αποτυχία ενημέρωσης κατάστασης LED πληκτρολογίου"
-
-#: vncviewer/Viewport.cxx:458 vncviewer/Viewport.cxx:466
-#: vncviewer/Viewport.cxx:483
-#, c-format
-msgid "Failed to get keyboard LED state: %d"
-msgstr "Αποτυχία λήψης κατάστασης LED πληκτρολογίου: %d"
-
-#: vncviewer/Viewport.cxx:833
-msgid "No key code specified on key press"
-msgstr "Δεν καθορίστηκε κώδικας πλήκτρου στο πάτημα πλήκτρου"
-
-#: vncviewer/Viewport.cxx:982
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
+msgid "Invalid state for 3 button emulation"
+msgstr ""
+
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "Χωρίς κώδικα σάρωσης για το εκτεταμένο εικονικό πλήκτρο 0x%02x"
 
-#: vncviewer/Viewport.cxx:984
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "Χωρίς κώδικα σάρωσης για το εικονικό πλήκτρο 0x%02x"
 
-#: vncviewer/Viewport.cxx:990
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "Μη έγκυρος κωδικός σάρωσης 0x%02x"
 
-#: vncviewer/Viewport.cxx:1020
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "Χωρίς σύμβολο για το εκτεταμένο εικονικό πλήκτρο 0x%02x"
 
-#: vncviewer/Viewport.cxx:1022
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "Χωρίς σύμβολο για το εικονικό πλήκτρο 0x%02x"
 
-#: vncviewer/Viewport.cxx:1115
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
-msgid "No symbol for key code 0x%02x (in the current state)"
-msgstr "Χωρίς σύμβολο για τον κώδικα πλήκτρου 0x%02x (στην τρέχουσα κατάσταση)"
+msgid "Failed to update keyboard LED state: %lu"
+msgstr "Αποτυχία ενημέρωσης κατάστασης LED πληκτρολογίου: %lu"
 
-#: vncviewer/Viewport.cxx:1148
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "Χωρίς σύμβολο για τον κώδικα πλήκτρου %d (στην τρέχουσα κατάσταση)"
 
-#: vncviewer/Viewport.cxx:1199
-#, fuzzy
-#| msgid "Exit viewer"
-msgctxt "ContextMenu|"
-msgid "E&xit viewer"
-msgstr "Έ&ξοδος από τον θεατή"
+#: vncviewer/KeyboardX11.cxx:148
+#, c-format
+msgid "Failed to get keyboard LED state: %d"
+msgstr "Αποτυχία λήψης κατάστασης LED πληκτρολογίου: %d"
 
-#: vncviewer/Viewport.cxx:1202
+#: vncviewer/KeyboardX11.cxx:193
+msgid "Failed to update keyboard LED state"
+msgstr "Αποτυχία ενημέρωσης κατάστασης LED πληκτρολογίου"
+
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
+msgid "Failed to get system monitor configuration"
+msgstr ""
+
+#: vncviewer/MonitorIndicesParameter.cxx:73
+#, c-format
+msgid "Monitor index %d does not exist"
+msgstr ""
+
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
+msgid "TigerVNC options"
+msgstr ""
+
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
+msgid "Cancel"
+msgstr "Άκυρο"
+
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
+msgid "OK"
+msgstr "Εντάξει"
+
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
+msgid "Compression"
+msgstr "Συμπίεση"
+
+#: vncviewer/OptionsDialog.cxx:524
+msgid "Auto select"
+msgstr "Αυτόματη επιλογή"
+
+#: vncviewer/OptionsDialog.cxx:536
+msgid "Preferred encoding"
+msgstr "Προτιμώμενη κωδικοποίηση"
+
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 #, fuzzy
-#| msgid "Full screen"
+msgid "Color level"
+msgstr "Επίπεδο χρώματος"
+
+#: vncviewer/OptionsDialog.cxx:611
+msgid "Full"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:619
+msgid "Medium"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:627
+msgid "Low"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:635
+msgid "Very low"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:658
+msgid "Custom compression level:"
+msgstr "Προσαρμοσμένο επίπεδο συμπίεσης:"
+
+#: vncviewer/OptionsDialog.cxx:666
+msgid "level (0=fast, 9=best)"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:674
+msgid "Allow JPEG compression:"
+msgstr "Να επιτρέπεται η συμπίεση JPEG"
+
+#: vncviewer/OptionsDialog.cxx:682
+msgid "quality (0=poor, 9=best)"
+msgstr "ποιότητα (0=φτωχή, 9=καλύτερη)"
+
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
+msgid "Security"
+msgstr "Ασφάλεια"
+
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
+msgid "Encryption"
+msgstr "Κρυπτογράφηση"
+
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
+msgid "None"
+msgstr "Κανένα"
+
+#: vncviewer/OptionsDialog.cxx:730
+msgid "TLS with anonymous certificates"
+msgstr "TLS με ανώνυμα πιστοποιητικά"
+
+#: vncviewer/OptionsDialog.cxx:737
+msgid "TLS with X509 certificates"
+msgstr "TLS με πιστοποιητικά X509"
+
+#: vncviewer/OptionsDialog.cxx:745
+msgid "Path to X509 CA certificate"
+msgstr "Μονοπάτι στο πιστοποιητικό X509 CA"
+
+#: vncviewer/OptionsDialog.cxx:753
+msgid "Path to X509 CRL file"
+msgstr "Μονοπάτι στο αρχείο X509 CRL"
+
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
+msgid "Authentication"
+msgstr "Πιστοποίηση"
+
+#: vncviewer/OptionsDialog.cxx:802
+msgid "Standard VNC (insecure without encryption)"
+msgstr "Τυπικό VNC (μη ασφαλές χωρίς κρυπτογράφηση)"
+
+#: vncviewer/OptionsDialog.cxx:809
+msgid "Username and password (insecure without encryption)"
+msgstr "Όνομα χρήστη και συνθηματικό"
+
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
+msgid "Input"
+msgstr "Είσοδος"
+
+#: vncviewer/OptionsDialog.cxx:852
+msgid "View only (ignore mouse and keyboard)"
+msgstr "Μόνο προβολή (αγνόηση ποντικιού και πληκτρολογίου)"
+
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
+msgid "Mouse"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:873
+msgid "Emulate middle mouse button"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:880
+msgid "Show local cursor when not provided by server"
+msgstr ""
+
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
+msgid "Cursor type"
+msgstr ""
+
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
+msgid "Dot"
+msgstr ""
+
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
+msgid "System"
+msgstr ""
+
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
+msgid "Keyboard"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:925
+msgid "Pass system keys directly to server (full screen)"
+msgstr ""
+"Πέρασμα των πλήκτρων συστήματος κατ' ευθείαν στον εξυπηρετητή (πλήρης οθόνη)"
+
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
+msgid "Menu key"
+msgstr "Πλήκτρο μενού"
+
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
+msgid "Clipboard"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:968
+msgid "Accept clipboard from server"
+msgstr "Αποδοχή πρόχειρου από τον εξηπηρετητή"
+
+#: vncviewer/OptionsDialog.cxx:977
+msgid "Also set primary selection"
+msgstr "Επίσης ορίζει την κύρια επιλογή"
+
+#: vncviewer/OptionsDialog.cxx:985
+msgid "Send clipboard to server"
+msgstr "Αποστολή του πρόχειρου στον εξηπηρετητή"
+
+#: vncviewer/OptionsDialog.cxx:994
+#, fuzzy
+msgid "Send primary selection as clipboard"
+msgstr ""
+"Αποστολή της κύριας επιλογής και αποκοπή της ενδιάμεσης μνήμης ως πρόχειρο"
+
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
+msgid "Display"
+msgstr ""
+
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
+msgid "Display mode"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1045
+msgid "Windowed"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1054
+msgid "Full screen on current monitor"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1063
+msgid "Full screen on all monitors"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1072
+msgid "Full screen on selected monitor(s)"
+msgstr ""
+
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
+msgid "Miscellaneous"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1111
+msgid "Shared (don't disconnect other viewers)"
+msgstr "Κοινόχρηστο (να μην αποσυνδεθούν άλλοι θεατές)"
+
+#: vncviewer/OptionsDialog.cxx:1118
+msgid "Ask to reconnect on connection errors"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:73
+msgid "VNC server:"
+msgstr "Εξυπηρετητής VNC:"
+
+#: vncviewer/ServerDialog.cxx:80
+msgid "Options..."
+msgstr "Επιλογές..."
+
+#: vncviewer/ServerDialog.cxx:84
+msgid "Load..."
+msgstr "Φόρτωση..."
+
+#: vncviewer/ServerDialog.cxx:88
+msgid "Save as..."
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:102
+msgid "About..."
+msgstr "Σχετικά..."
+
+#: vncviewer/ServerDialog.cxx:111
+msgid "Connect"
+msgstr "Σύνδεση"
+
+#: vncviewer/ServerDialog.cxx:147
+#, c-format
+msgid ""
+"Unable to load the server history:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:176 vncviewer/ServerDialog.cxx:216
+msgid "TigerVNC configuration (*.tigervnc)"
+msgstr "Ρυθμίσεις TigerVNC (*.tigervnc)"
+
+#: vncviewer/ServerDialog.cxx:177
+msgid "Select a TigerVNC configuration file"
+msgstr "Επιλογή αρχείου ρυθμίσεων του TigerVNC"
+
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
+#, c-format
+msgid ""
+"Unable to load the specified configuration file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:217
+msgid "Save the TigerVNC configuration to file"
+msgstr "Αποθήκευση ρυθμίσεων του TigerVNC σε αρχείο"
+
+#: vncviewer/ServerDialog.cxx:243
+#, c-format
+msgid "%s already exists. Do you want to overwrite?"
+msgstr "%s ήδη υπάρχει. Θέλετε να το αντικαταστήσετε;"
+
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
+msgid "No"
+msgstr "Όχι"
+
+#: vncviewer/ServerDialog.cxx:244
+msgid "Overwrite"
+msgstr "Αντικατάσταση"
+
+#: vncviewer/ServerDialog.cxx:260
+#, c-format
+msgid ""
+"Unable to save the specified configuration file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:294
+#, c-format
+msgid ""
+"Unable to save the default configuration:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:306
+#, c-format
+msgid ""
+"Unable to save the server history:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
+msgid "Could not determine VNC state directory path"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
+#, c-format
+msgid "Could not open \"%s\""
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
+#, c-format
+msgid "Failed to read line %d in file \"%s\""
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
+msgid "Line too long"
+msgstr "Πολύ μεγάλη γραμμή"
+
+#: vncviewer/UserDialog.cxx:130
+msgid "Opening password file failed"
+msgstr "Απέτυχε το άνοιγμα του αρχείου κωδικού"
+
+#: vncviewer/UserDialog.cxx:150
+msgid "VNC authentication"
+msgstr "Πιστοποίηση VNC"
+
+#: vncviewer/UserDialog.cxx:157
+msgid "This connection is secure"
+msgstr "Η σύνδεση είναι ασφαλής"
+
+#: vncviewer/UserDialog.cxx:161
+#, fuzzy
+msgid "This connection is not secure"
+msgstr "Πληροφορίες σύνδεσης VNC"
+
+#: vncviewer/UserDialog.cxx:183
+msgid "Username:"
+msgstr "Όνομα χρήστη:"
+
+#: vncviewer/UserDialog.cxx:196
+msgid "Password:"
+msgstr "Συνθηματικό:"
+
+#: vncviewer/UserDialog.cxx:204
+msgid "Keep password for reconnect"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:749
+msgctxt "ContextMenu|"
+msgid "Disconn&ect"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:752
+#, fuzzy
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "&Πλήρης οθόνη"
 
-#: vncviewer/Viewport.cxx:1205
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "Ε&λαχιστοποίηση"
 
-#: vncviewer/Viewport.cxx:1207
+#: vncviewer/Viewport.cxx:757
 #, fuzzy
-#| msgid "Resize window to session"
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "Αλλαγή &μεγέθους παραθύρου στην συνεδρία"
 
-#: vncviewer/Viewport.cxx:1212
+#: vncviewer/Viewport.cxx:762
 #, fuzzy
-#| msgid "Ctrl"
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:1215
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:1221
+#: vncviewer/Viewport.cxx:771
 #, fuzzy, c-format
-#| msgid "Send %s"
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "Αποστολή %s"
 
-#: vncviewer/Viewport.cxx:1227
+#: vncviewer/Viewport.cxx:779
 #, fuzzy
-#| msgid "Send Ctrl-Alt-Del"
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Αποστολή Ctrl-Alt-&Del"
 
-#: vncviewer/Viewport.cxx:1230
+#: vncviewer/Viewport.cxx:782
 #, fuzzy
-#| msgid "Refresh screen"
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "Ανανέωση &οθόνης"
 
-#: vncviewer/Viewport.cxx:1233
+#: vncviewer/Viewport.cxx:785
 #, fuzzy
-#| msgid "Options..."
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&Επιλογές..."
 
-#: vncviewer/Viewport.cxx:1235
+#: vncviewer/Viewport.cxx:787
 #, fuzzy
-#| msgid "Connection info..."
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "Πληροφορίες &σύνδεσης..."
 
-#: vncviewer/Viewport.cxx:1237
-#, fuzzy
-#| msgid "About TigerVNC viewer..."
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "Σχετικά με τον θεατή &TigerVNC..."
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:1240
-#, fuzzy
-msgctxt "ContextMenu|"
-msgid "Dismiss &menu"
-msgstr "&Μενού απόρριψης"
-
-#: vncviewer/Viewport.cxx:1329
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "Πληροφορίες σύνδεσης VNC"
 
-#: vncviewer/parameters.cxx:278 vncviewer/parameters.cxx:312
-#, fuzzy, c-format
-#| msgid "The value of the parameter %s on line %d in file %s is invalid."
-msgid "The name of the parameter %s was too large to write to the registry"
-msgstr "Η τιμή της παραμέτρου %s στην γραμμή %d του αρχείου %s είναι άκυρη."
+#: vncviewer/Win32TouchHandler.cxx:49
+msgid "Window is registered for touch instead of gestures"
+msgstr ""
 
-#: vncviewer/parameters.cxx:284 vncviewer/parameters.cxx:291
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
-msgid "The parameter %s was too large to write to the registry"
-msgstr "Η παράμετρος %s ήταν πολύ μεγάλη για να εγγραφεί στην registry"
+msgid "Failed to set gesture configuration (error 0x%x)"
+msgstr ""
 
-#: vncviewer/parameters.cxx:297 vncviewer/parameters.cxx:318
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
-msgid "Failed to write parameter %s of type %s to the registry: %ld"
-msgstr "Αποτυχία εγγραφής παραμέτρου %s τύπου %s στην registry: %ld"
+msgid "Failed to get gesture information (error 0x%x)"
+msgstr ""
 
-#: vncviewer/parameters.cxx:334 vncviewer/parameters.cxx:377
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
-msgid "The name of the parameter %s was too large to read from the registry"
-msgstr "Το όνομα της παραμέτρου %s ήταν πολύ μεγάλο για να διαβαστεί από την registry"
+msgid "Invalid mouse button %d, must be a number between 1 and 7."
+msgstr ""
 
-#: vncviewer/parameters.cxx:346 vncviewer/parameters.cxx:386
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
-msgid "Failed to read parameter %s from the registry: %ld"
-msgstr "Αποτυχία ανάγνωσης παραμέτρου %s από registry: %ld"
+msgid "Unhandled key 0x%x - can't generate keyboard event."
+msgstr ""
 
-#: vncviewer/parameters.cxx:357
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
-msgid "The parameter %s was too large to read from the registry"
-msgstr "Η παράμετρος %s ήταν πολύ μεγάλη για να διαβαστεί από την registry"
+msgid "Unable to get X Input 2 event mask for window 0x%08lx"
+msgstr ""
 
-#: vncviewer/parameters.cxx:406
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
-msgid "Failed to create registry key: %ld"
-msgstr "Αποτυχία δημιουργίας κλειδιού registry: %ld"
+msgid "Window 0x%08lx has no X Input 2 event mask"
+msgstr ""
 
-#: vncviewer/parameters.cxx:420 vncviewer/parameters.cxx:469
-#: vncviewer/parameters.cxx:532 vncviewer/parameters.cxx:666
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
-msgid "Unknown parameter type for parameter %s"
-msgstr "Άγνωστος τύπος παραμέτρου για την παράμετρο %s"
+msgid "Window 0x%08lx has more than one X Input 2 event mask"
+msgstr ""
 
-#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:476
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
-msgid "Failed to close registry key: %ld"
-msgstr "Αποτυχία κλεισίματος του κλειδιού registry: %ld"
+msgid "Failure grabbing device %i"
+msgstr ""
 
-#: vncviewer/parameters.cxx:443
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
+#: vncviewer/vncviewer.desktop.in.in:5
+msgid "Connect to VNC server and display remote desktop"
+msgstr ""
+"Σύνδεση σε ένα εξυπηρετητή VNC και εμφάνιση του απομακρυσμένου επιφάνειας "
+"εργασίας"
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
+
+#. developer_name tag deprecated with Appstream 1.0
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
+msgid "The TigerVNC team"
+msgstr ""
+
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
+msgid "The name of the parameter is too large"
+msgstr ""
+
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
+msgid "The parameter is too large"
+msgstr ""
+
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
+msgid "Invalid format or too large value"
+msgstr "Μη έγκυρη μορφή ή πολύ μεγάλη τιμή"
+
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
+msgid "Failed to create registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
+msgid "Failed to close registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
-msgid "Failed to open registry key: %ld"
-msgstr "Αποτυχία ανοίγματος του κλειδιού registry: %ld"
+msgid "Failed to save \"%s\": %s"
+msgstr ""
 
-#: vncviewer/parameters.cxx:500
-msgid "Failed to write configuration file, can't obtain home directory path."
-msgstr "Αποτυχία εγγραφής του αρχείου διαμόρφωσης, δεν μπορεί να ληφθεί το μονοπάτι του αρχικού καταλόγου."
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
+#, c-format
+msgid "Failed to remove \"%s\": %s"
+msgstr ""
 
-#: vncviewer/parameters.cxx:514
-#, fuzzy, c-format
-#| msgid "Failed to write configuration file, can't open %s"
-msgid "Failed to write configuration file, can't open %s: %s"
-msgstr "Αποτυχία εγγραφής τους αρχείου διαμόρφωσης, δεν μπορεί να ανοίξει το %s"
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
+msgid "Failed to open registry key"
+msgstr ""
 
-#: vncviewer/parameters.cxx:559
-msgid "Failed to read configuration file, can't obtain home directory path."
-msgstr "Αποτυχία ανάγνωσης αρχείου διαμόρφωσης, δεν βρέθηκε το μονοπάτι αρχικού καταλόγου."
+#: vncviewer/parameters.cxx:635
+#, c-format
+msgid "Failed to read server history entry %d: %s"
+msgstr ""
 
-#: vncviewer/parameters.cxx:573
-#, fuzzy, c-format
-#| msgid "Failed to read configuration file, can't open %s"
-msgid "Failed to read configuration file, can't open %s: %s"
-msgstr "Αποτυχία ανάγωνσης αρχείου διαμόρφωσης, δεν μπορεί να ανοίξει το %s"
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
+#, c-format
+msgid "Failed to read parameter \"%s\": %s"
+msgstr ""
 
-#: vncviewer/parameters.cxx:586 vncviewer/parameters.cxx:591
-#: vncviewer/parameters.cxx:616 vncviewer/parameters.cxx:629
-#: vncviewer/parameters.cxx:645
-#, fuzzy, c-format
-#| msgid "Failed to read line %d in file %s"
-msgid "Failed to read line %d in file %s: %s"
-msgstr "Αποτυχία ανάγνωσης της γραμμής %d από το αρχείο %s"
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
+msgid "Could not determine VNC config directory path"
+msgstr ""
 
-#: vncviewer/parameters.cxx:592
-msgid "Line too long"
-msgstr "Πολύ μεγάλη γραμμή"
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
+msgid "Could not encode parameter"
+msgstr ""
 
-#: vncviewer/parameters.cxx:599
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "Το αρχείο ρυθμίσεων %s δεν έχει έγκυρη μορφή"
 
-#: vncviewer/parameters.cxx:617
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "Μη έγκυρη μορφή"
 
-#: vncviewer/parameters.cxx:630 vncviewer/parameters.cxx:646
-msgid "Invalid format or too large value"
-msgstr "Μη έγκυρη μορφή ή πολύ μεγάλη τιμή"
+#: vncviewer/parameters.cxx:939
+msgid "Unknown parameter"
+msgstr ""
 
-#: vncviewer/parameters.cxx:673
-#, fuzzy, c-format
-#| msgid "Invalid parameter name on line: %d in file: %s"
-msgid "Unknown parameter %s on line %d in file %s"
-msgstr "Άκυρο όνομα παραμέτρου στην γραμμή %d στο αρχείο: %s"
+#: vncviewer/touch.cxx:75
+#, c-format
+msgid "Got message (0x%x) for an unhandled window"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:100
-#, fuzzy, c-format
-#| msgid ""
-#| "TigerVNC Viewer %d-bit v%s\n"
-#| "Built on: %s\n"
-#| "Copyright (C) 1999-%d TigerVNC Team and many others (see README.txt)\n"
-#| "See http://www.tigervnc.org for information on TigerVNC."
+#: vncviewer/touch.cxx:138 vncviewer/touch.cxx:160
+#, c-format
+msgid "Invalid window 0x%08lx specified for pointer grab"
+msgstr ""
+
+#: vncviewer/touch.cxx:183 vncviewer/touch.cxx:184
+#, c-format
+msgid "Failed to create touch handler: %s"
+msgstr ""
+
+#: vncviewer/touch.cxx:188
+#, c-format
+msgid "Couldn't attach event handler to window (error 0x%x)"
+msgstr ""
+
+#: vncviewer/touch.cxx:215
+msgid "Failed to get event data for X Input event"
+msgstr ""
+
+#: vncviewer/touch.cxx:228
+msgid "X Input event for unknown window"
+msgstr ""
+
+#: vncviewer/touch.cxx:254
+msgid "X Input extension not available."
+msgstr ""
+
+#: vncviewer/touch.cxx:261
+msgid "X Input 2 (or newer) is not available."
+msgstr ""
+
+#: vncviewer/touch.cxx:266
 msgid ""
-"TigerVNC Viewer %d-bit v%s\n"
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:103
+#, c-format
+msgid ""
+"TigerVNC v%s\n"
 "Built on: %s\n"
-"Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+"Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"Θεατής TigerVNC %d-bit v%s\n"
-"Built on: %s\n"
-"Πνευματικά δικαιώματα (C) 1999-%d Ομάδα TigerVNC και πολλοί άλλοι (δείτε το README.txt)\n"
-"Δείτε στο http://www.tigervnc.org για πληροφορίες σχετικά με το TigerVNC."
 
-#: vncviewer/vncviewer.cxx:127
-msgid "About TigerVNC Viewer"
-msgstr "Σχετικά με τον Θεατή TigerVNC"
+#: vncviewer/vncviewer.cxx:157
+#, c-format
+msgid ""
+"An unexpected error occurred when communicating with the server:\n"
+"\n"
+"%s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:140
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "Εσωτερικό σφάλμα του FLTK. Γίνεται έξοδος."
 
-#: vncviewer/vncviewer.cxx:158 vncviewer/vncviewer.cxx:170
-#, fuzzy, c-format
-#| msgid "About TigerVNC Viewer"
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Σχετικά με τον Θεατή TigerVNC"
-
-#: vncviewer/vncviewer.cxx:179
+#: vncviewer/vncviewer.cxx:213
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC Viewer will now exit."
-msgstr "Λήφθηκε σήμα τερματισμού %d. Το TigerVNC θα τερματιστεί."
+msgid ""
+"%s\n"
+"\n"
+"Attempt to reconnect?"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:271 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC Viewer"
-msgstr "Θεατής TigerVNC"
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
+#, c-format
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:280
+#: vncviewer/vncviewer.cxx:265
+#, c-format
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "Ναι"
 
-#: vncviewer/vncviewer.cxx:283
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "Κλείσιμο"
 
-#: vncviewer/vncviewer.cxx:288
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "Σχετικά"
 
-#: vncviewer/vncviewer.cxx:291
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "Απόκρυψη"
 
-#: vncviewer/vncviewer.cxx:294
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "Εγκατάλειψη"
 
-#: vncviewer/vncviewer.cxx:298
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "Υπηρεσίες"
 
-#: vncviewer/vncviewer.cxx:299
-msgid "Hide Others"
-msgstr "Απόκρυψη άλλων"
+#: vncviewer/vncviewer.cxx:413
+msgid "Hide others"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:300
-msgid "Show All"
-msgstr "Εμφάνιση όλων"
+#: vncviewer/vncviewer.cxx:414
+msgid "Show all"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:309
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "&Αρχείο"
 
-#: vncviewer/vncviewer.cxx:312
+#: vncviewer/vncviewer.cxx:426
 #, fuzzy
-#| msgid "VNC connection info"
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "Πληροφορίες σύνδεσης VNC"
 
-#: vncviewer/vncviewer.cxx:324
-msgid "Could not create VNC home directory: can't obtain home directory path."
-msgstr "Αδυναμία δημιουργίας αρχικού καταλόγου VNC: δεν μπορεί να ληφθεί το μονοπάτι του αρχικού καταλόγου."
-
-#: vncviewer/vncviewer.cxx:329
+#: vncviewer/vncviewer.cxx:449
 #, c-format
-msgid "Could not create VNC home directory: %s."
-msgstr "Αδυναμία δημιουργίας αρχικού καταλόγου VNC: %s."
+msgid ""
+"\n"
+"Usage: %s [parameters] [host][:displayNum]\n"
+"       %s [parameters] [host][::port]\n"
+"       %s [parameters] [unix socket]\n"
+"       %s [parameters] -listen [port]\n"
+"       %s [parameters] [.tigervnc file]\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:464
+#, c-format
+msgid ""
+"\n"
+"Options:\n"
+"\n"
+"  -display Xdisplay  - Specifies the X display for the viewer window\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
+"                       man page for details.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:471
+#, c-format
+msgid ""
+"\n"
+"Parameters can be turned on with -<param> or off with -<param>=0\n"
+"Parameters which take a value can be specified as -<param> <value>\n"
+"Other valid forms are <param>=<value> -<param>=<value> --<param>=<value>\n"
+"Parameter names are case-insensitive.  The parameters are:\n"
+"\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:556
+#, c-format
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:561
+#, c-format
+msgid "Could not create VNC config directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:567
+msgid "Could not determine VNC data directory path"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:573
+#, c-format
+msgid "Could not create VNC data directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:585
+#, c-format
+msgid "Could not create VNC state directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:704
+#, c-format
+msgid "%s: Unrecognized option '%s'\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
+#, c-format
+msgid "See '%s --help' for more information.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:713
+#, c-format
+msgid "%s: Extra argument '%s'\n"
+msgstr ""
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:602 vncviewer/vncviewer.cxx:604
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "Οι παράμετροι -listen και -via δεν είναι συμβατές"
 
-#: vncviewer/vncviewer.cxx:619
+#: vncviewer/vncviewer.cxx:764
+msgid "Unable to listen for incoming connections"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:766
 #, fuzzy, c-format
-#| msgid "Listening on port %d\n"
 msgid "Listening on port %d"
 msgstr "Ακρόαση στην θύρα %d\n"
 
+#: vncviewer/vncviewer.cxx:795
+#, c-format
+msgid ""
+"Failure waiting for incoming VNC connection:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:816
+#, c-format
+msgid ""
+"Failure setting up encrypted tunnel:\n"
+"\n"
+"%s"
+msgstr ""
+
 #: vncviewer/vncviewer.desktop.in.in:4
-msgid "Remote Desktop Viewer"
-msgstr "Θεατής απομακρυσμένης επιφάνειας εργασίας"
+msgid "Remote desktop viewer"
+msgstr ""
 
-#: vncviewer/vncviewer.desktop.in.in:5
-msgid "Connect to VNC server and display remote desktop"
-msgstr "Σύνδεση σε ένα εξυπηρετητή VNC και εμφάνιση του απομακρυσμένου επιφάνειας εργασίας"
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(προκαθορισμένο εξυπηρετητή %s)"
 
-#: vncviewer/vncviewer.desktop.in.in:7
-msgid "tigervnc"
-msgstr "tigervnc"
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "Απέτυχε το SetDesktopSize: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "Άκυρο SetColourMapEntries από τον εξυπηρετητή!"
+
+#~ msgid "Adjusting window size to avoid accidental full screen request"
+#~ msgstr ""
+#~ "Προσαρμογή του μεγέθους παραθύρου για αποφυγή τυχαίου αιτήματος πλήρους "
+#~ "οθόνης"
+
+#~ msgid "Failure grabbing mouse"
+#~ msgstr "Αποτυχία σύλληψης ποντικιού"
+
+#~ msgid "VNC Viewer: Connection Options"
+#~ msgstr "Θεατής VNC: Επιλογές σύνδεσης"
+
+# Color level. Επίπεδο χρώματος.
+#~ msgid "Full (all available colors)"
+#~ msgstr "Πλήρες (όλα τα διαθέσιμα χρώματα)"
+
+# Color level. Επίπεδο χρώματος.
+#~ msgid "Medium (256 colors)"
+#~ msgstr "Ενδιάμεσο (256 χρώματα)"
+
+# Color level. Επίπεδο χρώματος.
+#~ msgid "Low (64 colors)"
+#~ msgstr "Χαμηλό (64 χρώματα)"
+
+# Color level. Επίπεδο χρώματος.
+#~ msgid "Very low (8 colors)"
+#~ msgstr "Πολύ χαμηλό (8 χρώματα)"
+
+#~ msgid "level (1=fast, 6=best [4-6 are rarely useful])"
+#~ msgstr "επίπεδο (1=γρήγορο, 6=καλύτερο [4-6 είναι σπάνια χρήσιμα])"
+
+#~ msgid "Screen"
+#~ msgstr "Οθόνη"
+
+#~ msgid "Resize remote session on connect"
+#~ msgstr "Αλλαγή μεγέθους απομακρυσμένης συνεδρίας κατά την σύνδεση"
+
+#~ msgid "Resize remote session to the local window"
+#~ msgstr "Αλλαγή μεγέθους απομακρυσμένης συνεδρίας στο τοπικό παράθυρο"
+
+#~ msgid "Full-screen mode"
+#~ msgstr "Κατάσταση πλήρους οθόνης"
+
+#~ msgid "Enable full-screen mode over all monitors"
+#~ msgstr "Ενεργοποίηση κατάστασης πλήρους-οθόνης σε όλες τις οθόνες"
+
+#~ msgid "Misc."
+#~ msgstr "Διάφορα"
+
+#~ msgid "Show dot when no cursor"
+#~ msgstr "Εμφάνιση κουκίδας όταν δεν υπάρχει δρομέας"
+
+#~ msgid "VNC Viewer: Connection Details"
+#~ msgstr "Θεατής VNC: Λεπτομέρειες σύνδεσης"
+
+#~ msgid "Save As..."
+#~ msgstr "Αποθήκευση ως..."
+
+#~ msgid "Authentication cancelled"
+#~ msgstr "Ακυρώθηκε η πιστοποίηση"
+
+#, c-format
+#~ msgid "Failed to update keyboard LED state: %d"
+#~ msgstr "Αποτυχία ενημέρωσης κατάστασης LED πληκτρολογίου: %d"
+
+#~ msgid "No key code specified on key press"
+#~ msgstr "Δεν καθορίστηκε κώδικας πλήκτρου στο πάτημα πλήκτρου"
+
+#, c-format
+#~ msgid "No symbol for key code 0x%02x (in the current state)"
+#~ msgstr ""
+#~ "Χωρίς σύμβολο για τον κώδικα πλήκτρου 0x%02x (στην τρέχουσα κατάσταση)"
+
+#, fuzzy
+#~| msgid "Exit viewer"
+#~ msgctxt "ContextMenu|"
+#~ msgid "E&xit viewer"
+#~ msgstr "Έ&ξοδος από τον θεατή"
+
+#, fuzzy
+#~| msgid "About TigerVNC viewer..."
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "Σχετικά με τον θεατή &TigerVNC..."
+
+#, fuzzy
+#~ msgctxt "ContextMenu|"
+#~ msgid "Dismiss &menu"
+#~ msgstr "&Μενού απόρριψης"
+
+#, fuzzy, c-format
+#~| msgid "The value of the parameter %s on line %d in file %s is invalid."
+#~ msgid "The name of the parameter %s was too large to write to the registry"
+#~ msgstr "Η τιμή της παραμέτρου %s στην γραμμή %d του αρχείου %s είναι άκυρη."
+
+#, c-format
+#~ msgid "The parameter %s was too large to write to the registry"
+#~ msgstr "Η παράμετρος %s ήταν πολύ μεγάλη για να εγγραφεί στην registry"
+
+#, c-format
+#~ msgid "Failed to write parameter %s of type %s to the registry: %ld"
+#~ msgstr "Αποτυχία εγγραφής παραμέτρου %s τύπου %s στην registry: %ld"
+
+#, c-format
+#~ msgid "The name of the parameter %s was too large to read from the registry"
+#~ msgstr ""
+#~ "Το όνομα της παραμέτρου %s ήταν πολύ μεγάλο για να διαβαστεί από την "
+#~ "registry"
+
+#, c-format
+#~ msgid "Failed to read parameter %s from the registry: %ld"
+#~ msgstr "Αποτυχία ανάγνωσης παραμέτρου %s από registry: %ld"
+
+#, c-format
+#~ msgid "The parameter %s was too large to read from the registry"
+#~ msgstr "Η παράμετρος %s ήταν πολύ μεγάλη για να διαβαστεί από την registry"
+
+#, c-format
+#~ msgid "Failed to create registry key: %ld"
+#~ msgstr "Αποτυχία δημιουργίας κλειδιού registry: %ld"
+
+#, c-format
+#~ msgid "Unknown parameter type for parameter %s"
+#~ msgstr "Άγνωστος τύπος παραμέτρου για την παράμετρο %s"
+
+#, c-format
+#~ msgid "Failed to close registry key: %ld"
+#~ msgstr "Αποτυχία κλεισίματος του κλειδιού registry: %ld"
+
+#, c-format
+#~ msgid "Failed to open registry key: %ld"
+#~ msgstr "Αποτυχία ανοίγματος του κλειδιού registry: %ld"
+
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Αποτυχία εγγραφής του αρχείου διαμόρφωσης, δεν μπορεί να ληφθεί το "
+#~ "μονοπάτι του αρχικού καταλόγου."
+
+#, fuzzy, c-format
+#~| msgid "Failed to write configuration file, can't open %s"
+#~ msgid "Failed to write configuration file, can't open %s: %s"
+#~ msgstr ""
+#~ "Αποτυχία εγγραφής τους αρχείου διαμόρφωσης, δεν μπορεί να ανοίξει το %s"
+
+#~ msgid "Failed to read configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Αποτυχία ανάγνωσης αρχείου διαμόρφωσης, δεν βρέθηκε το μονοπάτι αρχικού "
+#~ "καταλόγου."
+
+#, fuzzy, c-format
+#~| msgid "Failed to read configuration file, can't open %s"
+#~ msgid "Failed to read configuration file, can't open %s: %s"
+#~ msgstr "Αποτυχία ανάγωνσης αρχείου διαμόρφωσης, δεν μπορεί να ανοίξει το %s"
+
+#, fuzzy, c-format
+#~| msgid "Failed to read line %d in file %s"
+#~ msgid "Failed to read line %d in file %s: %s"
+#~ msgstr "Αποτυχία ανάγνωσης της γραμμής %d από το αρχείο %s"
+
+#, fuzzy, c-format
+#~| msgid "Invalid parameter name on line: %d in file: %s"
+#~ msgid "Unknown parameter %s on line %d in file %s"
+#~ msgstr "Άκυρο όνομα παραμέτρου στην γραμμή %d στο αρχείο: %s"
+
+#, fuzzy, c-format
+#~| msgid ""
+#~| "TigerVNC Viewer %d-bit v%s\n"
+#~| "Built on: %s\n"
+#~| "Copyright (C) 1999-%d TigerVNC Team and many others (see README.txt)\n"
+#~| "See http://www.tigervnc.org for information on TigerVNC."
+#~ msgid ""
+#~ "TigerVNC Viewer %d-bit v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "Θεατής TigerVNC %d-bit v%s\n"
+#~ "Built on: %s\n"
+#~ "Πνευματικά δικαιώματα (C) 1999-%d Ομάδα TigerVNC και πολλοί άλλοι (δείτε "
+#~ "το README.txt)\n"
+#~ "Δείτε στο http://www.tigervnc.org για πληροφορίες σχετικά με το TigerVNC."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "Σχετικά με τον Θεατή TigerVNC"
+
+#, fuzzy, c-format
+#~| msgid "About TigerVNC Viewer"
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Σχετικά με τον Θεατή TigerVNC"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC Viewer will now exit."
+#~ msgstr "Λήφθηκε σήμα τερματισμού %d. Το TigerVNC θα τερματιστεί."
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "Θεατής TigerVNC"
+
+#~ msgid "Hide Others"
+#~ msgstr "Απόκρυψη άλλων"
+
+#~ msgid "Show All"
+#~ msgstr "Εμφάνιση όλων"
+
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
+#~ msgstr ""
+#~ "Αδυναμία δημιουργίας αρχικού καταλόγου VNC: δεν μπορεί να ληφθεί το "
+#~ "μονοπάτι του αρχικού καταλόγου."
+
+#, c-format
+#~ msgid "Could not create VNC home directory: %s."
+#~ msgstr "Αδυναμία δημιουργίας αρχικού καταλόγου VNC: %s."
+
+#~ msgid "Remote Desktop Viewer"
+#~ msgstr "Θεατής απομακρυσμένης επιφάνειας εργασίας"
+
+#~ msgid "tigervnc"
+#~ msgstr "tigervnc"
 
 #~ msgid "Alt"
 #~ msgstr "Alt"
@@ -778,8 +1311,12 @@ msgstr "tigervnc"
 #~ msgstr "Κλήθηκε το CleanupSignalHandler"
 
 #, fuzzy
-#~ msgid "Could not convert the parameter-name %s to wchar_t* when reading from the Registry, the buffersize is to small."
-#~ msgstr "Δεν μπορούσε να μετατραπεί το όνομα παραμέτου %s σε wchar_t* κατά την ανάγνωση από την registry, το buffersize είναι πολύ μικρό."
+#~ msgid ""
+#~ "Could not convert the parameter-name %s to wchar_t* when reading from the "
+#~ "Registry, the buffersize is to small."
+#~ msgstr ""
+#~ "Δεν μπορούσε να μετατραπεί το όνομα παραμέτου %s σε wchar_t* κατά την "
+#~ "ανάγνωση από την registry, το buffersize είναι πολύ μικρό."
 
 #, fuzzy
 #~ msgid "Could not create framebuffer bitmap"
@@ -792,8 +1329,12 @@ msgstr "tigervnc"
 #~ msgstr "Αδυναμία δημιουργίας εικόνας framebuffer"
 
 #, fuzzy
-#~ msgid "Could not read the line(%d) in the configuration file,the buffersize is to small."
-#~ msgstr "Αδυναμία ανάγνωσης της γραμμής(%d) στο αρχείο διαμόρφωσης, το buffersize είναι πολύ μικρό."
+#~ msgid ""
+#~ "Could not read the line(%d) in the configuration file,the buffersize is "
+#~ "to small."
+#~ msgstr ""
+#~ "Αδυναμία ανάγνωσης της γραμμής(%d) στο αρχείο διαμόρφωσης, το buffersize "
+#~ "είναι πολύ μικρό."
 
 #, fuzzy
 #~ msgid "Couldn't find suitable pixmap format"
@@ -802,8 +1343,12 @@ msgstr "tigervnc"
 #~ msgid "CreateCompatibleDC failed"
 #~ msgstr "Απέτυχε το CreateCompatibleDC"
 
-#~ msgid "Decoding: The size of the buffer dest is to small, it needs to be 1 byte bigger."
-#~ msgstr "Αποκωδικοποίηση: Το μέγεθος του buffer είναι πολύ μικρό, χρειάζεται να είναι 1 byte μεγαλύτερο."
+#~ msgid ""
+#~ "Decoding: The size of the buffer dest is to small, it needs to be 1 byte "
+#~ "bigger."
+#~ msgstr ""
+#~ "Αποκωδικοποίηση: Το μέγεθος του buffer είναι πολύ μικρό, χρειάζεται να "
+#~ "είναι 1 byte μεγαλύτερο."
 
 #~ msgid "Display lacks pixmap format for default depth"
 #~ msgstr "Η οθόνη στερείται τύπου pixmap για το προκαθορισμένο βάθος"
@@ -811,14 +1356,26 @@ msgstr "tigervnc"
 #~ msgid "Enabling continuous updates"
 #~ msgstr "Ενεργοποίηση συνεχών ενημερώσεων"
 
-#~ msgid "Encoding backslash: The size of the buffer dest is to small, it needs to be more than %d bytes bigger."
-#~ msgstr "Κωδικοποίηση ανάποδης καθέτου: Το μέγεθος του buffer προορισμού είναι πολύ μικρό, χρειάζεται είναι περισσότερο από %d byte μεγαλύτερο."
+#~ msgid ""
+#~ "Encoding backslash: The size of the buffer dest is to small, it needs to "
+#~ "be more than %d bytes bigger."
+#~ msgstr ""
+#~ "Κωδικοποίηση ανάποδης καθέτου: Το μέγεθος του buffer προορισμού είναι "
+#~ "πολύ μικρό, χρειάζεται είναι περισσότερο από %d byte μεγαλύτερο."
 
-#~ msgid "Encoding escape sequence: The size of the buffer dest is to small, it needs to be more than %d bytes bigger."
-#~ msgstr "Κωδικοποίηση ακολουθίας escape: Το μέγεθος του buffer προορισμού είναι πολύ μικρό, χρειάζεται είναι περισσότερο από %d byte μεγαλύτερο."
+#~ msgid ""
+#~ "Encoding escape sequence: The size of the buffer dest is to small, it "
+#~ "needs to be more than %d bytes bigger."
+#~ msgstr ""
+#~ "Κωδικοποίηση ακολουθίας escape: Το μέγεθος του buffer προορισμού είναι "
+#~ "πολύ μικρό, χρειάζεται είναι περισσότερο από %d byte μεγαλύτερο."
 
-#~ msgid "Encoding normal character: The size of the buffer dest is to small, it needs to be more than %d bytes bigger."
-#~ msgstr "Κωδικοποίηση κανονικού χαρακτήρα: Το μέγεθος του buffer προορισμού είναι πολύ μικρό, χρειάζεται είναι περισσότερο από %d byte μεγαλύτερο."
+#~ msgid ""
+#~ "Encoding normal character: The size of the buffer dest is to small, it "
+#~ "needs to be more than %d bytes bigger."
+#~ msgstr ""
+#~ "Κωδικοποίηση κανονικού χαρακτήρα: Το μέγεθος του buffer προορισμού είναι "
+#~ "πολύ μικρό, χρειάζεται είναι περισσότερο από %d byte μεγαλύτερο."
 
 #~ msgid "Error(%d) closing key:  Software\\TigerVNC\\vncviewer"
 #~ msgstr "Σφάλμα(%d) closing key:  Software\\TigerVNC\\vncviewer"
@@ -838,11 +1395,13 @@ msgstr "tigervnc"
 #~ "\"%s\""
 #~ msgstr ""
 #~ "Η γραμμή 1 στο αρχείο %s\n"
-#~ "πρέπει να περιέχει τη συμβολοσειρά αναγνώρισης αρχείου διαμόρφωσης του TigerVNC:\n"
+#~ "πρέπει να περιέχει τη συμβολοσειρά αναγνώρισης αρχείου διαμόρφωσης του "
+#~ "TigerVNC:\n"
 #~ "\"%s\""
 
 #~ msgid "Multiple characters given for key code %d (0x%04x): '%s'"
-#~ msgstr "Πολλαπλοί χαρακτήρες δόθηκαν για τον κώδικα πλήκτρου %d (0x%04x): '%s'"
+#~ msgstr ""
+#~ "Πολλαπλοί χαρακτήρες δόθηκαν για τον κώδικα πλήκτρου %d (0x%04x): '%s'"
 
 #~ msgid "Not enough memory for framebuffer"
 #~ msgstr "Ανεπάρκεια μνήμης για τον framebuffer"
@@ -854,7 +1413,8 @@ msgstr "tigervnc"
 #~ msgstr "Απέτυχε το SelectObject"
 
 #~ msgid "The parameterArray contains a object of a invalid type at line %d."
-#~ msgstr "Το parameterArray περιέχει ένα αντικείμενο άκυρου τύπου στην γραμμή %d."
+#~ msgstr ""
+#~ "Το parameterArray περιέχει ένα αντικείμενο άκυρου τύπου στην γραμμή %d."
 
 #~ msgid "Unable to create platform specific framebuffer: %s"
 #~ msgstr "Αδυναμία δημιουργίας framebuffer στη συγκεκριμένη πλατφόρμα: %s"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.9.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2019-10-18 10:14+0200\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2019-12-25 12:34-0300\n"
 "Last-Translator: Felipe Castro <fefcas@gmail.com>\n"
 "Language-Team: Esperanto <translation-team-eo@lists.sourceforge.net>\n"
@@ -18,703 +18,1242 @@ msgstr ""
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: Poedit 2.2.1\n"
 
-#: vncviewer/CConn.cxx:99
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "Konektita al konektinterfaco %s"
 
-#: vncviewer/CConn.cxx:106
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "Konektita al gastiganto %s pordo %d"
 
-#: vncviewer/CConn.cxx:157
+#: vncviewer/CConn.cxx:115
+#, c-format
+msgid ""
+"Failed to connect to \"%s\":\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Labortabla nomo: %.80s"
 
-#: vncviewer/CConn.cxx:162
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Gastiganto: %.80s pordo: %d"
 
-#: vncviewer/CConn.cxx:167
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Grando: %d x %d"
 
-#: vncviewer/CConn.cxx:175
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Bildero-formo: %s"
 
-#: vncviewer/CConn.cxx:182
-#, c-format
-msgid "(server default %s)"
-msgstr "(servila implicito %s)"
-
-#: vncviewer/CConn.cxx:187
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Petata enkodigo: %s"
 
-#: vncviewer/CConn.cxx:192
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Lasta uzata enkodigo: %s"
 
-#: vncviewer/CConn.cxx:197
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Lini-rapida konjekto: %d kbit/s"
 
-#: vncviewer/CConn.cxx:202
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Protokola versio: %d.%d"
 
-#: vncviewer/CConn.cxx:207
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Sekureca metodo: %s"
 
-#: vncviewer/CConn.cxx:324
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
+msgstr ""
+
+#: vncviewer/CConn.cxx:258
 #, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "SetDesktopSize fiaskis: %d"
+msgid "Authentication failed: %s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:372
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "Malvalida SetColourMapEntries el servilo!"
+#: vncviewer/CConn.cxx:259
+#, c-format
+msgid ""
+"Failed to authenticate with the server. Reason given by the server:\n"
+"\n"
+"%s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:480
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Traigo %d kbit/s - ni ŝanĝas al kvalito %d"
 
-#: vncviewer/CConn.cxx:502
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "Traigo %d kbit/s - plenkoloro nun estas ebligita"
 
-#: vncviewer/CConn.cxx:505
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "Traigo %d kbit/s - plenkoloro nun estas malebligita"
 
-#: vncviewer/CConn.cxx:531
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Ni uzas bilderformon %s"
 
-#: vncviewer/DesktopWindow.cxx:122
+#: vncviewer/DesktopWindow.cxx:146
 msgid "Invalid geometry specified!"
 msgstr "Malvalida geometrio indikita!"
 
-#: vncviewer/DesktopWindow.cxx:495
-msgid "Adjusting window size to avoid accidental full screen request"
-msgstr "Alĝustigo de fenestra grando por eviti akcidentan plenekranan peton"
+#: vncviewer/DesktopWindow.cxx:167
+msgid "Reducing window size to fit on current monitor"
+msgstr ""
 
-#: vncviewer/DesktopWindow.cxx:539
+#: vncviewer/DesktopWindow.cxx:681
+msgid "Adjusting window size to avoid accidental full-screen request"
+msgstr ""
+
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Premu %s por malfermi la kuntekstan menuon"
 
-#: vncviewer/DesktopWindow.cxx:836 vncviewer/DesktopWindow.cxx:844
-#: vncviewer/DesktopWindow.cxx:864
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Fiasko dum elpreno de klavaro"
 
-#: vncviewer/DesktopWindow.cxx:938
-msgid "Failure grabbing mouse"
-msgstr "Fiasko dum elpreno de muso"
-
-#: vncviewer/DesktopWindow.cxx:1162
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
 msgstr "Malvalida ekrana aranĝo komputita por regrandiga peto!"
 
-#: vncviewer/OptionsDialog.cxx:57
-msgid "VNC Viewer: Connection Options"
-msgstr "Rigardilo VNC: konektaj preferoj"
-
-#: vncviewer/OptionsDialog.cxx:83 vncviewer/ServerDialog.cxx:91
-#: vncviewer/vncviewer.cxx:282
-msgid "Cancel"
-msgstr "Nuligi"
-
-#: vncviewer/OptionsDialog.cxx:88 vncviewer/vncviewer.cxx:281
-msgid "OK"
-msgstr "Bone"
-
-#: vncviewer/OptionsDialog.cxx:423
-msgid "Compression"
-msgstr "Densigo"
-
-#: vncviewer/OptionsDialog.cxx:439
-msgid "Auto select"
-msgstr "Aŭtomate elekti"
-
-#: vncviewer/OptionsDialog.cxx:451
-msgid "Preferred encoding"
-msgstr "Preferata enkodigo"
-
-#: vncviewer/OptionsDialog.cxx:499
-msgid "Color level"
-msgstr "Kolora nivelo"
-
-#: vncviewer/OptionsDialog.cxx:510
-msgid "Full (all available colors)"
-msgstr "Kompleta (ĉiuj disponeblaj koloroj)"
-
-#: vncviewer/OptionsDialog.cxx:517
-msgid "Medium (256 colors)"
-msgstr "Meze (256 koloroj)"
-
-#: vncviewer/OptionsDialog.cxx:524
-msgid "Low (64 colors)"
-msgstr "Malalte (64 koloroj)"
-
-#: vncviewer/OptionsDialog.cxx:531
-msgid "Very low (8 colors)"
-msgstr "Tre malalta (8 koloroj)"
-
-#: vncviewer/OptionsDialog.cxx:548
-msgid "Custom compression level:"
-msgstr "Persona densig-nivelo:"
-
-#: vncviewer/OptionsDialog.cxx:554
-msgid "level (1=fast, 6=best [4-6 are rarely useful])"
-msgstr "nivelo (1=rapida, 6=plejbona [4-6 rare utilas])"
-
-#: vncviewer/OptionsDialog.cxx:561
-msgid "Allow JPEG compression:"
-msgstr "Permesi JPEG-densigon:"
-
-#: vncviewer/OptionsDialog.cxx:567
-msgid "quality (0=poor, 9=best)"
-msgstr "kvalito (0=aĉa, 9=plejbona)"
-
-#: vncviewer/OptionsDialog.cxx:578
-msgid "Security"
-msgstr "Sekureco"
-
-#: vncviewer/OptionsDialog.cxx:593
-msgid "Encryption"
-msgstr "Ĉifrado"
-
-#: vncviewer/OptionsDialog.cxx:604 vncviewer/OptionsDialog.cxx:657
-#: vncviewer/OptionsDialog.cxx:737
-msgid "None"
-msgstr "Nenio"
-
-#: vncviewer/OptionsDialog.cxx:610
-msgid "TLS with anonymous certificates"
-msgstr "TLS kun anonimaj atestiloj"
-
-#: vncviewer/OptionsDialog.cxx:616
-msgid "TLS with X509 certificates"
-msgstr "TLS kun atestiloj X509"
-
-#: vncviewer/OptionsDialog.cxx:623
-msgid "Path to X509 CA certificate"
-msgstr "Vojo al atestilo X509 CA"
-
-#: vncviewer/OptionsDialog.cxx:630
-msgid "Path to X509 CRL file"
-msgstr "Vojo al dosiero X509 CRL"
-
-#: vncviewer/OptionsDialog.cxx:646
-msgid "Authentication"
-msgstr "Aŭtentikiĝo"
-
-#: vncviewer/OptionsDialog.cxx:663
-msgid "Standard VNC (insecure without encryption)"
-msgstr "Ordinara VNC (nesekura sen ĉifrado)"
-
-#: vncviewer/OptionsDialog.cxx:669
-msgid "Username and password (insecure without encryption)"
-msgstr "Uzantnomo kaj pasvorto (nesekura sen ĉifrado)"
-
-#: vncviewer/OptionsDialog.cxx:688
-msgid "Input"
-msgstr "Enigo"
-
-#: vncviewer/OptionsDialog.cxx:696
-msgid "View only (ignore mouse and keyboard)"
-msgstr "Nur rigardi (preteratenti muson kaj klavaron)"
-
-#: vncviewer/OptionsDialog.cxx:702
-msgid "Accept clipboard from server"
-msgstr "Akcepti tondaĵon el la servilo"
-
-#: vncviewer/OptionsDialog.cxx:710
-msgid "Also set primary selection"
-msgstr "Difini ankaŭ la ĉefan elekton"
-
-#: vncviewer/OptionsDialog.cxx:717
-msgid "Send clipboard to server"
-msgstr "Sendi tondaĵon al la servilo"
-
-#: vncviewer/OptionsDialog.cxx:725
-msgid "Send primary selection as clipboard"
-msgstr "Sendi ĉefan elekton kiel tondajô"
-
-#: vncviewer/OptionsDialog.cxx:732
-msgid "Pass system keys directly to server (full screen)"
-msgstr "Pasi sistemajn klavojn rekte al la servilo (plenekrane)"
-
-#: vncviewer/OptionsDialog.cxx:735
-msgid "Menu key"
-msgstr "Menu-klavo"
-
-#: vncviewer/OptionsDialog.cxx:751
-msgid "Screen"
-msgstr "Ekrano"
-
-#: vncviewer/OptionsDialog.cxx:759
-msgid "Resize remote session on connect"
-msgstr "Regrandigi foran seancon dum konekto"
-
-#: vncviewer/OptionsDialog.cxx:772
-msgid "Resize remote session to the local window"
-msgstr "Regrandigi foran seancon al la loka fenestro"
-
-#: vncviewer/OptionsDialog.cxx:778
-msgid "Full-screen mode"
-msgstr "Plenekrana reĝimo"
-
-#: vncviewer/OptionsDialog.cxx:784
-msgid "Enable full-screen mode over all monitors"
-msgstr "Ebligi plenekranan reĝimon en ĉiuj ekranoj"
-
-#: vncviewer/OptionsDialog.cxx:793
-msgid "Misc."
-msgstr "Divers."
-
-#: vncviewer/OptionsDialog.cxx:801
-msgid "Shared (don't disconnect other viewers)"
-msgstr "Kunhave (ne malkonekti aliajn rigardilojn)"
-
-#: vncviewer/OptionsDialog.cxx:807
-msgid "Show dot when no cursor"
-msgstr "Montri punkton kiam sen kursoro"
-
-#: vncviewer/ServerDialog.cxx:42
-msgid "VNC Viewer: Connection Details"
-msgstr "Rigardilo VNC: konektaj detaloj"
-
-#: vncviewer/ServerDialog.cxx:49 vncviewer/ServerDialog.cxx:54
-msgid "VNC server:"
-msgstr "Servilo VNC:"
-
-#: vncviewer/ServerDialog.cxx:64
-msgid "Options..."
-msgstr "Modifiloj..."
-
-#: vncviewer/ServerDialog.cxx:69
-msgid "Load..."
-msgstr "Ŝargo..."
-
-#: vncviewer/ServerDialog.cxx:74
-msgid "Save As..."
-msgstr "Konservi kiel..."
-
-#: vncviewer/ServerDialog.cxx:86
-msgid "About..."
-msgstr "Pri..."
-
-#: vncviewer/ServerDialog.cxx:96
-msgid "Connect"
-msgstr "Konekti"
-
-#: vncviewer/ServerDialog.cxx:137 vncviewer/ServerDialog.cxx:171
-msgid "TigerVNC configuration (*.tigervnc)"
-msgstr "Agordo de TigerVNC (*.tigervnc)"
-
-#: vncviewer/ServerDialog.cxx:138
-msgid "Select a TigerVNC configuration file"
-msgstr "Elekti agordo-dosieron de TigerVNC"
-
-#: vncviewer/ServerDialog.cxx:172
-msgid "Save the TigerVNC configuration to file"
-msgstr "Konservi la agordo-dosieron de TigerVNC"
-
-#: vncviewer/ServerDialog.cxx:197
-#, c-format
-msgid "%s already exists. Do you want to overwrite?"
-msgstr "%s jam ekzistas. Ĉu vi volas anstataŭigi?"
-
-#: vncviewer/ServerDialog.cxx:198 vncviewer/vncviewer.cxx:279
-msgid "No"
-msgstr "Ne"
-
-#: vncviewer/ServerDialog.cxx:198
-msgid "Overwrite"
-msgstr "Anstataŭigi"
-
-#: vncviewer/UserDialog.cxx:85
-msgid "Opening password file failed"
-msgstr "Malfermo de pasvorta dosiero fiaskis"
-
-#: vncviewer/UserDialog.cxx:105
-msgid "VNC authentication"
-msgstr "Aŭtentikiĝo de VNC"
-
-#: vncviewer/UserDialog.cxx:112
-msgid "This connection is secure"
-msgstr "Tiu ĉi konekto estas sekura"
-
-#: vncviewer/UserDialog.cxx:116
-msgid "This connection is not secure"
-msgstr "Tiu ĉi konekto ne estas sekora"
-
-#: vncviewer/UserDialog.cxx:133
-msgid "Username:"
-msgstr "Uzantnomo:"
-
-#: vncviewer/UserDialog.cxx:146
-msgid "Password:"
-msgstr "Pasvorto:"
-
-#: vncviewer/UserDialog.cxx:185
-msgid "Authentication cancelled"
-msgstr "Aŭtentikiĝo estas nuligita"
-
-#: vncviewer/Viewport.cxx:389
-#, c-format
-msgid "Failed to update keyboard LED state: %lu"
-msgstr "Fiasko dum ĝisdatigo de stato de klavaro-LED: %lu"
-
-#: vncviewer/Viewport.cxx:395 vncviewer/Viewport.cxx:401
-#, c-format
-msgid "Failed to update keyboard LED state: %d"
-msgstr "Fiasko dum ĝisdatigo de stato de klavaro-LED: %d"
-
-#: vncviewer/Viewport.cxx:431
-msgid "Failed to update keyboard LED state"
-msgstr "Fiasko dum ĝisdatigo de stato de klavaro-LED"
-
-#: vncviewer/Viewport.cxx:458 vncviewer/Viewport.cxx:466
-#: vncviewer/Viewport.cxx:483
-#, c-format
-msgid "Failed to get keyboard LED state: %d"
-msgstr "Fiasko dum kontrolo de stato de klavaro-LED: %d"
-
-#: vncviewer/Viewport.cxx:833
-msgid "No key code specified on key press"
-msgstr "Neniu klavkodo estis specifica por klav-aktivigo"
-
-#: vncviewer/Viewport.cxx:982
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
+msgid "Invalid state for 3 button emulation"
+msgstr ""
+
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "Neniu skankodo por kroma virtuala klavo 0x%02x"
 
-#: vncviewer/Viewport.cxx:984
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "Neniu skankodo por virtuala klavo 0x%02x"
 
-#: vncviewer/Viewport.cxx:990
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "Malvalida skankodo 0x%02x"
 
-#: vncviewer/Viewport.cxx:1020
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "Neniu simbolo por kroma virtuala klavo 0x%02x"
 
-#: vncviewer/Viewport.cxx:1022
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "Neniu simbolo por virtuala klavo 0x%02x"
 
-#: vncviewer/Viewport.cxx:1115
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
-msgid "No symbol for key code 0x%02x (in the current state)"
-msgstr "Neniu simbolo por klavkodo 0x%02x (en la nuna stato)"
+msgid "Failed to update keyboard LED state: %lu"
+msgstr "Fiasko dum ĝisdatigo de stato de klavaro-LED: %lu"
 
-#: vncviewer/Viewport.cxx:1148
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "Neniu simbolo por klavkodo %d (en la nuna stato)"
 
-#: vncviewer/Viewport.cxx:1199
-msgctxt "ContextMenu|"
-msgid "E&xit viewer"
-msgstr "E&liri la rigardilon"
+#: vncviewer/KeyboardX11.cxx:148
+#, c-format
+msgid "Failed to get keyboard LED state: %d"
+msgstr "Fiasko dum kontrolo de stato de klavaro-LED: %d"
 
-#: vncviewer/Viewport.cxx:1202
+#: vncviewer/KeyboardX11.cxx:193
+msgid "Failed to update keyboard LED state"
+msgstr "Fiasko dum ĝisdatigo de stato de klavaro-LED"
+
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
+msgid "Failed to get system monitor configuration"
+msgstr ""
+
+#: vncviewer/MonitorIndicesParameter.cxx:73
+#, c-format
+msgid "Monitor index %d does not exist"
+msgstr ""
+
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
+msgid "TigerVNC options"
+msgstr ""
+
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
+msgid "Cancel"
+msgstr "Nuligi"
+
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
+msgid "OK"
+msgstr "Bone"
+
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
+msgid "Compression"
+msgstr "Densigo"
+
+#: vncviewer/OptionsDialog.cxx:524
+msgid "Auto select"
+msgstr "Aŭtomate elekti"
+
+#: vncviewer/OptionsDialog.cxx:536
+msgid "Preferred encoding"
+msgstr "Preferata enkodigo"
+
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
+msgid "Color level"
+msgstr "Kolora nivelo"
+
+#: vncviewer/OptionsDialog.cxx:611
+msgid "Full"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:619
+msgid "Medium"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:627
+msgid "Low"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:635
+msgid "Very low"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:658
+msgid "Custom compression level:"
+msgstr "Persona densig-nivelo:"
+
+#: vncviewer/OptionsDialog.cxx:666
+msgid "level (0=fast, 9=best)"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:674
+msgid "Allow JPEG compression:"
+msgstr "Permesi JPEG-densigon:"
+
+#: vncviewer/OptionsDialog.cxx:682
+msgid "quality (0=poor, 9=best)"
+msgstr "kvalito (0=aĉa, 9=plejbona)"
+
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
+msgid "Security"
+msgstr "Sekureco"
+
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
+msgid "Encryption"
+msgstr "Ĉifrado"
+
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
+msgid "None"
+msgstr "Nenio"
+
+#: vncviewer/OptionsDialog.cxx:730
+msgid "TLS with anonymous certificates"
+msgstr "TLS kun anonimaj atestiloj"
+
+#: vncviewer/OptionsDialog.cxx:737
+msgid "TLS with X509 certificates"
+msgstr "TLS kun atestiloj X509"
+
+#: vncviewer/OptionsDialog.cxx:745
+msgid "Path to X509 CA certificate"
+msgstr "Vojo al atestilo X509 CA"
+
+#: vncviewer/OptionsDialog.cxx:753
+msgid "Path to X509 CRL file"
+msgstr "Vojo al dosiero X509 CRL"
+
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
+msgid "Authentication"
+msgstr "Aŭtentikiĝo"
+
+#: vncviewer/OptionsDialog.cxx:802
+msgid "Standard VNC (insecure without encryption)"
+msgstr "Ordinara VNC (nesekura sen ĉifrado)"
+
+#: vncviewer/OptionsDialog.cxx:809
+msgid "Username and password (insecure without encryption)"
+msgstr "Uzantnomo kaj pasvorto (nesekura sen ĉifrado)"
+
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
+msgid "Input"
+msgstr "Enigo"
+
+#: vncviewer/OptionsDialog.cxx:852
+msgid "View only (ignore mouse and keyboard)"
+msgstr "Nur rigardi (preteratenti muson kaj klavaron)"
+
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
+msgid "Mouse"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:873
+msgid "Emulate middle mouse button"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:880
+msgid "Show local cursor when not provided by server"
+msgstr ""
+
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
+msgid "Cursor type"
+msgstr ""
+
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
+msgid "Dot"
+msgstr ""
+
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
+msgid "System"
+msgstr ""
+
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
+msgid "Keyboard"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:925
+msgid "Pass system keys directly to server (full screen)"
+msgstr "Pasi sistemajn klavojn rekte al la servilo (plenekrane)"
+
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
+msgid "Menu key"
+msgstr "Menu-klavo"
+
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
+msgid "Clipboard"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:968
+msgid "Accept clipboard from server"
+msgstr "Akcepti tondaĵon el la servilo"
+
+#: vncviewer/OptionsDialog.cxx:977
+msgid "Also set primary selection"
+msgstr "Difini ankaŭ la ĉefan elekton"
+
+#: vncviewer/OptionsDialog.cxx:985
+msgid "Send clipboard to server"
+msgstr "Sendi tondaĵon al la servilo"
+
+#: vncviewer/OptionsDialog.cxx:994
+msgid "Send primary selection as clipboard"
+msgstr "Sendi ĉefan elekton kiel tondajô"
+
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
+msgid "Display"
+msgstr ""
+
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
+msgid "Display mode"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1045
+msgid "Windowed"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1054
+msgid "Full screen on current monitor"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1063
+msgid "Full screen on all monitors"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1072
+msgid "Full screen on selected monitor(s)"
+msgstr ""
+
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
+msgid "Miscellaneous"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1111
+msgid "Shared (don't disconnect other viewers)"
+msgstr "Kunhave (ne malkonekti aliajn rigardilojn)"
+
+#: vncviewer/OptionsDialog.cxx:1118
+msgid "Ask to reconnect on connection errors"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:73
+msgid "VNC server:"
+msgstr "Servilo VNC:"
+
+#: vncviewer/ServerDialog.cxx:80
+msgid "Options..."
+msgstr "Modifiloj..."
+
+#: vncviewer/ServerDialog.cxx:84
+msgid "Load..."
+msgstr "Ŝargo..."
+
+#: vncviewer/ServerDialog.cxx:88
+msgid "Save as..."
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:102
+msgid "About..."
+msgstr "Pri..."
+
+#: vncviewer/ServerDialog.cxx:111
+msgid "Connect"
+msgstr "Konekti"
+
+#: vncviewer/ServerDialog.cxx:147
+#, c-format
+msgid ""
+"Unable to load the server history:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:176 vncviewer/ServerDialog.cxx:216
+msgid "TigerVNC configuration (*.tigervnc)"
+msgstr "Agordo de TigerVNC (*.tigervnc)"
+
+#: vncviewer/ServerDialog.cxx:177
+msgid "Select a TigerVNC configuration file"
+msgstr "Elekti agordo-dosieron de TigerVNC"
+
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
+#, c-format
+msgid ""
+"Unable to load the specified configuration file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:217
+msgid "Save the TigerVNC configuration to file"
+msgstr "Konservi la agordo-dosieron de TigerVNC"
+
+#: vncviewer/ServerDialog.cxx:243
+#, c-format
+msgid "%s already exists. Do you want to overwrite?"
+msgstr "%s jam ekzistas. Ĉu vi volas anstataŭigi?"
+
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
+msgid "No"
+msgstr "Ne"
+
+#: vncviewer/ServerDialog.cxx:244
+msgid "Overwrite"
+msgstr "Anstataŭigi"
+
+#: vncviewer/ServerDialog.cxx:260
+#, c-format
+msgid ""
+"Unable to save the specified configuration file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:294
+#, c-format
+msgid ""
+"Unable to save the default configuration:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:306
+#, c-format
+msgid ""
+"Unable to save the server history:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
+msgid "Could not determine VNC state directory path"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
+#, c-format
+msgid "Could not open \"%s\""
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
+#, c-format
+msgid "Failed to read line %d in file \"%s\""
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
+msgid "Line too long"
+msgstr "Linio tro longas"
+
+#: vncviewer/UserDialog.cxx:130
+msgid "Opening password file failed"
+msgstr "Malfermo de pasvorta dosiero fiaskis"
+
+#: vncviewer/UserDialog.cxx:150
+msgid "VNC authentication"
+msgstr "Aŭtentikiĝo de VNC"
+
+#: vncviewer/UserDialog.cxx:157
+msgid "This connection is secure"
+msgstr "Tiu ĉi konekto estas sekura"
+
+#: vncviewer/UserDialog.cxx:161
+msgid "This connection is not secure"
+msgstr "Tiu ĉi konekto ne estas sekora"
+
+#: vncviewer/UserDialog.cxx:183
+msgid "Username:"
+msgstr "Uzantnomo:"
+
+#: vncviewer/UserDialog.cxx:196
+msgid "Password:"
+msgstr "Pasvorto:"
+
+#: vncviewer/UserDialog.cxx:204
+msgid "Keep password for reconnect"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:749
+msgctxt "ContextMenu|"
+msgid "Disconn&ect"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "&Plena ekrano"
 
-#: vncviewer/Viewport.cxx:1205
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "Mal&grandigi"
 
-#: vncviewer/Viewport.cxx:1207
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "Regrandigi &fenestron al seanco"
 
-#: vncviewer/Viewport.cxx:1212
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Stirklavo"
 
-#: vncviewer/Viewport.cxx:1215
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:1221
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "Sendi %s"
 
-#: vncviewer/Viewport.cxx:1227
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Sendi Ctrl-Alt-&Del"
 
-#: vncviewer/Viewport.cxx:1230
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "A&ktualigi ekranon"
 
-#: vncviewer/Viewport.cxx:1233
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&Modifiloj..."
 
-#: vncviewer/Viewport.cxx:1235
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "&Informo pri konekto..."
 
-#: vncviewer/Viewport.cxx:1237
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "Pri la rigardilo &TigerVNC..."
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:1240
-msgctxt "ContextMenu|"
-msgid "Dismiss &menu"
-msgstr "Forlasi la me&nuon"
-
-#: vncviewer/Viewport.cxx:1329
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "Konekta informo de VNC"
 
-#: vncviewer/parameters.cxx:278 vncviewer/parameters.cxx:312
-#, c-format
-msgid "The name of the parameter %s was too large to write to the registry"
-msgstr "La nomo de la parametro %s estis tro granda por skribi al la registrujo"
-
-#: vncviewer/parameters.cxx:284 vncviewer/parameters.cxx:291
-#, c-format
-msgid "The parameter %s was too large to write to the registry"
-msgstr "La parametro %s estis tro granda por skribi al la registrujo"
-
-#: vncviewer/parameters.cxx:297 vncviewer/parameters.cxx:318
-#, c-format
-msgid "Failed to write parameter %s of type %s to the registry: %ld"
-msgstr "Fiasko dum skribo de la parametro %s el tipo %s al la registrujo: %ld"
-
-#: vncviewer/parameters.cxx:334 vncviewer/parameters.cxx:377
-#, c-format
-msgid "The name of the parameter %s was too large to read from the registry"
-msgstr "La nomo de la parametro %s estis tro longa por legi el la registrujo"
-
-#: vncviewer/parameters.cxx:346 vncviewer/parameters.cxx:386
-#, c-format
-msgid "Failed to read parameter %s from the registry: %ld"
-msgstr "Fiasko dum lego de parametro %s el la registrujo: %ld"
-
-#: vncviewer/parameters.cxx:357
-#, c-format
-msgid "The parameter %s was too large to read from the registry"
-msgstr "La parametro %s estis tro longa por legi el la registrujo"
-
-#: vncviewer/parameters.cxx:406
-#, c-format
-msgid "Failed to create registry key: %ld"
-msgstr "Fiasko dum kreo de registruja ŝlosilo: %ld"
-
-#: vncviewer/parameters.cxx:420 vncviewer/parameters.cxx:469
-#: vncviewer/parameters.cxx:532 vncviewer/parameters.cxx:666
-#, c-format
-msgid "Unknown parameter type for parameter %s"
-msgstr "Nekonata parametra tipo por parametro %s"
-
-#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:476
-#, c-format
-msgid "Failed to close registry key: %ld"
-msgstr "Fiasko dum fermo de registruja ŝlosilo: %ld"
-
-#: vncviewer/parameters.cxx:443
-#, c-format
-msgid "Failed to open registry key: %ld"
-msgstr "Fiasko dum malfermo  de registruja ŝlosilo: %ld"
-
-#: vncviewer/parameters.cxx:500
-msgid "Failed to write configuration file, can't obtain home directory path."
-msgstr "Fiasko dum skribo de agorda dosiero, ne eblas preni la hejman dosierujan vojon."
-
-#: vncviewer/parameters.cxx:514
-#, c-format
-msgid "Failed to write configuration file, can't open %s: %s"
-msgstr "Fiasko dum skribo de la agorda dosiero, ne eblas malfermi %s: %s"
-
-#: vncviewer/parameters.cxx:559
-msgid "Failed to read configuration file, can't obtain home directory path."
-msgstr "Fiasko dum lego de agorda dosiero, ne eblas preni la hejman dosierujan vojon."
-
-#: vncviewer/parameters.cxx:573
-#, c-format
-msgid "Failed to read configuration file, can't open %s: %s"
-msgstr "Fiasko dum lego de agorda dosiero, ne eblas malfermi %s: %s"
-
-#: vncviewer/parameters.cxx:586 vncviewer/parameters.cxx:591
-#: vncviewer/parameters.cxx:616 vncviewer/parameters.cxx:629
-#: vncviewer/parameters.cxx:645
-#, c-format
-msgid "Failed to read line %d in file %s: %s"
-msgstr "Fiasko dum lego de linio %d en la dosiero %s: %s"
-
-#: vncviewer/parameters.cxx:592
-msgid "Line too long"
-msgstr "Linio tro longas"
-
-#: vncviewer/parameters.cxx:599
-#, c-format
-msgid "Configuration file %s is in an invalid format"
-msgstr "Agorda dosiero %s estas en nevalida formo"
-
-#: vncviewer/parameters.cxx:617
-msgid "Invalid format"
-msgstr "Nevalida formo"
-
-#: vncviewer/parameters.cxx:630 vncviewer/parameters.cxx:646
-msgid "Invalid format or too large value"
-msgstr "Nevalida formo aŭ tro granda valoro"
-
-#: vncviewer/parameters.cxx:673
-#, c-format
-msgid "Unknown parameter %s on line %d in file %s"
-msgstr "Nekonata parametro %s en linio %d en dosiero %s"
-
-#: vncviewer/vncviewer.cxx:100
-#, c-format
-msgid ""
-"TigerVNC Viewer %d-bit v%s\n"
-"Built on: %s\n"
-"Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
-"See https://www.tigervnc.org for information on TigerVNC."
+#: vncviewer/Win32TouchHandler.cxx:49
+msgid "Window is registered for touch instead of gestures"
 msgstr ""
-"Rigardilo TigerVNC %d-bit v%s\n"
-"Konstruita en: %s\n"
-"Kopirajto (C) 1999-%d teamo de TigerVNC kaj multaj aliaj (konsultu README.rst)\n"
-"Konsultu https://www.tigervnc.org por informoj pri TigerVNC."
 
-#: vncviewer/vncviewer.cxx:127
-msgid "About TigerVNC Viewer"
-msgstr "Pri la rigardilo TigerVNC"
-
-#: vncviewer/vncviewer.cxx:140
-msgid "Internal FLTK error. Exiting."
-msgstr "Interna eraro de FLTK. Ni ĉesas."
-
-#: vncviewer/vncviewer.cxx:158 vncviewer/vncviewer.cxx:170
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Eraro dum ekigo de nova Rigardilo TigerVNC: %s"
+msgid "Failed to set gesture configuration (error 0x%x)"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:179
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC Viewer will now exit."
-msgstr "Finiga signalo %d estis ricevata. La Rigardilo TigerVNC ĉesos nun."
+msgid "Failed to get gesture information (error 0x%x)"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:271 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC Viewer"
-msgstr "Rigardilo TigerVNC"
-
-#: vncviewer/vncviewer.cxx:280
-msgid "Yes"
-msgstr "Jes"
-
-#: vncviewer/vncviewer.cxx:283
-msgid "Close"
-msgstr "Fermi"
-
-#: vncviewer/vncviewer.cxx:288
-msgid "About"
-msgstr "Pri"
-
-#: vncviewer/vncviewer.cxx:291
-msgid "Hide"
-msgstr "Kaŝi"
-
-#: vncviewer/vncviewer.cxx:294
-msgid "Quit"
-msgstr "Eliri"
-
-#: vncviewer/vncviewer.cxx:298
-msgid "Services"
-msgstr "Servoj"
-
-#: vncviewer/vncviewer.cxx:299
-msgid "Hide Others"
-msgstr "Kaŝi aliajn"
-
-#: vncviewer/vncviewer.cxx:300
-msgid "Show All"
-msgstr "Montri ĉiujn"
-
-#: vncviewer/vncviewer.cxx:309
-msgctxt "SysMenu|"
-msgid "&File"
-msgstr "&Dosiero"
-
-#: vncviewer/vncviewer.cxx:312
-msgctxt "SysMenu|File|"
-msgid "&New Connection"
-msgstr "&Nova konekto"
-
-#: vncviewer/vncviewer.cxx:324
-msgid "Could not create VNC home directory: can't obtain home directory path."
-msgstr "Ne eblis krei hejman dosierujon de VNC: ne eblas havi tiun vojon."
-
-#: vncviewer/vncviewer.cxx:329
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
-msgid "Could not create VNC home directory: %s."
-msgstr "Ne eblis krei hejman dosierujon de VNC: %s."
+msgid "Invalid mouse button %d, must be a number between 1 and 7."
+msgstr ""
 
-#. TRANSLATORS: "Parameters" are command line arguments, or settings
-#. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:602 vncviewer/vncviewer.cxx:604
-msgid "Parameters -listen and -via are incompatible"
-msgstr "Parametroj -listen kaj -via estas malkongruaj"
-
-#: vncviewer/vncviewer.cxx:619
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
-msgid "Listening on port %d"
-msgstr "Ni aŭskultas pordon %d"
+msgid "Unhandled key 0x%x - can't generate keyboard event."
+msgstr ""
 
-#: vncviewer/vncviewer.desktop.in.in:4
-msgid "Remote Desktop Viewer"
-msgstr "Defora Labortabla Rigardilo"
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
+#, c-format
+msgid "Unable to get X Input 2 event mask for window 0x%08lx"
+msgstr ""
 
+#: vncviewer/XInputTouchHandler.cxx:105
+#, c-format
+msgid "Window 0x%08lx has no X Input 2 event mask"
+msgstr ""
+
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
+#, c-format
+msgid "Window 0x%08lx has more than one X Input 2 event mask"
+msgstr ""
+
+#: vncviewer/XInputTouchHandler.cxx:144
+#, c-format
+msgid "Failure grabbing device %i"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
 msgid "Connect to VNC server and display remote desktop"
 msgstr "Konekti al servilo VNC kaj montrigi deforan labortablon"
 
-#: vncviewer/vncviewer.desktop.in.in:7
-msgid "tigervnc"
-msgstr "tigervnc"
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
+
+#. developer_name tag deprecated with Appstream 1.0
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
+msgid "The TigerVNC team"
+msgstr ""
+
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
+msgid "The name of the parameter is too large"
+msgstr ""
+
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
+msgid "The parameter is too large"
+msgstr ""
+
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
+msgid "Invalid format or too large value"
+msgstr "Nevalida formo aŭ tro granda valoro"
+
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
+msgid "Failed to create registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
+msgid "Failed to close registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
+#, c-format
+msgid "Failed to save \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
+#, c-format
+msgid "Failed to remove \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
+msgid "Failed to open registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:635
+#, c-format
+msgid "Failed to read server history entry %d: %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
+#, c-format
+msgid "Failed to read parameter \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
+msgid "Could not determine VNC config directory path"
+msgstr ""
+
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
+msgid "Could not encode parameter"
+msgstr ""
+
+#: vncviewer/parameters.cxx:872
+#, c-format
+msgid "Configuration file %s is in an invalid format"
+msgstr "Agorda dosiero %s estas en nevalida formo"
+
+#: vncviewer/parameters.cxx:895
+msgid "Invalid format"
+msgstr "Nevalida formo"
+
+#: vncviewer/parameters.cxx:939
+msgid "Unknown parameter"
+msgstr ""
+
+#: vncviewer/touch.cxx:75
+#, c-format
+msgid "Got message (0x%x) for an unhandled window"
+msgstr ""
+
+#: vncviewer/touch.cxx:138 vncviewer/touch.cxx:160
+#, c-format
+msgid "Invalid window 0x%08lx specified for pointer grab"
+msgstr ""
+
+#: vncviewer/touch.cxx:183 vncviewer/touch.cxx:184
+#, c-format
+msgid "Failed to create touch handler: %s"
+msgstr ""
+
+#: vncviewer/touch.cxx:188
+#, c-format
+msgid "Couldn't attach event handler to window (error 0x%x)"
+msgstr ""
+
+#: vncviewer/touch.cxx:215
+msgid "Failed to get event data for X Input event"
+msgstr ""
+
+#: vncviewer/touch.cxx:228
+msgid "X Input event for unknown window"
+msgstr ""
+
+#: vncviewer/touch.cxx:254
+msgid "X Input extension not available."
+msgstr ""
+
+#: vncviewer/touch.cxx:261
+msgid "X Input 2 (or newer) is not available."
+msgstr ""
+
+#: vncviewer/touch.cxx:266
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:103
+#, c-format
+msgid ""
+"TigerVNC v%s\n"
+"Built on: %s\n"
+"Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+"See https://www.tigervnc.org for information on TigerVNC."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:157
+#, c-format
+msgid ""
+"An unexpected error occurred when communicating with the server:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:194
+msgid "Internal FLTK error. Exiting."
+msgstr "Interna eraro de FLTK. Ni ĉesas."
+
+#: vncviewer/vncviewer.cxx:213
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"Attempt to reconnect?"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
+#, c-format
+msgid "Error starting new connection: %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:265
+#, c-format
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:394
+msgid "Yes"
+msgstr "Jes"
+
+#: vncviewer/vncviewer.cxx:397
+msgid "Close"
+msgstr "Fermi"
+
+#: vncviewer/vncviewer.cxx:402
+msgid "About"
+msgstr "Pri"
+
+#: vncviewer/vncviewer.cxx:405
+msgid "Hide"
+msgstr "Kaŝi"
+
+#: vncviewer/vncviewer.cxx:408
+msgid "Quit"
+msgstr "Eliri"
+
+#: vncviewer/vncviewer.cxx:412
+msgid "Services"
+msgstr "Servoj"
+
+#: vncviewer/vncviewer.cxx:413
+msgid "Hide others"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:414
+msgid "Show all"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:423
+msgctxt "SysMenu|"
+msgid "&File"
+msgstr "&Dosiero"
+
+#: vncviewer/vncviewer.cxx:426
+msgctxt "SysMenu|File|"
+msgid "&New Connection"
+msgstr "&Nova konekto"
+
+#: vncviewer/vncviewer.cxx:449
+#, c-format
+msgid ""
+"\n"
+"Usage: %s [parameters] [host][:displayNum]\n"
+"       %s [parameters] [host][::port]\n"
+"       %s [parameters] [unix socket]\n"
+"       %s [parameters] -listen [port]\n"
+"       %s [parameters] [.tigervnc file]\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:464
+#, c-format
+msgid ""
+"\n"
+"Options:\n"
+"\n"
+"  -display Xdisplay  - Specifies the X display for the viewer window\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
+"                       man page for details.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:471
+#, c-format
+msgid ""
+"\n"
+"Parameters can be turned on with -<param> or off with -<param>=0\n"
+"Parameters which take a value can be specified as -<param> <value>\n"
+"Other valid forms are <param>=<value> -<param>=<value> --<param>=<value>\n"
+"Parameter names are case-insensitive.  The parameters are:\n"
+"\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:556
+#, c-format
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:561
+#, c-format
+msgid "Could not create VNC config directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:567
+msgid "Could not determine VNC data directory path"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:573
+#, c-format
+msgid "Could not create VNC data directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:585
+#, c-format
+msgid "Could not create VNC state directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:704
+#, c-format
+msgid "%s: Unrecognized option '%s'\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
+#, c-format
+msgid "See '%s --help' for more information.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:713
+#, c-format
+msgid "%s: Extra argument '%s'\n"
+msgstr ""
+
+#. TRANSLATORS: "Parameters" are command line arguments, or settings
+#. from a file or the Windows registry.
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
+msgid "Parameters -listen and -via are incompatible"
+msgstr "Parametroj -listen kaj -via estas malkongruaj"
+
+#: vncviewer/vncviewer.cxx:764
+msgid "Unable to listen for incoming connections"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:766
+#, c-format
+msgid "Listening on port %d"
+msgstr "Ni aŭskultas pordon %d"
+
+#: vncviewer/vncviewer.cxx:795
+#, c-format
+msgid ""
+"Failure waiting for incoming VNC connection:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:816
+#, c-format
+msgid ""
+"Failure setting up encrypted tunnel:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.desktop.in.in:4
+msgid "Remote desktop viewer"
+msgstr ""
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(servila implicito %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "SetDesktopSize fiaskis: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "Malvalida SetColourMapEntries el servilo!"
+
+#~ msgid "Adjusting window size to avoid accidental full screen request"
+#~ msgstr "Alĝustigo de fenestra grando por eviti akcidentan plenekranan peton"
+
+#~ msgid "Failure grabbing mouse"
+#~ msgstr "Fiasko dum elpreno de muso"
+
+#~ msgid "VNC Viewer: Connection Options"
+#~ msgstr "Rigardilo VNC: konektaj preferoj"
+
+#~ msgid "Full (all available colors)"
+#~ msgstr "Kompleta (ĉiuj disponeblaj koloroj)"
+
+#~ msgid "Medium (256 colors)"
+#~ msgstr "Meze (256 koloroj)"
+
+#~ msgid "Low (64 colors)"
+#~ msgstr "Malalte (64 koloroj)"
+
+#~ msgid "Very low (8 colors)"
+#~ msgstr "Tre malalta (8 koloroj)"
+
+#~ msgid "level (1=fast, 6=best [4-6 are rarely useful])"
+#~ msgstr "nivelo (1=rapida, 6=plejbona [4-6 rare utilas])"
+
+#~ msgid "Screen"
+#~ msgstr "Ekrano"
+
+#~ msgid "Resize remote session on connect"
+#~ msgstr "Regrandigi foran seancon dum konekto"
+
+#~ msgid "Resize remote session to the local window"
+#~ msgstr "Regrandigi foran seancon al la loka fenestro"
+
+#~ msgid "Full-screen mode"
+#~ msgstr "Plenekrana reĝimo"
+
+#~ msgid "Enable full-screen mode over all monitors"
+#~ msgstr "Ebligi plenekranan reĝimon en ĉiuj ekranoj"
+
+#~ msgid "Misc."
+#~ msgstr "Divers."
+
+#~ msgid "Show dot when no cursor"
+#~ msgstr "Montri punkton kiam sen kursoro"
+
+#~ msgid "VNC Viewer: Connection Details"
+#~ msgstr "Rigardilo VNC: konektaj detaloj"
+
+#~ msgid "Save As..."
+#~ msgstr "Konservi kiel..."
+
+#~ msgid "Authentication cancelled"
+#~ msgstr "Aŭtentikiĝo estas nuligita"
+
+#, c-format
+#~ msgid "Failed to update keyboard LED state: %d"
+#~ msgstr "Fiasko dum ĝisdatigo de stato de klavaro-LED: %d"
+
+#~ msgid "No key code specified on key press"
+#~ msgstr "Neniu klavkodo estis specifica por klav-aktivigo"
+
+#, c-format
+#~ msgid "No symbol for key code 0x%02x (in the current state)"
+#~ msgstr "Neniu simbolo por klavkodo 0x%02x (en la nuna stato)"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "E&xit viewer"
+#~ msgstr "E&liri la rigardilon"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "Pri la rigardilo &TigerVNC..."
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "Dismiss &menu"
+#~ msgstr "Forlasi la me&nuon"
+
+#, c-format
+#~ msgid "The name of the parameter %s was too large to write to the registry"
+#~ msgstr ""
+#~ "La nomo de la parametro %s estis tro granda por skribi al la registrujo"
+
+#, c-format
+#~ msgid "The parameter %s was too large to write to the registry"
+#~ msgstr "La parametro %s estis tro granda por skribi al la registrujo"
+
+#, c-format
+#~ msgid "Failed to write parameter %s of type %s to the registry: %ld"
+#~ msgstr ""
+#~ "Fiasko dum skribo de la parametro %s el tipo %s al la registrujo: %ld"
+
+#, c-format
+#~ msgid "The name of the parameter %s was too large to read from the registry"
+#~ msgstr ""
+#~ "La nomo de la parametro %s estis tro longa por legi el la registrujo"
+
+#, c-format
+#~ msgid "Failed to read parameter %s from the registry: %ld"
+#~ msgstr "Fiasko dum lego de parametro %s el la registrujo: %ld"
+
+#, c-format
+#~ msgid "The parameter %s was too large to read from the registry"
+#~ msgstr "La parametro %s estis tro longa por legi el la registrujo"
+
+#, c-format
+#~ msgid "Failed to create registry key: %ld"
+#~ msgstr "Fiasko dum kreo de registruja ŝlosilo: %ld"
+
+#, c-format
+#~ msgid "Unknown parameter type for parameter %s"
+#~ msgstr "Nekonata parametra tipo por parametro %s"
+
+#, c-format
+#~ msgid "Failed to close registry key: %ld"
+#~ msgstr "Fiasko dum fermo de registruja ŝlosilo: %ld"
+
+#, c-format
+#~ msgid "Failed to open registry key: %ld"
+#~ msgstr "Fiasko dum malfermo  de registruja ŝlosilo: %ld"
+
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Fiasko dum skribo de agorda dosiero, ne eblas preni la hejman dosierujan "
+#~ "vojon."
+
+#, c-format
+#~ msgid "Failed to write configuration file, can't open %s: %s"
+#~ msgstr "Fiasko dum skribo de la agorda dosiero, ne eblas malfermi %s: %s"
+
+#~ msgid "Failed to read configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Fiasko dum lego de agorda dosiero, ne eblas preni la hejman dosierujan "
+#~ "vojon."
+
+#, c-format
+#~ msgid "Failed to read configuration file, can't open %s: %s"
+#~ msgstr "Fiasko dum lego de agorda dosiero, ne eblas malfermi %s: %s"
+
+#, c-format
+#~ msgid "Failed to read line %d in file %s: %s"
+#~ msgstr "Fiasko dum lego de linio %d en la dosiero %s: %s"
+
+#, c-format
+#~ msgid "Unknown parameter %s on line %d in file %s"
+#~ msgstr "Nekonata parametro %s en linio %d en dosiero %s"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC Viewer %d-bit v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "Rigardilo TigerVNC %d-bit v%s\n"
+#~ "Konstruita en: %s\n"
+#~ "Kopirajto (C) 1999-%d teamo de TigerVNC kaj multaj aliaj (konsultu README."
+#~ "rst)\n"
+#~ "Konsultu https://www.tigervnc.org por informoj pri TigerVNC."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "Pri la rigardilo TigerVNC"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Eraro dum ekigo de nova Rigardilo TigerVNC: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC Viewer will now exit."
+#~ msgstr "Finiga signalo %d estis ricevata. La Rigardilo TigerVNC ĉesos nun."
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "Rigardilo TigerVNC"
+
+#~ msgid "Hide Others"
+#~ msgstr "Kaŝi aliajn"
+
+#~ msgid "Show All"
+#~ msgstr "Montri ĉiujn"
+
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
+#~ msgstr "Ne eblis krei hejman dosierujon de VNC: ne eblas havi tiun vojon."
+
+#, c-format
+#~ msgid "Could not create VNC home directory: %s."
+#~ msgstr "Ne eblis krei hejman dosierujon de VNC: %s."
+
+#~ msgid "Remote Desktop Viewer"
+#~ msgstr "Defora Labortabla Rigardilo"
+
+#~ msgid "tigervnc"
+#~ msgstr "tigervnc"
 
 #~ msgid "Enabling continuous updates"
 #~ msgstr "Ebligo de daŭrigaj ĝisdatigoj"
@@ -779,32 +1318,68 @@ msgstr "tigervnc"
 #~ msgid "CleanupSignalHandler called"
 #~ msgstr "CleanupSignalHandler estas vokita"
 
-#~ msgid "Could not convert the parameter-name %s to wchar_t* when reading from the Registry, the buffersize is to small."
-#~ msgstr "Ne eblis konverti la parametro-nomo %s al wchar_t* dum lego el la Registrujo, la bufrogrando tro malgrandas."
+#~ msgid ""
+#~ "Could not convert the parameter-name %s to wchar_t* when reading from the "
+#~ "Registry, the buffersize is to small."
+#~ msgstr ""
+#~ "Ne eblis konverti la parametro-nomo %s al wchar_t* dum lego el la "
+#~ "Registrujo, la bufrogrando tro malgrandas."
 
-#~ msgid "Could not convert the parameter-name %s to wchar_t* when writing to the Registry, the buffersize is to small."
-#~ msgstr "Ne eblis konverti la parametro-nomo %s al wchar_t* dum skribo al la Registrujo, la bufrogrando tro malgrandas."
+#~ msgid ""
+#~ "Could not convert the parameter-name %s to wchar_t* when writing to the "
+#~ "Registry, the buffersize is to small."
+#~ msgstr ""
+#~ "Ne eblis konverti la parametro-nomo %s al wchar_t* dum skribo al la "
+#~ "Registrujo, la bufrogrando tro malgrandas."
 
-#~ msgid "Could not convert the parameter-value %s to wchar_t* when writing to the Registry, the buffersize is to small."
-#~ msgstr "Ne eblis konverti la parametro-valoro %s al wchar_t* dum skribo al la Registrujo, la bufrogrando tro malgrandas."
+#~ msgid ""
+#~ "Could not convert the parameter-value %s to wchar_t* when writing to the "
+#~ "Registry, the buffersize is to small."
+#~ msgstr ""
+#~ "Ne eblis konverti la parametro-valoro %s al wchar_t* dum skribo al la "
+#~ "Registrujo, la bufrogrando tro malgrandas."
 
-#~ msgid "Could not convert the parameter-value for %s to utf8 char* when reading from the Registry, the buffer dest is to small."
-#~ msgstr "Ne eblis konverti la parametro-valoro %s al utf8 char* dum lego el la Registrujo, la bufra celo tro malgrandas."
+#~ msgid ""
+#~ "Could not convert the parameter-value for %s to utf8 char* when reading "
+#~ "from the Registry, the buffer dest is to small."
+#~ msgstr ""
+#~ "Ne eblis konverti la parametro-valoro %s al utf8 char* dum lego el la "
+#~ "Registrujo, la bufra celo tro malgrandas."
 
-#~ msgid "Could not read the line(%d) in the configuration file,the buffersize is to small."
-#~ msgstr "Ne eblis legi la linion(%d) en la agorda dosiero, la bufrogrando tro malgrandas."
+#~ msgid ""
+#~ "Could not read the line(%d) in the configuration file,the buffersize is "
+#~ "to small."
+#~ msgstr ""
+#~ "Ne eblis legi la linion(%d) en la agorda dosiero, la bufrogrando tro "
+#~ "malgrandas."
 
-#~ msgid "Decoding: The size of the buffer dest is to small, it needs to be 1 byte bigger."
-#~ msgstr "Dekodigo: la grando de la bufra celo tro etas, ĝi bezonas esti 1 bajto pli granda."
+#~ msgid ""
+#~ "Decoding: The size of the buffer dest is to small, it needs to be 1 byte "
+#~ "bigger."
+#~ msgstr ""
+#~ "Dekodigo: la grando de la bufra celo tro etas, ĝi bezonas esti 1 bajto "
+#~ "pli granda."
 
-#~ msgid "Encoding backslash: The size of the buffer dest is to small, it needs to be more than %d bytes bigger."
-#~ msgstr "Enkodigo de retroklino: la grando de la bufra celo tro etas, ĝi bezonas esti pli ol %d bajtoj pli granda."
+#~ msgid ""
+#~ "Encoding backslash: The size of the buffer dest is to small, it needs to "
+#~ "be more than %d bytes bigger."
+#~ msgstr ""
+#~ "Enkodigo de retroklino: la grando de la bufra celo tro etas, ĝi bezonas "
+#~ "esti pli ol %d bajtoj pli granda."
 
-#~ msgid "Encoding escape sequence: The size of the buffer dest is to small, it needs to be more than %d bytes bigger."
-#~ msgstr "Enkodigo de skapsekvo: la grando de la bufra celo tro etas, ĝi bezonas esti pli ol %d bajtoj pli granda."
+#~ msgid ""
+#~ "Encoding escape sequence: The size of the buffer dest is to small, it "
+#~ "needs to be more than %d bytes bigger."
+#~ msgstr ""
+#~ "Enkodigo de skapsekvo: la grando de la bufra celo tro etas, ĝi bezonas "
+#~ "esti pli ol %d bajtoj pli granda."
 
-#~ msgid "Encoding normal character: The size of the buffer dest is to small, it needs to be more than %d bytes bigger."
-#~ msgstr "Enkodigo de ordinara signo: la grando de la bufra celo tro etas, ĝi bezonas esti pli ol %d bajtoj pli granda."
+#~ msgid ""
+#~ "Encoding normal character: The size of the buffer dest is to small, it "
+#~ "needs to be more than %d bytes bigger."
+#~ msgstr ""
+#~ "Enkodigo de ordinara signo: la grando de la bufra celo tro etas, ĝi "
+#~ "bezonas esti pli ol %d bajtoj pli granda."
 
 #~ msgid "Error(%d) closing key:  Software\\TigerVNC\\vncviewer"
 #~ msgstr "Eraro(%d) dum fermo de ŝlosilo:  Software\\TigerVNC\\vncviewer"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.14.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2025-01-14 16:15+0100\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2025-01-21 10:33-0600\n"
 "Last-Translator: Cristian Othón Martínez Vera <cfuga@cfuga.mx>\n"
 "Language-Team: Spanish <es@tp.org.es>\n"
@@ -18,17 +18,17 @@ msgstr ""
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: vncviewer/CConn.cxx:102
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "Conectado al zócalo %s"
 
-#: vncviewer/CConn.cxx:109
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "Conectado al anfitrión %s puerto %d"
 
-#: vncviewer/CConn.cxx:114
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -39,66 +39,65 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:151
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Nombre del escritorio: %.80s"
 
-#: vncviewer/CConn.cxx:154
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Anfitrión: %.80s puerto: %d"
 
-#: vncviewer/CConn.cxx:158
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Tamaño: %d x %d"
 
-#: vncviewer/CConn.cxx:165
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Formato de pixel: %s"
 
-#: vncviewer/CConn.cxx:170
-#, c-format
-msgid "(server default %s)"
-msgstr "(servidor pred. %s)"
-
-#: vncviewer/CConn.cxx:173
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Codificación solicitada: %s"
 
-#: vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Última codificación empleada: %s"
 
-#: vncviewer/CConn.cxx:181
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Velocidad de línea estimada: %d kbit/s"
 
-#: vncviewer/CConn.cxx:185
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Versión de protocolo: %d.%d"
 
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Método de seguridad: %s"
 
-#: vncviewer/CConn.cxx:250 vncviewer/CConn.cxx:252
-msgid "The connection was dropped by the server before the session could be established."
-msgstr "La conexión fue rechazada por el servidor antes de que la sesión se pudiera establecer."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
+msgstr ""
+"La conexión fue rechazada por el servidor antes de que la sesión se pudiera "
+"establecer."
 
-#: vncviewer/CConn.cxx:262
+#: vncviewer/CConn.cxx:258
 #, c-format
 msgid "Authentication failed: %s"
 msgstr "Falló la autenticación: %s"
 
-#: vncviewer/CConn.cxx:263
+#: vncviewer/CConn.cxx:259
 #, c-format
 msgid ""
 "Failed to authenticate with the server. Reason given by the server:\n"
@@ -109,31 +108,22 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:335
-#, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "Error en SetDesktopSize: %d"
-
-#: vncviewer/CConn.cxx:408
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "¡SetColourMapEntries inválida del servidor!"
-
-#: vncviewer/CConn.cxx:516
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Procesamiento %d kbit/s - cambiado a calidad %d"
 
-#: vncviewer/CConn.cxx:538
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "Procesamiento %d kbit/s - se activa el color total"
 
-#: vncviewer/CConn.cxx:541
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "Procesamiento %d kbit/s - se desactiva el color total"
 
-#: vncviewer/CConn.cxx:567
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Utilizando formato de pixel %s"
@@ -146,136 +136,128 @@ msgstr "¡Se especificó una geometría inválida!"
 msgid "Reducing window size to fit on current monitor"
 msgstr "Se reduce el tamaño de ventana para ajustar al monitor actual"
 
-#: vncviewer/DesktopWindow.cxx:646
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
-msgstr "Se ajusta el tamaño de ventana para evitar peticiones accidentales de pantalla completa"
+msgstr ""
+"Se ajusta el tamaño de ventana para evitar peticiones accidentales de "
+"pantalla completa"
 
-#: vncviewer/DesktopWindow.cxx:694
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Pulse %s para abrir el menú contextual"
 
-#: vncviewer/DesktopWindow.cxx:1094 vncviewer/DesktopWindow.cxx:1102
-#: vncviewer/DesktopWindow.cxx:1122
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Error al coger el teclado"
 
-#: vncviewer/DesktopWindow.cxx:1411
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
-msgstr "¡Disposición de pantalla computada inválida para petición de redimensionado!"
+msgstr ""
+"¡Disposición de pantalla computada inválida para petición de redimensionado!"
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "Estado inválido para la emulación de 3 botones"
 
-#: vncviewer/KeyboardWin32.cxx:242
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "No hay un código de rastreo para la tecla virtual extendida 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:244
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "No hay un código de rastreo para la tecla virtual 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:250
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "Código de rastreo 0x%02x inválido"
 
-#: vncviewer/KeyboardWin32.cxx:262
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "No hay un símbolo para la tecla virtual extendida 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:264
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "No hay un símbolo para la tecla virtual 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:423
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
 msgid "Failed to update keyboard LED state: %lu"
 msgstr "Falló al actualizar el estado de LED del teclado: %lu"
 
-#: vncviewer/KeyboardX11.cxx:104
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "No hay un símbolo para el código de tecla %d (en el estado actual)"
 
-#: vncviewer/KeyboardX11.cxx:129
+#: vncviewer/KeyboardX11.cxx:148
 #, c-format
 msgid "Failed to get keyboard LED state: %d"
 msgstr "Falló al obtener el estado de LED del teclado: %d"
 
-#: vncviewer/KeyboardX11.cxx:174
+#: vncviewer/KeyboardX11.cxx:193
 msgid "Failed to update keyboard LED state"
 msgstr "Falló al actualizar el estado de LED del teclado"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:100
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "Falló al obtener la configuración del monitor del sistema"
 
-#: vncviewer/MonitorIndicesParameter.cxx:79
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "Se especificó una configuración inválida para %s"
-
-#: vncviewer/MonitorIndicesParameter.cxx:86
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "El índice de monitor %d no existe"
 
-#: vncviewer/MonitorIndicesParameter.cxx:162
-#: vncviewer/MonitorIndicesParameter.cxx:182
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "Índice de monitor '%s' inválido"
-
-#: vncviewer/MonitorIndicesParameter.cxx:170
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "Carácter '%c' inesperado"
-
-#: vncviewer/OptionsDialog.cxx:64
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
 msgid "TigerVNC options"
 msgstr "Opciones de TigerVNC"
 
-#: vncviewer/OptionsDialog.cxx:97 vncviewer/ServerDialog.cxx:107
-#: vncviewer/vncviewer.cxx:397
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: vncviewer/OptionsDialog.cxx:102 vncviewer/vncviewer.cxx:396
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "Aceptar"
 
-#: vncviewer/OptionsDialog.cxx:514
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "Compresión"
 
-#: vncviewer/OptionsDialog.cxx:530
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "Autoseleccionar"
 
-#: vncviewer/OptionsDialog.cxx:541
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "Codificación preferida"
 
-#: vncviewer/OptionsDialog.cxx:602
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "Nivel de color"
 
-#: vncviewer/OptionsDialog.cxx:614
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "Total"
 
-#: vncviewer/OptionsDialog.cxx:621
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "Medio"
 
-#: vncviewer/OptionsDialog.cxx:628
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "Bajo"
 
@@ -283,166 +265,178 @@ msgstr "Bajo"
 msgid "Very low"
 msgstr "Muy bajo"
 
-#: vncviewer/OptionsDialog.cxx:657
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "Nivel de compresión personal:"
 
-#: vncviewer/OptionsDialog.cxx:664
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "calidad (0=rápido, 9=mejor)"
 
-#: vncviewer/OptionsDialog.cxx:671
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "Permitir compresión JPEG:"
 
-#: vncviewer/OptionsDialog.cxx:678
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "calidad (0=peor, 9=mejor)"
 
-#: vncviewer/OptionsDialog.cxx:689
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "Seguridad"
 
-#: vncviewer/OptionsDialog.cxx:703
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "Cifrado"
 
-#: vncviewer/OptionsDialog.cxx:715 vncviewer/OptionsDialog.cxx:782
-#: vncviewer/OptionsDialog.cxx:905
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "Ninguno"
 
-#: vncviewer/OptionsDialog.cxx:722
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "TLS con certificados anónimos"
 
-#: vncviewer/OptionsDialog.cxx:728
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "TLS con certificados X509"
 
-#: vncviewer/OptionsDialog.cxx:735
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "Ruta a AC de certificado X509"
 
-#: vncviewer/OptionsDialog.cxx:742
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "Ruta a fichero CRL de X509"
 
-#: vncviewer/OptionsDialog.cxx:770
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "Autenticación"
 
-#: vncviewer/OptionsDialog.cxx:788
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "VNC común (inseguro sin cifrado)"
 
-#: vncviewer/OptionsDialog.cxx:794
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "Usuario y contraseña (inseguro sin cifrado)"
 
-#: vncviewer/OptionsDialog.cxx:822
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "Entrada"
 
-#: vncviewer/OptionsDialog.cxx:835
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "Ver solo (ignora ratón y teclado)"
 
-#: vncviewer/OptionsDialog.cxx:842
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "Ratón"
 
-#: vncviewer/OptionsDialog.cxx:854
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "Emula el botón medio del ratón"
 
-#: vncviewer/OptionsDialog.cxx:860
+#: vncviewer/OptionsDialog.cxx:880
 msgid "Show local cursor when not provided by server"
 msgstr "Muestra el cursor local cuando el servidor no lo proporciona"
 
-#: vncviewer/OptionsDialog.cxx:865
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
 msgid "Cursor type"
 msgstr "Tipo de cursor"
 
-#: vncviewer/OptionsDialog.cxx:867
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
 msgid "Dot"
 msgstr "Punto"
 
-#: vncviewer/OptionsDialog.cxx:868
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
 msgid "System"
 msgstr "Sistema"
 
-#: vncviewer/OptionsDialog.cxx:888
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "Teclado"
 
-#: vncviewer/OptionsDialog.cxx:900
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
-msgstr "Pasa las teclas del sistema directamente al servidor (pantalla completa)"
+msgstr ""
+"Pasa las teclas del sistema directamente al servidor (pantalla completa)"
 
-#: vncviewer/OptionsDialog.cxx:903
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "Tecla Menú"
 
-#: vncviewer/OptionsDialog.cxx:926
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "Portapapeles"
 
-#: vncviewer/OptionsDialog.cxx:938
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "Acepta texto desde el portapapeles"
 
-#: vncviewer/OptionsDialog.cxx:946
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "Además establece selección primaria"
 
-#: vncviewer/OptionsDialog.cxx:953
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "Envía portapapel al servidor"
 
-#: vncviewer/OptionsDialog.cxx:961
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "Envía selección primaria como portapapeles"
 
-#: vncviewer/OptionsDialog.cxx:982
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "Despliegue"
 
-#: vncviewer/OptionsDialog.cxx:996
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "Modo de despliegue"
 
-#: vncviewer/OptionsDialog.cxx:1009
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "Ventana"
 
-#: vncviewer/OptionsDialog.cxx:1017
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "Pantalla completa en el monitor actual"
 
-#: vncviewer/OptionsDialog.cxx:1025
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "Pantalla completa en todos los monitores"
 
-#: vncviewer/OptionsDialog.cxx:1033
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "Pantalla completa en el(los) monitor(es) seleccionado(s)"
 
-#: vncviewer/OptionsDialog.cxx:1062
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
 msgid "Miscellaneous"
 msgstr "Misceláneos"
 
-#: vncviewer/OptionsDialog.cxx:1070
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "Compartido (no desconecta otras visores)"
 
-#: vncviewer/OptionsDialog.cxx:1076
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "Pregunta para reconectar después de errores de conexión"
-
-#: vncviewer/ServerDialog.cxx:63
-msgid "VNC viewer: Connection details"
-msgstr "Visor VNC: Datos de conexión"
 
 #: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
@@ -487,7 +481,7 @@ msgstr "Configuración de TigerVNC (*.tigervnc)"
 msgid "Select a TigerVNC configuration file"
 msgstr "Selecciona un fichero de configuración TigerVNC"
 
-#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:517
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -507,7 +501,7 @@ msgstr "Guarda la configuración de TigerVNC en el fichero"
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "%s ya existe. ¿Lo quiere sobreescribir?"
 
-#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:394
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "No"
 
@@ -547,169 +541,171 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:351 vncviewer/ServerDialog.cxx:429
-#: vncviewer/vncviewer.cxx:580
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
 msgid "Could not determine VNC state directory path"
 msgstr "No se puede obtener la ruta del directorio de estado de VNC"
 
-#: vncviewer/ServerDialog.cxx:363 vncviewer/ServerDialog.cxx:437
-#: vncviewer/parameters.cxx:671 vncviewer/parameters.cxx:752
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
 msgid "Could not open \"%s\""
 msgstr "No se puede abrir \"%s\""
 
-#: vncviewer/ServerDialog.cxx:378 vncviewer/ServerDialog.cxx:387
-#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:773
-#: vncviewer/parameters.cxx:807 vncviewer/parameters.cxx:837
-#: vncviewer/parameters.cxx:844
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
 msgid "Failed to read line %d in file \"%s\""
 msgstr "Falló al leer la línea %d en el fichero \"%s\""
 
-#: vncviewer/ServerDialog.cxx:390 vncviewer/parameters.cxx:776
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "Línea demasiado larga"
 
-#: vncviewer/UserDialog.cxx:123
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "Falló al abrir el fichero de contraseña"
 
-#: vncviewer/UserDialog.cxx:143
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "Autenticación VNC"
 
-#: vncviewer/UserDialog.cxx:150
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "Esta conexión es segura"
 
-#: vncviewer/UserDialog.cxx:154
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "Esta conexión no es segura"
 
-#: vncviewer/UserDialog.cxx:176
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "Usuario:"
 
-#: vncviewer/UserDialog.cxx:189
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "Contraseña:"
 
-#: vncviewer/UserDialog.cxx:197
+#: vncviewer/UserDialog.cxx:204
 msgid "Keep password for reconnect"
 msgstr "Conserva la contraseña para reconexión"
 
-#: vncviewer/Viewport.cxx:695
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
 msgid "Disconn&ect"
 msgstr "Des&conectar"
 
-#: vncviewer/Viewport.cxx:698
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "&Pantalla completa"
 
-#: vncviewer/Viewport.cxx:701
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "Minimi&zar"
 
-#: vncviewer/Viewport.cxx:703
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "Redimensionar &ventana a sesión"
 
-#: vncviewer/Viewport.cxx:708
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:711
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:717
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "Enviar %s"
 
-#: vncviewer/Viewport.cxx:724
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Enviar Ctrl+Alt+&Supr"
 
-#: vncviewer/Viewport.cxx:727
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "&Actualizar pantalla"
 
-#: vncviewer/Viewport.cxx:730
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&Opciones..."
 
-#: vncviewer/Viewport.cxx:732
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "&Info de conexión..."
 
-#: vncviewer/Viewport.cxx:734
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "Acerca del visor &TigerVNC..."
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:830
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "Info de conexión VNC"
 
-#: vncviewer/Win32TouchHandler.cxx:48
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "La ventana está registrada para toques en lugar de gestos"
 
-#: vncviewer/Win32TouchHandler.cxx:83
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "Falló al definir la configuración de gestos (error 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:95
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "Falló al obtener la información de gestos (error 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:360
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr "Botón de ratón %d inválido, debe ser un número entre 1 y 7."
 
-#: vncviewer/Win32TouchHandler.cxx:425
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
 msgstr "Tecla 0x%x sin manejar - no se puede generar un evento de teclado."
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:107
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
-msgstr "No se puede obtener la máscara de evento X Input 2 para la ventana 0x%08lx"
+msgstr ""
+"No se puede obtener la máscara de evento X Input 2 para la ventana 0x%08lx"
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr "La ventana 0x%08lx no tiene máscara de evento X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:114
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr "La ventana 0x%08lx tiene más de una máscara de evento X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "Error al coger el dispositivo %i"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-msgid "TigerVNC Viewer"
-msgstr "Visor TigerVNC"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -717,100 +713,129 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr "Conecta al servidor VNC y muestra el escritorio remoto"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
-msgstr "Cómputo de Red Virtual (VNC, por sus siglas en inglés) es un sistema de despliegue remoto que le permite ver e interactuar con un ambiente de escritorio virtual ejecutándose en otra computadora en la red. Al usar VNC, puede ejecutar aplicaciones gráficas en una máquina remota y enviar solamente el despliegue de esas aplicaciones a su dispositivo local. Este paquete contiene un cliente, el cual le permitirá conectarse a otros escritorios que estén ejecutando un servidor VNC. VNC es independiente de plataforma y admite varios sistemas operativos y arquitecturas como servidores así como clientes."
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+"Cómputo de Red Virtual (VNC, por sus siglas en inglés) es un sistema de "
+"despliegue remoto que le permite ver e interactuar con un ambiente de "
+"escritorio virtual ejecutándose en otra computadora en la red. Al usar VNC, "
+"puede ejecutar aplicaciones gráficas en una máquina remota y enviar "
+"solamente el despliegue de esas aplicaciones a su dispositivo local. Este "
+"paquete contiene un cliente, el cual le permitirá conectarse a otros "
+"escritorios que estén ejecutando un servidor VNC. VNC es independiente de "
+"plataforma y admite varios sistemas operativos y arquitecturas como "
+"servidores así como clientes."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
-msgstr "TigerVNC es una versión de alta velocidad de VNC basada en las bases de código de RealVNC 4 y X.org. TigerVNC empezó como un esfuerzo de desarrollo de próxima generación para TightVNC en plataformas Unix y Linux, pero se separó de su proyecto padre a inicios del 2009 para que TightVNC se enfocara en plataformas Windows. TigerVNC admite una variante de la codificación Tight que tiene una gran aceleración por el uso del codificador JPEG de libjpeg-turbo."
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+"TigerVNC es una versión de alta velocidad de VNC basada en las bases de "
+"código de RealVNC 4 y X.org. TigerVNC empezó como un esfuerzo de desarrollo "
+"de próxima generación para TightVNC en plataformas Unix y Linux, pero se "
+"separó de su proyecto padre a inicios del 2009 para que TightVNC se enfocara "
+"en plataformas Windows. TigerVNC admite una variante de la codificación "
+"Tight que tiene una gran aceleración por el uso del codificador JPEG de "
+"libjpeg-turbo."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC viewer connection to a CentOS machine"
-msgstr "Conexión de visor TigerVNC a una máquina CentOS"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC viewer connection to a macOS machine"
-msgstr "Conexión de visor TigerVNC a una máquina macOS"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC viewer connection to a Windows machine"
-msgstr "Conexión de visor TigerVNC a una máquina Windows"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
 #. developer_name tag deprecated with Appstream 1.0
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
-#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:48
 msgid "The TigerVNC team"
 msgstr "El equipo TigerVNC"
 
-#: vncviewer/parameters.cxx:319 vncviewer/parameters.cxx:344
-#: vncviewer/parameters.cxx:361 vncviewer/parameters.cxx:401
-#: vncviewer/parameters.cxx:421
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "El nombre del parámetro es demasiado grande"
 
-#: vncviewer/parameters.cxx:323 vncviewer/parameters.cxx:328
-#: vncviewer/parameters.cxx:379
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "El parámetro es demasiado grande"
 
-#: vncviewer/parameters.cxx:386 vncviewer/parameters.cxx:712
-#: vncviewer/parameters.cxx:822
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "Formato inválido o valor demansiado grande"
 
-#: vncviewer/parameters.cxx:440 vncviewer/parameters.cxx:473
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "Falló al crear la llave de registro"
 
-#: vncviewer/parameters.cxx:461 vncviewer/parameters.cxx:528
-#: vncviewer/parameters.cxx:571 vncviewer/parameters.cxx:638
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "Falló al cerrar la llave de registro"
 
-#: vncviewer/parameters.cxx:479 vncviewer/parameters.cxx:506
-#: vncviewer/parameters.cxx:680 vncviewer/parameters.cxx:692
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "Falló al guardar \"%s\": %s"
 
-#: vncviewer/parameters.cxx:489 vncviewer/parameters.cxx:520
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "Falló al borrar \"%s\": %s"
 
-#: vncviewer/parameters.cxx:544 vncviewer/parameters.cxx:616
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "Falló al abrir la llave de registro"
 
-#: vncviewer/parameters.cxx:561
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "Falló al leer la entrada de histora del servidor %d: %s"
 
-#: vncviewer/parameters.cxx:597 vncviewer/parameters.cxx:627
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "Falló al leer el parámetro \"%s\": %s"
 
-#: vncviewer/parameters.cxx:661 vncviewer/parameters.cxx:740
-#: vncviewer/vncviewer.cxx:546
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
 msgid "Could not determine VNC config directory path"
 msgstr "No se puede obtener la ruta del directorio de configuración de VNC"
 
-#: vncviewer/parameters.cxx:682 vncviewer/parameters.cxx:694
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "No se puede codificar el parámetro"
 
-#: vncviewer/parameters.cxx:785
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "El fichero de configuración %s tiene un formato inválido"
 
-#: vncviewer/parameters.cxx:809
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "Formato inválido"
 
-#: vncviewer/parameters.cxx:846
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "Parámetro desconocido"
 
@@ -851,23 +876,23 @@ msgid "X Input 2 (or newer) is not available."
 msgstr "X Input 2 (o más reciente) no está disponible."
 
 #: vncviewer/touch.cxx:266
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
-msgstr "X Input 2.2 (o más reciente) no está disponible. No se admitirán los gestos de toque."
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+"X Input 2.2 (o más reciente) no está disponible. No se admitirán los gestos "
+"de toque."
 
-#: vncviewer/vncviewer.cxx:104
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
 "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"Visor de TigerVNC v%s\n"
-"Compilado en: %s\n"
-"Copyright (C) 1999-%d Equipo TigerVNC y muchos otros (vea README.rst)\n"
-"Vea https://www.tigervnc.org para más información sobre TigerVNC."
 
-#: vncviewer/vncviewer.cxx:158
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -878,15 +903,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:174
-msgid "About TigerVNC Viewer"
-msgstr "Acerca del visor TigerVNC"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:195
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "Error interno en FLTK. Saliendo."
 
-#: vncviewer/vncviewer.cxx:214
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -897,63 +922,59 @@ msgstr ""
 "\n"
 "¿Se intenta la reconexión?"
 
-#: vncviewer/vncviewer.cxx:245 vncviewer/vncviewer.cxx:257
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Error al iniciar un nuevo visor TigerVNC: %s"
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:266
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC viewer will now exit."
-msgstr "Se recibió la señal de terminación %d. El visor TigerVNC terminará ahora."
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:391 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC viewer"
-msgstr "Visor TigerVNC"
-
-#: vncviewer/vncviewer.cxx:395
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "Sí"
 
-#: vncviewer/vncviewer.cxx:398
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "Cerrar"
 
-#: vncviewer/vncviewer.cxx:403
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "Acerca de"
 
-#: vncviewer/vncviewer.cxx:406
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "Ocultar"
 
-#: vncviewer/vncviewer.cxx:409
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "Salir"
 
-#: vncviewer/vncviewer.cxx:413
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "Servicios"
 
-#: vncviewer/vncviewer.cxx:414
+#: vncviewer/vncviewer.cxx:413
 msgid "Hide others"
 msgstr "Ocultar otros"
 
-#: vncviewer/vncviewer.cxx:415
+#: vncviewer/vncviewer.cxx:414
 msgid "Show all"
 msgstr "Mostrar todos"
 
-#: vncviewer/vncviewer.cxx:424
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "&Archivo"
 
-#: vncviewer/vncviewer.cxx:427
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "&Nueva conexión"
 
-#: vncviewer/vncviewer.cxx:450
+#: vncviewer/vncviewer.cxx:449
 #, c-format
 msgid ""
 "\n"
@@ -970,24 +991,19 @@ msgstr ""
 "     %s [parámetros] -listen [puerto]\n"
 "     %s [parámetros] [fichero .tigervnc]\n"
 
-#: vncviewer/vncviewer.cxx:465
+#: vncviewer/vncviewer.cxx:464
 #, c-format
 msgid ""
 "\n"
 "Options:\n"
 "\n"
 "  -display Xdisplay  - Specifies the X display for the viewer window\n"
-"  -geometry geometry - Initial position of the main VNC viewer window. See the\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
 "                       man page for details.\n"
 msgstr ""
-"\n"
-"Opciones:\n"
-"\n"
-"  -display Xdisplay   - Especifica el despliegue X para la ventana del visor\n"
-"  -geometry geometría - Posición inicial de la ventana principal del visor VNC\n"
-"                        Consulte la página del manual para más detalles.\n"
 
-#: vncviewer/vncviewer.cxx:472
+#: vncviewer/vncviewer.cxx:471
 #, c-format
 msgid ""
 "\n"
@@ -999,79 +1015,93 @@ msgid ""
 msgstr ""
 "\n"
 "Los parámetros se pueden activar con -<param> o desactivar con -<param>=0\n"
-"Los parámetros que admiten un valor se pueden especificar como -<param> <valor>\n"
+"Los parámetros que admiten un valor se pueden especificar como -<param> "
+"<valor>\n"
 "Otras formas válidas son <param>=<valor> -<param>=<valor> --<param>=<valor>\n"
 "Los nombres de parámetro no distinguen entre mayúsculas y minúsculas.\n"
 "Los parámetros son:\n"
 "\n"
 
-#: vncviewer/vncviewer.cxx:527
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
-msgstr "FullScreenAllMonitors es obsoleto, en su lugar defina FullScreenMode a 'all'"
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+"FullScreenAllMonitors es obsoleto, en su lugar defina FullScreenMode a 'all'"
 
-#: vncviewer/vncviewer.cxx:532
-msgid "DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' instead"
-msgstr "DotWhenNoCursor es obsoleto, en su lugar defina AlwaysCursor a 1 y CursorType a 'Dot'"
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+"DotWhenNoCursor es obsoleto, en su lugar defina AlwaysCursor a 1 y "
+"CursorType a 'Dot'"
 
-#: vncviewer/vncviewer.cxx:553
-msgid "~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
-msgstr "~/.vnc es obsoleto, por favor consulte 'man vncviewer' para conocer rutas de migración."
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+"~/.vnc es obsoleto, por favor consulte 'man vncviewer' para conocer rutas de "
+"migración."
 
-#: vncviewer/vncviewer.cxx:557
+#: vncviewer/vncviewer.cxx:556
 #, c-format
-msgid "%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC location."
-msgstr "%%APPDATA%%\\vnc es obsoleto, por favor cambie a la ubicación %%APPDATA%%\\TigerVNC."
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+"%%APPDATA%%\\vnc es obsoleto, por favor cambie a la ubicación %%APPDATA%%"
+"\\TigerVNC."
 
-#: vncviewer/vncviewer.cxx:562
+#: vncviewer/vncviewer.cxx:561
 #, c-format
 msgid "Could not create VNC config directory \"%s\": %s"
 msgstr "No se puede crear el directorio de inicio VNC \"%s\": %s"
 
-#: vncviewer/vncviewer.cxx:568
+#: vncviewer/vncviewer.cxx:567
 msgid "Could not determine VNC data directory path"
 msgstr "No se puede crear el directorio de datos VNC"
 
-#: vncviewer/vncviewer.cxx:574
+#: vncviewer/vncviewer.cxx:573
 #, c-format
 msgid "Could not create VNC data directory \"%s\": %s"
 msgstr "No se puede crear el directorio de datos VNC \"%s\": %s"
 
-#: vncviewer/vncviewer.cxx:586
+#: vncviewer/vncviewer.cxx:585
 #, c-format
 msgid "Could not create VNC state directory \"%s\": %s"
 msgstr "No se puede crear el directorio de estado VNC \"%s\": %s"
 
-#: vncviewer/vncviewer.cxx:703
+#: vncviewer/vncviewer.cxx:704
 #, c-format
 msgid "%s: Unrecognized option '%s'\n"
 msgstr "%s: No se reconoce la opción '%s'\n"
 
-#: vncviewer/vncviewer.cxx:705 vncviewer/vncviewer.cxx:713
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
 #, c-format
 msgid "See '%s --help' for more information.\n"
 msgstr "Vea '%s --help' para más información.\n"
 
-#: vncviewer/vncviewer.cxx:712
+#: vncviewer/vncviewer.cxx:713
 #, c-format
 msgid "%s: Extra argument '%s'\n"
 msgstr "%s: Argumento '%s' extra\n"
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:748 vncviewer/vncviewer.cxx:749
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "Los parámetros -listen y -via son incompatibles"
 
-#: vncviewer/vncviewer.cxx:763
+#: vncviewer/vncviewer.cxx:764
 msgid "Unable to listen for incoming connections"
 msgstr "No se pueden escuchar las conexiones entrantes"
 
-#: vncviewer/vncviewer.cxx:765
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "Escuchando en el puerto %d"
 
-#: vncviewer/vncviewer.cxx:794
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -1082,7 +1112,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:815
+#: vncviewer/vncviewer.cxx:816
 #, c-format
 msgid ""
 "Failure setting up encrypted tunnel:\n"
@@ -1097,6 +1127,95 @@ msgstr ""
 msgid "Remote desktop viewer"
 msgstr "Visor de escritorio eemoto"
 
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(servidor pred. %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "Error en SetDesktopSize: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "¡SetColourMapEntries inválida del servidor!"
+
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "Se especificó una configuración inválida para %s"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "Índice de monitor '%s' inválido"
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "Carácter '%c' inesperado"
+
+#~ msgid "VNC viewer: Connection details"
+#~ msgstr "Visor VNC: Datos de conexión"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "Acerca del visor &TigerVNC..."
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "Visor TigerVNC"
+
+#~ msgid "TigerVNC viewer connection to a CentOS machine"
+#~ msgstr "Conexión de visor TigerVNC a una máquina CentOS"
+
+#~ msgid "TigerVNC viewer connection to a macOS machine"
+#~ msgstr "Conexión de visor TigerVNC a una máquina macOS"
+
+#~ msgid "TigerVNC viewer connection to a Windows machine"
+#~ msgstr "Conexión de visor TigerVNC a una máquina Windows"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "Visor de TigerVNC v%s\n"
+#~ "Compilado en: %s\n"
+#~ "Copyright (C) 1999-%d Equipo TigerVNC y muchos otros (vea README.rst)\n"
+#~ "Vea https://www.tigervnc.org para más información sobre TigerVNC."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "Acerca del visor TigerVNC"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Error al iniciar un nuevo visor TigerVNC: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC viewer will now exit."
+#~ msgstr ""
+#~ "Se recibió la señal de terminación %d. El visor TigerVNC terminará ahora."
+
+#~ msgid "TigerVNC viewer"
+#~ msgstr "Visor TigerVNC"
+
+#, c-format
+#~ msgid ""
+#~ "\n"
+#~ "Options:\n"
+#~ "\n"
+#~ "  -display Xdisplay  - Specifies the X display for the viewer window\n"
+#~ "  -geometry geometry - Initial position of the main VNC viewer window. "
+#~ "See the\n"
+#~ "                       man page for details.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Opciones:\n"
+#~ "\n"
+#~ "  -display Xdisplay   - Especifica el despliegue X para la ventana del "
+#~ "visor\n"
+#~ "  -geometry geometría - Posición inicial de la ventana principal del "
+#~ "visor VNC\n"
+#~ "                        Consulte la página del manual para más detalles.\n"
+
 #~ msgid "Show dot when no cursor"
 #~ msgstr "Muestra punto cuando no hay cursor"
 
@@ -1109,7 +1228,8 @@ msgstr "Visor de escritorio eemoto"
 
 #, c-format
 #~ msgid "No symbol for key code 0x%02x (in the current state)"
-#~ msgstr "No hay un símbolo para el código de tecla 0x%02x (en el estado actual)"
+#~ msgstr ""
+#~ "No hay un símbolo para el código de tecla 0x%02x (en el estado actual)"
 
 #~ msgid "Unknown parameter type"
 #~ msgstr "Parámetro de tipo desconocido"
@@ -1121,7 +1241,8 @@ msgstr "Visor de escritorio eemoto"
 #~ msgstr "Misc."
 
 #~ msgid "Failed to get monitor name because X11 RandR could not be found"
-#~ msgstr "Falló al obtener el nombre del monitor porque no se encuentra X11 RandR"
+#~ msgstr ""
+#~ "Falló al obtener el nombre del monitor porque no se encuentra X11 RandR"
 
 #~ msgid "Failed to get information about CRTC %d"
 #~ msgstr "Falló al obtener la información sobre el CRTC %d"
@@ -1136,7 +1257,8 @@ msgstr "Visor de escritorio eemoto"
 #~ msgstr "Redimensiona sesión remota al conectar"
 
 #~ msgid "Resize remote session to the local window"
-#~ msgstr "Cambia el tamaño de la sesión remota para adaptarlo a la ventana local"
+#~ msgstr ""
+#~ "Cambia el tamaño de la sesión remota para adaptarlo a la ventana local"
 
 #~ msgid "Enable full-screen"
 #~ msgstr "Activar el modo de pantalla completa"
@@ -1186,28 +1308,40 @@ msgstr "Visor de escritorio eemoto"
 #~ msgstr "Fallado para escribir parámetro %s de tipo %s al registro: %ld"
 
 #~ msgid "The name of the parameter %s was too large to read from the registry"
-#~ msgstr "El nombre del parámetro %s fue demasiado grande para leer desde el registro"
+#~ msgstr ""
+#~ "El nombre del parámetro %s fue demasiado grande para leer desde el "
+#~ "registro"
 
 #~ msgid "The parameter %s was too large to read from the registry"
 #~ msgstr "El parámetro %s fue demasiado grande para leer desde el registro"
 
-#~ msgid "Failed to write configuration file, can't obtain home directory path."
-#~ msgstr "Fallaba al escribir el directorio de configuración, no se puede obtener la ruta del directorio de inicio."
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Fallaba al escribir el directorio de configuración, no se puede obtener "
+#~ "la ruta del directorio de inicio."
 
 #~ msgid "Failed to write configuration file, can't open %s: %s"
-#~ msgstr "Fallaba al escribir el fichero de configuración, no puede abrir %s: %s"
+#~ msgstr ""
+#~ "Fallaba al escribir el fichero de configuración, no puede abrir %s: %s"
 
 #~ msgid "Failed to read configuration file, can't obtain home directory path."
-#~ msgstr "Fallaba al leer fichero de configuración, no puede obtener ruta de directorio inicial."
+#~ msgstr ""
+#~ "Fallaba al leer fichero de configuración, no puede obtener ruta de "
+#~ "directorio inicial."
 
 #~ msgid "Unknown parameter %s on line %d in file %s"
 #~ msgstr "Parámetro desconocido %s en línea %d en fichero %s"
 
-#~ msgid "Could not create VNC home directory: can't obtain home directory path."
-#~ msgstr "No se ha podido crear el directorio de inicio de VNC: no se puede obtener la ruta del directorio de inicio."
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
+#~ msgstr ""
+#~ "No se ha podido crear el directorio de inicio de VNC: no se puede obtener "
+#~ "la ruta del directorio de inicio."
 
 #~ msgid "Multiple characters given for key code %d (0x%04x): '%s'"
-#~ msgstr "Se han dado múltiples caracteres para el código clave %d (0x%04x): '%s'"
+#~ msgstr ""
+#~ "Se han dado múltiples caracteres para el código clave %d (0x%04x): '%s'"
 
 #~ msgid "Unknown FLTK key code %d (0x%04x)"
 #~ msgstr "Código clave FLTK desconocido %d (0x%04x)"

--- a/po/fi.po
+++ b/po/fi.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.14.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2025-01-14 16:15+0100\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2025-01-22 23:21+0200\n"
 "Last-Translator: Lauri Nurmi <lanurmi@iki.fi>\n"
 "Language-Team: Finnish <translation-team-fi@lists.sourceforge.net>\n"
@@ -20,17 +20,17 @@ msgstr ""
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: Poedit 3.5\n"
 
-#: vncviewer/CConn.cxx:102
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "Yhdistetty sokettiin %s"
 
-#: vncviewer/CConn.cxx:109
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "Yhdistetty koneeseen %s porttiin %d"
 
-#: vncviewer/CConn.cxx:114
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -41,66 +41,63 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:151
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Työpöydän nimi: %.80s"
 
-#: vncviewer/CConn.cxx:154
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Kone: %.80s portti: %d"
 
-#: vncviewer/CConn.cxx:158
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Koko: %d × %d"
 
-#: vncviewer/CConn.cxx:165
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Pikselimuoto: %s"
 
-#: vncviewer/CConn.cxx:170
-#, c-format
-msgid "(server default %s)"
-msgstr "(palvelimen oletus %s)"
-
-#: vncviewer/CConn.cxx:173
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Pyydetty koodaus: %s"
 
-#: vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Viimeksi käytetty koodaus: %s"
 
-#: vncviewer/CConn.cxx:181
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Rivinopeusarvio: %d kilobittiä/s"
 
-#: vncviewer/CConn.cxx:185
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Yhteyskäytäntöversio: %d.%d"
 
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Turvamenetelmä: %s"
 
-#: vncviewer/CConn.cxx:250 vncviewer/CConn.cxx:252
-msgid "The connection was dropped by the server before the session could be established."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
 msgstr "Palvelin pudotti yhteyden ennen kuin istuntoa voitiin muodostaa."
 
-#: vncviewer/CConn.cxx:262
+#: vncviewer/CConn.cxx:258
 #, c-format
 msgid "Authentication failed: %s"
 msgstr "Todennus epäonnistui: %s"
 
-#: vncviewer/CConn.cxx:263
+#: vncviewer/CConn.cxx:259
 #, c-format
 msgid ""
 "Failed to authenticate with the server. Reason given by the server:\n"
@@ -111,31 +108,22 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:335
-#, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "SetDesktopSize epäonnistui: %d"
-
-#: vncviewer/CConn.cxx:408
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "Virheellisiä SetColourMapEntries-tietueita palvelimelta!"
-
-#: vncviewer/CConn.cxx:516
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Läpisyöttö %d kilobittiä/s - vaihdetaan laaduksi %d"
 
-#: vncviewer/CConn.cxx:538
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "Läpisyöttö %d kilobittiä/s - täysvärit ovat nyt käytössä"
 
-#: vncviewer/CConn.cxx:541
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "Läpisyöttö %d kilobittiä/s - täysvärit ovat nyt pois käytöstä"
 
-#: vncviewer/CConn.cxx:567
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Käytetään pikselimuotoa %s"
@@ -148,136 +136,125 @@ msgstr "Virheellinen geometria määritelty!"
 msgid "Reducing window size to fit on current monitor"
 msgstr "Pienennetään ikkunan kokoa nykyiseen näyttöön sovittamiseksi"
 
-#: vncviewer/DesktopWindow.cxx:646
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
 msgstr "Säädetään ikkunakokoa tahattomien kokonäyttöpyyntöjen välttämiseksi"
 
-#: vncviewer/DesktopWindow.cxx:694
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "%s avaa ponnahdusvalikon"
 
-#: vncviewer/DesktopWindow.cxx:1094 vncviewer/DesktopWindow.cxx:1102
-#: vncviewer/DesktopWindow.cxx:1122
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Häiriö näppäimistöön tarttumisessa"
 
-#: vncviewer/DesktopWindow.cxx:1411
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
 msgstr "Virheellinen näyttöasettelu laskettu koonmuuttamispyynnölle!"
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "Virheellinen tila kolmen painikkeen jäljittelylle"
 
-#: vncviewer/KeyboardWin32.cxx:242
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "Ei toimintakoodia laajennetulle virtuaalinäppäimelle 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:244
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "Ei toimintakoodia virtuaalinäppäimelle 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:250
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "Virheellinen toimintakoodi 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:262
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "Laajennetulle virtuaalinäppäimelle 0x%02x ei ole symbolia"
 
-#: vncviewer/KeyboardWin32.cxx:264
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "Virtuaalinäppäimelle 0x%02x ei ole symbolia"
 
-#: vncviewer/KeyboardWin32.cxx:423
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
 msgid "Failed to update keyboard LED state: %lu"
 msgstr "Näppäimistön LED-tilan päivittäminen epäonnistui: %lu"
 
-#: vncviewer/KeyboardX11.cxx:104
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "Näppäinkoodille %d ei ole symbolia (nykyisessä tilassa)"
 
-#: vncviewer/KeyboardX11.cxx:129
+#: vncviewer/KeyboardX11.cxx:148
 #, c-format
 msgid "Failed to get keyboard LED state: %d"
 msgstr "Näppäimistön LED-tilan noutaminen epäonnistui: %d"
 
-#: vncviewer/KeyboardX11.cxx:174
+#: vncviewer/KeyboardX11.cxx:193
 msgid "Failed to update keyboard LED state"
 msgstr "Näppäimistön LED-tilan päivittäminen epäonnistui"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:100
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "Järjestelmän näyttökokoonpanon selvittäminen epäonnistui"
 
-#: vncviewer/MonitorIndicesParameter.cxx:79
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "%s:lle määritetty virheellinen arvo"
-
-#: vncviewer/MonitorIndicesParameter.cxx:86
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "Näyttöä numero %d ei ole olemassa"
 
-#: vncviewer/MonitorIndicesParameter.cxx:162
-#: vncviewer/MonitorIndicesParameter.cxx:182
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "Virheellinen näytön numero ”%s”"
-
-#: vncviewer/MonitorIndicesParameter.cxx:170
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "Odottamaton merkki ”%c”"
-
-#: vncviewer/OptionsDialog.cxx:64
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
 msgid "TigerVNC options"
 msgstr "TigerVNC-asetukset"
 
-#: vncviewer/OptionsDialog.cxx:97 vncviewer/ServerDialog.cxx:107
-#: vncviewer/vncviewer.cxx:397
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "Peru"
 
-#: vncviewer/OptionsDialog.cxx:102 vncviewer/vncviewer.cxx:396
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "Valmis"
 
-#: vncviewer/OptionsDialog.cxx:514
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "Tiivistys"
 
-#: vncviewer/OptionsDialog.cxx:530
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "Automaattivalinta"
 
-#: vncviewer/OptionsDialog.cxx:541
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "Ensisijainen koodaus"
 
-#: vncviewer/OptionsDialog.cxx:602
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "Väritaso"
 
-#: vncviewer/OptionsDialog.cxx:614
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "Täysi"
 
-#: vncviewer/OptionsDialog.cxx:621
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "Keskilaatu"
 
-#: vncviewer/OptionsDialog.cxx:628
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "Matala"
 
@@ -285,166 +262,177 @@ msgstr "Matala"
 msgid "Very low"
 msgstr "Hyvin matala"
 
-#: vncviewer/OptionsDialog.cxx:657
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "Oma tiivistystaso:"
 
-#: vncviewer/OptionsDialog.cxx:664
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "laatu (0=nopea, 9=paras)"
 
-#: vncviewer/OptionsDialog.cxx:671
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "Salli JPEG-tiivistys:"
 
-#: vncviewer/OptionsDialog.cxx:678
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "laatu (0=heikko, 9=paras)"
 
-#: vncviewer/OptionsDialog.cxx:689
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "Turvallisuus"
 
-#: vncviewer/OptionsDialog.cxx:703
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "Salaus"
 
-#: vncviewer/OptionsDialog.cxx:715 vncviewer/OptionsDialog.cxx:782
-#: vncviewer/OptionsDialog.cxx:905
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "Ei mitään"
 
-#: vncviewer/OptionsDialog.cxx:722
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "TLS anonyymeilla varmenteilla"
 
-#: vncviewer/OptionsDialog.cxx:728
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "TLS X509-varmenteilla"
 
-#: vncviewer/OptionsDialog.cxx:735
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "Polku X509 CA-varmenteeseen"
 
-#: vncviewer/OptionsDialog.cxx:742
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "Polku X509 CRL-tiedostoon"
 
-#: vncviewer/OptionsDialog.cxx:770
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "Todennus"
 
-#: vncviewer/OptionsDialog.cxx:788
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "Standardi-VNC (turvaton salauksetta)"
 
-#: vncviewer/OptionsDialog.cxx:794
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "Käyttäjätunnus ja salasana (turvaton salauksetta)"
 
-#: vncviewer/OptionsDialog.cxx:822
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "Syöte"
 
-#: vncviewer/OptionsDialog.cxx:835
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "Vain katselu (hiirtä ja näppäimistöä ei huomioida)"
 
-#: vncviewer/OptionsDialog.cxx:842
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "Hiiri"
 
-#: vncviewer/OptionsDialog.cxx:854
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "Jäljittele hiiren keskipainiketta"
 
-#: vncviewer/OptionsDialog.cxx:860
+#: vncviewer/OptionsDialog.cxx:880
 msgid "Show local cursor when not provided by server"
 msgstr "Näytä paikallinen kohdistin, kun palvelin ei tarjoa kohdistinta"
 
-#: vncviewer/OptionsDialog.cxx:865
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
 msgid "Cursor type"
 msgstr "Kohdistimen tyyppi"
 
-#: vncviewer/OptionsDialog.cxx:867
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
 msgid "Dot"
 msgstr "Piste"
 
-#: vncviewer/OptionsDialog.cxx:868
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
 msgid "System"
 msgstr "Järjestelmä"
 
-#: vncviewer/OptionsDialog.cxx:888
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "Näppäimistö"
 
-#: vncviewer/OptionsDialog.cxx:900
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
 msgstr "Välitä järjestelmänäppäimet suoraan palvelimelle (kokonäyttö)"
 
-#: vncviewer/OptionsDialog.cxx:903
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "Valikkonäppäin"
 
-#: vncviewer/OptionsDialog.cxx:926
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "Leikepöytä"
 
-#: vncviewer/OptionsDialog.cxx:938
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "Hyväksy leikepöytä palvelimelta"
 
-#: vncviewer/OptionsDialog.cxx:946
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "Aseta myös ensisijainen valinta"
 
-#: vncviewer/OptionsDialog.cxx:953
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "Lähetä leikepöytä palvelimelle"
 
-#: vncviewer/OptionsDialog.cxx:961
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "Lähetä ensisijainen valinta leikepöytänä"
 
-#: vncviewer/OptionsDialog.cxx:982
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "Näyttö"
 
-#: vncviewer/OptionsDialog.cxx:996
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "Näyttötila"
 
-#: vncviewer/OptionsDialog.cxx:1009
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "Ikkunoitu"
 
-#: vncviewer/OptionsDialog.cxx:1017
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "Kokonäyttö nykyisellä näytöllä"
 
-#: vncviewer/OptionsDialog.cxx:1025
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "Kokonäyttö kaikilla näytöillä"
 
-#: vncviewer/OptionsDialog.cxx:1033
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "Kokonäyttö valituilla näytöillä"
 
-#: vncviewer/OptionsDialog.cxx:1062
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
 msgid "Miscellaneous"
 msgstr "Sekalaiset"
 
-#: vncviewer/OptionsDialog.cxx:1070
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "Jaettu (älä katkaise muiden katselimien yhteyksiä)"
 
-#: vncviewer/OptionsDialog.cxx:1076
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "Pyydä uudelleenyhdistämään yhteysvirheen sattuessa"
-
-#: vncviewer/ServerDialog.cxx:63
-msgid "VNC viewer: Connection details"
-msgstr "VNC-katselin: Yhteyden yksityiskohdat"
 
 #: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
@@ -490,7 +478,7 @@ msgstr "TigerVNC-asetukset (*.tigervnc)"
 msgid "Select a TigerVNC configuration file"
 msgstr "Valitse TigerVNC-asetustiedosto"
 
-#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:517
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -510,7 +498,7 @@ msgstr "Tallenna TigerVNC-asetukset tiedostoon"
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "%s on jo olemassa. Haluatko korvata sen?"
 
-#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:394
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "Ei"
 
@@ -551,169 +539,170 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:351 vncviewer/ServerDialog.cxx:429
-#: vncviewer/vncviewer.cxx:580
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
 msgid "Could not determine VNC state directory path"
 msgstr "VNC-tilahakemiston polkua ei saatu selvitettyä"
 
-#: vncviewer/ServerDialog.cxx:363 vncviewer/ServerDialog.cxx:437
-#: vncviewer/parameters.cxx:671 vncviewer/parameters.cxx:752
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
 msgid "Could not open \"%s\""
 msgstr "Tiedoston ”%s” avaaminen epäonnistui"
 
-#: vncviewer/ServerDialog.cxx:378 vncviewer/ServerDialog.cxx:387
-#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:773
-#: vncviewer/parameters.cxx:807 vncviewer/parameters.cxx:837
-#: vncviewer/parameters.cxx:844
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
 msgid "Failed to read line %d in file \"%s\""
 msgstr "Rivin %d lukeminen tiedostosta ”%s” epäonnistui"
 
-#: vncviewer/ServerDialog.cxx:390 vncviewer/parameters.cxx:776
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "Liian pitkä rivi"
 
-#: vncviewer/UserDialog.cxx:123
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "Salasanatiedoston avaaminen epäonnistui"
 
-#: vncviewer/UserDialog.cxx:143
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "VNC-todennus"
 
-#: vncviewer/UserDialog.cxx:150
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "Tämä yhteys on turvallinen"
 
-#: vncviewer/UserDialog.cxx:154
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "Tämä yhteys ei ole turvallinen"
 
-#: vncviewer/UserDialog.cxx:176
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "Käyttäjätunnus:"
 
-#: vncviewer/UserDialog.cxx:189
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "Salasana:"
 
-#: vncviewer/UserDialog.cxx:197
+#: vncviewer/UserDialog.cxx:204
 msgid "Keep password for reconnect"
 msgstr "Säilytä salasana yhteyden uudelleenmuodostamiseen"
 
-#: vncviewer/Viewport.cxx:695
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
 msgid "Disconn&ect"
 msgstr "Ka&tkaise yhteys"
 
-#: vncviewer/Viewport.cxx:698
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "&Kokonäyttö"
 
-#: vncviewer/Viewport.cxx:701
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "Pi&enennä"
 
-#: vncviewer/Viewport.cxx:703
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "&Sovita ikkunan koko istuntoon"
 
-#: vncviewer/Viewport.cxx:708
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:711
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:717
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "Lähetä %s"
 
-#: vncviewer/Viewport.cxx:724
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Lähetä Ctrl-Alt-&Del"
 
-#: vncviewer/Viewport.cxx:727
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "Vi&rkistä näyttö"
 
-#: vncviewer/Viewport.cxx:730
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&Valinnat..."
 
-#: vncviewer/Viewport.cxx:732
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "Yh&teyden tiedot..."
 
-#: vncviewer/Viewport.cxx:734
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "Tietoa &TigerVNC:stä..."
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:830
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "VNC-yhteyden tiedot"
 
-#: vncviewer/Win32TouchHandler.cxx:48
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "Ikkuna on rekisteröity kosketuksille eikä eleille"
 
-#: vncviewer/Win32TouchHandler.cxx:83
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "Eleasetusten asettaminen epäonnistui (virhe 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:95
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "Eletietojen saaminen epäonnistui (virhe 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:360
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr "Virheellinen hiiren painike %d, ei ole välillä 1 – 7."
 
-#: vncviewer/Win32TouchHandler.cxx:425
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
 msgstr "Käsittelemätön näppäin 0x%x - ei voi luoda näppäimistötapahtumaa."
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:107
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
 msgstr "X Input 2 -tapahtumapeitettä ei saada ikkunalle 0x%08lx"
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr "Ikkunalla 0x%08lx ei ole X Input 2 -tapahtumapeitettä"
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:114
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr "Ikkunalla 0x%08lx on useampi X Input 2 -tapahtumapeite"
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "Häiriö laitteeseen %i tarttumisessa"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-msgid "TigerVNC Viewer"
-msgstr "TigerVNC-katselin"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -721,100 +710,127 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr "Yhdistä VNC-palvelimeen ja näytä etätyöpöytä"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
-msgstr "Virtual Network Computing (VNC) on etänäyttöjärjestelmä, jonka avulla voi katsella ja ohjata toisessa verkon koneessa toimivaa virtuaalista työpöytäympäristöä. VNC:n avulla voi suorittaa graafisia sovelluksia etäkoneella ja lähettää näistä sovelluksista vain näytön paikalliseen laitteeseen. Tämä paketti sisältää asiakasohjelman, jolla voi muodostaa yhteyden muihin työpöytiin, joilla on VNC-palvelin. VNC on alustariippumaton ja tukee erilaisia käyttöjärjestelmiä ja arkkitehtuureja sekä palvelimina että asiakasohjelmina."
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+"Virtual Network Computing (VNC) on etänäyttöjärjestelmä, jonka avulla voi "
+"katsella ja ohjata toisessa verkon koneessa toimivaa virtuaalista "
+"työpöytäympäristöä. VNC:n avulla voi suorittaa graafisia sovelluksia "
+"etäkoneella ja lähettää näistä sovelluksista vain näytön paikalliseen "
+"laitteeseen. Tämä paketti sisältää asiakasohjelman, jolla voi muodostaa "
+"yhteyden muihin työpöytiin, joilla on VNC-palvelin. VNC on alustariippumaton "
+"ja tukee erilaisia käyttöjärjestelmiä ja arkkitehtuureja sekä palvelimina "
+"että asiakasohjelmina."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
-msgstr "TigerVNC on RealVNC 4- ja X.org koodikantoihin perustuva nopea versio VNC:stä. TigerVNC aloitettiin uuteen sukupolveen tähtäävänä TightVNC:n kehitystyönä Unix- ja Linux-alustoilla, mutta se erosi emoprojektistaan vuoden 2009 alussa, jotta TightVNC voisi keskittyä Windows-alustoihin. TigerVNC tukee Tight-koodauksen muunnosta, jota libjpeg-turbo-JPEG-koodekin käyttö nopeuttaa huomattavasti."
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+"TigerVNC on RealVNC 4- ja X.org koodikantoihin perustuva nopea versio VNC:"
+"stä. TigerVNC aloitettiin uuteen sukupolveen tähtäävänä TightVNC:n "
+"kehitystyönä Unix- ja Linux-alustoilla, mutta se erosi emoprojektistaan "
+"vuoden 2009 alussa, jotta TightVNC voisi keskittyä Windows-alustoihin. "
+"TigerVNC tukee Tight-koodauksen muunnosta, jota libjpeg-turbo-JPEG-koodekin "
+"käyttö nopeuttaa huomattavasti."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC viewer connection to a CentOS machine"
-msgstr "TigerVNC-katselimen yhteys CentOS-koneeseen"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC viewer connection to a macOS machine"
-msgstr "TigerVNC-katselimen yhteys macOS-koneeseen"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC viewer connection to a Windows machine"
-msgstr "TigerVNC-katselimen yhteys Windows-koneeseen"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
 #. developer_name tag deprecated with Appstream 1.0
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
-#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:48
 msgid "The TigerVNC team"
 msgstr "TigerVNC-ryhmä"
 
-#: vncviewer/parameters.cxx:319 vncviewer/parameters.cxx:344
-#: vncviewer/parameters.cxx:361 vncviewer/parameters.cxx:401
-#: vncviewer/parameters.cxx:421
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "Parametrin nimi on liian suuri"
 
-#: vncviewer/parameters.cxx:323 vncviewer/parameters.cxx:328
-#: vncviewer/parameters.cxx:379
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "Parametri on liian suuri"
 
-#: vncviewer/parameters.cxx:386 vncviewer/parameters.cxx:712
-#: vncviewer/parameters.cxx:822
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "Virheellinen muoto tai liian suuri arvo"
 
-#: vncviewer/parameters.cxx:440 vncviewer/parameters.cxx:473
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "Rekisteriavaimen luominen epäonnistui"
 
-#: vncviewer/parameters.cxx:461 vncviewer/parameters.cxx:528
-#: vncviewer/parameters.cxx:571 vncviewer/parameters.cxx:638
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "Rekisteriavaimen sulkeminen epäonnistui"
 
-#: vncviewer/parameters.cxx:479 vncviewer/parameters.cxx:506
-#: vncviewer/parameters.cxx:680 vncviewer/parameters.cxx:692
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "Tiedoston ”%s” tallentaminen epäonnistui: %s"
 
-#: vncviewer/parameters.cxx:489 vncviewer/parameters.cxx:520
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "Tiedoston ”%s” poistaminen epäonnistui: %s"
 
-#: vncviewer/parameters.cxx:544 vncviewer/parameters.cxx:616
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "Rekisteriavaimen avaaminen epäonnistui"
 
-#: vncviewer/parameters.cxx:561
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "Palvelinhistorian merkinnän %d lukeminen epäonnistui: %s"
 
-#: vncviewer/parameters.cxx:597 vncviewer/parameters.cxx:627
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "Parametrin ”%s” lukeminen epäonnistui: %s"
 
-#: vncviewer/parameters.cxx:661 vncviewer/parameters.cxx:740
-#: vncviewer/vncviewer.cxx:546
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
 msgid "Could not determine VNC config directory path"
 msgstr "VNC-setushakemiston polkua ei saatu selvitettyä"
 
-#: vncviewer/parameters.cxx:682 vncviewer/parameters.cxx:694
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "Parametria ei voitu koodata"
 
-#: vncviewer/parameters.cxx:785
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "Asetustiedosto %s on virheellisessä muodossa"
 
-#: vncviewer/parameters.cxx:809
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "Virheellinen muoto"
 
-#: vncviewer/parameters.cxx:846
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "Tuntematon parametri"
 
@@ -855,23 +871,21 @@ msgid "X Input 2 (or newer) is not available."
 msgstr "X Input 2 (tai uudempi) ei ole saatavilla."
 
 #: vncviewer/touch.cxx:266
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
 msgstr "X Input 2.2 (tai uudempi) ei ole saatavilla. Kosketuseleitä ei tueta."
 
-#: vncviewer/vncviewer.cxx:104
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
 "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"TigerVNC-katselin v%s\n"
-"Koontihetki: %s\n"
-"Copyright © 1999-%d TigerVNC-ryhmä ja monet muut (ks. README.rst)\n"
-"Lisätietoja TigerVNC:stä osoitteessa https://www.tigervnc.org."
 
-#: vncviewer/vncviewer.cxx:158
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -882,15 +896,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:174
-msgid "About TigerVNC Viewer"
-msgstr "Tietoa &TigerVNC:stä"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:195
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "Sisäinen FLTK-virhe. Poistutaan."
 
-#: vncviewer/vncviewer.cxx:214
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -901,63 +915,59 @@ msgstr ""
 "\n"
 "Yritetäänkö uudelleenyhdistämistä?"
 
-#: vncviewer/vncviewer.cxx:245 vncviewer/vncviewer.cxx:257
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Virhe käynnistettäessä uutta TigerVNC-katselinta: %s"
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:266
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC viewer will now exit."
-msgstr "Päättämissignaali %d on vastaanotettu. TigerVNC-katselin sulkeutuu."
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:391 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC viewer"
-msgstr "TigerVNC-katselin"
-
-#: vncviewer/vncviewer.cxx:395
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "Kyllä"
 
-#: vncviewer/vncviewer.cxx:398
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "Sulje"
 
-#: vncviewer/vncviewer.cxx:403
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "Tietoja"
 
-#: vncviewer/vncviewer.cxx:406
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "Piilota"
 
-#: vncviewer/vncviewer.cxx:409
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "Poistu"
 
-#: vncviewer/vncviewer.cxx:413
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "Palvelut"
 
-#: vncviewer/vncviewer.cxx:414
+#: vncviewer/vncviewer.cxx:413
 msgid "Hide others"
 msgstr "Piilota muut"
 
-#: vncviewer/vncviewer.cxx:415
+#: vncviewer/vncviewer.cxx:414
 msgid "Show all"
 msgstr "Näytä kaikki"
 
-#: vncviewer/vncviewer.cxx:424
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "&Tiedosto"
 
-#: vncviewer/vncviewer.cxx:427
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "&Uusi yhteys"
 
-#: vncviewer/vncviewer.cxx:450
+#: vncviewer/vncviewer.cxx:449
 #, c-format
 msgid ""
 "\n"
@@ -974,24 +984,19 @@ msgstr ""
 "       %s [parametrit] -listen [portti]\n"
 "       %s [parametrit] [.tigervnc-tiedosto]\n"
 
-#: vncviewer/vncviewer.cxx:465
+#: vncviewer/vncviewer.cxx:464
 #, c-format
 msgid ""
 "\n"
 "Options:\n"
 "\n"
 "  -display Xdisplay  - Specifies the X display for the viewer window\n"
-"  -geometry geometry - Initial position of the main VNC viewer window. See the\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
 "                       man page for details.\n"
 msgstr ""
-"\n"
-"Asetukset:\n"
-"\n"
-"-display Xnäyttö      - Määrittää katselinikkunan X-näytön\n"
-"  -geometry geometria - VNC-katselinohjelman pääikkunan alkusijainti. Katso\n"
-"                        man-sivulta lisätietoja.\n"
 
-#: vncviewer/vncviewer.cxx:472
+#: vncviewer/vncviewer.cxx:471
 #, c-format
 msgid ""
 "\n"
@@ -1008,73 +1013,86 @@ msgstr ""
 "Kirjainkoolla ei ole merkitystä parametrien nimissä. Parametrit ovat:\n"
 "\n"
 
-#: vncviewer/vncviewer.cxx:527
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
-msgstr "FullScreenAllMonitors on vanhentunut, aseta FullScreenMode-asetukseksi ”all” sen sijaan"
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+"FullScreenAllMonitors on vanhentunut, aseta FullScreenMode-asetukseksi ”all” "
+"sen sijaan"
 
-#: vncviewer/vncviewer.cxx:532
-msgid "DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' instead"
-msgstr "DotWhenNoCursor on vanhentunut, aseta sen sijaan AlwaysCursor-arvoksi 1 ja CursorType-valinnaksi ”Piste”"
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+"DotWhenNoCursor on vanhentunut, aseta sen sijaan AlwaysCursor-arvoksi 1 ja "
+"CursorType-valinnaksi ”Piste”"
 
-#: vncviewer/vncviewer.cxx:553
-msgid "~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
-msgstr "~/.vnc on vanhentunut, katso ”man vncviewer” sisältää lisätietoa korvaavista poluista."
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+"~/.vnc on vanhentunut, katso ”man vncviewer” sisältää lisätietoa korvaavista "
+"poluista."
 
-#: vncviewer/vncviewer.cxx:557
+#: vncviewer/vncviewer.cxx:556
 #, c-format
-msgid "%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC location."
-msgstr "%%APPDATA%%\\vnc on vanhentunut, vaihda sijainniksi %%APPDATA%%\\TigerVNC."
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+"%%APPDATA%%\\vnc on vanhentunut, vaihda sijainniksi %%APPDATA%%\\TigerVNC."
 
-#: vncviewer/vncviewer.cxx:562
+#: vncviewer/vncviewer.cxx:561
 #, c-format
 msgid "Could not create VNC config directory \"%s\": %s"
 msgstr "VNC-asetushakemiston ”%s” luominen epäonnistui: %s"
 
-#: vncviewer/vncviewer.cxx:568
+#: vncviewer/vncviewer.cxx:567
 msgid "Could not determine VNC data directory path"
 msgstr "VNC-tietohakemiston polun selvitys epäonnistui"
 
-#: vncviewer/vncviewer.cxx:574
+#: vncviewer/vncviewer.cxx:573
 #, c-format
 msgid "Could not create VNC data directory \"%s\": %s"
 msgstr "VNC-tietohakemiston ”%s” luominen epäonnistui: %s"
 
-#: vncviewer/vncviewer.cxx:586
+#: vncviewer/vncviewer.cxx:585
 #, c-format
 msgid "Could not create VNC state directory \"%s\": %s"
 msgstr "VNC-tilahakemiston ”%s” luominen epäonnistui: %s"
 
-#: vncviewer/vncviewer.cxx:703
+#: vncviewer/vncviewer.cxx:704
 #, c-format
 msgid "%s: Unrecognized option '%s'\n"
 msgstr "%s: Tuntematon valitsin ”%s”\n"
 
-#: vncviewer/vncviewer.cxx:705 vncviewer/vncviewer.cxx:713
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
 #, c-format
 msgid "See '%s --help' for more information.\n"
 msgstr "Lisätietoja komennolla ”%s --help”.\n"
 
-#: vncviewer/vncviewer.cxx:712
+#: vncviewer/vncviewer.cxx:713
 #, c-format
 msgid "%s: Extra argument '%s'\n"
 msgstr "%s: Ylimääräinen argumentti ”%s”\n"
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:748 vncviewer/vncviewer.cxx:749
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "Parametrit -listen ja -via ovat yhteensopimattomia"
 
-#: vncviewer/vncviewer.cxx:763
+#: vncviewer/vncviewer.cxx:764
 msgid "Unable to listen for incoming connections"
 msgstr "Saapuvia yhteyksiä ei voi kuunnella"
 
-#: vncviewer/vncviewer.cxx:765
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "Kuunnellaan portissa %d"
 
-#: vncviewer/vncviewer.cxx:794
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -1085,7 +1103,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:815
+#: vncviewer/vncviewer.cxx:816
 #, c-format
 msgid ""
 "Failure setting up encrypted tunnel:\n"
@@ -1099,6 +1117,93 @@ msgstr ""
 #: vncviewer/vncviewer.desktop.in.in:4
 msgid "Remote desktop viewer"
 msgstr "Etätyöpöytäkatselin"
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(palvelimen oletus %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "SetDesktopSize epäonnistui: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "Virheellisiä SetColourMapEntries-tietueita palvelimelta!"
+
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "%s:lle määritetty virheellinen arvo"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "Virheellinen näytön numero ”%s”"
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "Odottamaton merkki ”%c”"
+
+#~ msgid "VNC viewer: Connection details"
+#~ msgstr "VNC-katselin: Yhteyden yksityiskohdat"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "Tietoa &TigerVNC:stä..."
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "TigerVNC-katselin"
+
+#~ msgid "TigerVNC viewer connection to a CentOS machine"
+#~ msgstr "TigerVNC-katselimen yhteys CentOS-koneeseen"
+
+#~ msgid "TigerVNC viewer connection to a macOS machine"
+#~ msgstr "TigerVNC-katselimen yhteys macOS-koneeseen"
+
+#~ msgid "TigerVNC viewer connection to a Windows machine"
+#~ msgstr "TigerVNC-katselimen yhteys Windows-koneeseen"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "TigerVNC-katselin v%s\n"
+#~ "Koontihetki: %s\n"
+#~ "Copyright © 1999-%d TigerVNC-ryhmä ja monet muut (ks. README.rst)\n"
+#~ "Lisätietoja TigerVNC:stä osoitteessa https://www.tigervnc.org."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "Tietoa &TigerVNC:stä"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Virhe käynnistettäessä uutta TigerVNC-katselinta: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC viewer will now exit."
+#~ msgstr "Päättämissignaali %d on vastaanotettu. TigerVNC-katselin sulkeutuu."
+
+#~ msgid "TigerVNC viewer"
+#~ msgstr "TigerVNC-katselin"
+
+#, c-format
+#~ msgid ""
+#~ "\n"
+#~ "Options:\n"
+#~ "\n"
+#~ "  -display Xdisplay  - Specifies the X display for the viewer window\n"
+#~ "  -geometry geometry - Initial position of the main VNC viewer window. "
+#~ "See the\n"
+#~ "                       man page for details.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Asetukset:\n"
+#~ "\n"
+#~ "-display Xnäyttö      - Määrittää katselinikkunan X-näytön\n"
+#~ "  -geometry geometria - VNC-katselinohjelman pääikkunan alkusijainti. "
+#~ "Katso\n"
+#~ "                        man-sivulta lisätietoja.\n"
 
 #~ msgid "Show dot when no cursor"
 #~ msgstr "Näytä piste kohdistimen puuttuessa"
@@ -1124,7 +1229,8 @@ msgstr "Etätyöpöytäkatselin"
 #~ msgstr "Sekalaiset"
 
 #~ msgid "Failed to get monitor name because X11 RandR could not be found"
-#~ msgstr "Näytön nimen noutaminen epäonnistui, koska X11:n RandR:ää ei löytynyt"
+#~ msgstr ""
+#~ "Näytön nimen noutaminen epäonnistui, koska X11:n RandR:ää ei löytynyt"
 
 #~ msgid "Screen"
 #~ msgstr "Näyttö"
@@ -1165,7 +1271,8 @@ msgstr "Etätyöpöytäkatselin"
 #~ msgstr "Sul&je valikko"
 
 #~ msgid "Failed to write parameter %s of type %s to the registry: %ld"
-#~ msgstr "Parametrin %s (tyyppiä %s) kirjoittaminen rekisteriin epäonnistui: %ld"
+#~ msgstr ""
+#~ "Parametrin %s (tyyppiä %s) kirjoittaminen rekisteriin epäonnistui: %ld"
 
 #~ msgid "The name of the parameter %s was too large to read from the registry"
 #~ msgstr "Parametrin %s nimi oli liian suuri luettavaksi rekisteristä"
@@ -1173,20 +1280,30 @@ msgstr "Etätyöpöytäkatselin"
 #~ msgid "The parameter %s was too large to read from the registry"
 #~ msgstr "Parametri %s oli liian suuri luettavaksi rekisteristä"
 
-#~ msgid "Failed to write configuration file, can't obtain home directory path."
-#~ msgstr "Asetustiedoston kirjoittaminen epäonnistui, kotihakemiston polun selvittäminen epäonnistui."
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Asetustiedoston kirjoittaminen epäonnistui, kotihakemiston polun "
+#~ "selvittäminen epäonnistui."
 
 #~ msgid "Failed to write configuration file, can't open %s: %s"
-#~ msgstr "Asetustiedoston kirjoittaminen epäonnistui, tiedostn %s avaaminen epäonnistui: %s"
+#~ msgstr ""
+#~ "Asetustiedoston kirjoittaminen epäonnistui, tiedostn %s avaaminen "
+#~ "epäonnistui: %s"
 
 #~ msgid "Failed to read configuration file, can't obtain home directory path."
-#~ msgstr "Asetustiedoston lukeminen epäonnistui, kotihakemiston polun selvittäminen epäonnistui."
+#~ msgstr ""
+#~ "Asetustiedoston lukeminen epäonnistui, kotihakemiston polun selvittäminen "
+#~ "epäonnistui."
 
 #~ msgid "Unknown parameter %s on line %d in file %s"
 #~ msgstr "Tuntematon parametri %s rivillä %d tiedostossa %s"
 
-#~ msgid "Could not create VNC home directory: can't obtain home directory path."
-#~ msgstr "VNC-kotihakemiston luominen epäonnistui: kotihakemiston polun selvittäminen epäonnistui."
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
+#~ msgstr ""
+#~ "VNC-kotihakemiston luominen epäonnistui: kotihakemiston polun "
+#~ "selvittäminen epäonnistui."
 
 #~ msgid "tigervnc"
 #~ msgstr "tigervnc"
@@ -1246,7 +1363,8 @@ msgstr "Etätyöpöytäkatselin"
 #~ msgstr "Tuetaan vain true color-näyttöjä"
 
 #~ msgid "Using default colormap and visual, TrueColor, depth %d."
-#~ msgstr "Käytetään oletusvärikarttaa ja visuaalisuutta, TrueColor, syvyys %d."
+#~ msgstr ""
+#~ "Käytetään oletusvärikarttaa ja visuaalisuutta, TrueColor, syvyys %d."
 
 #~ msgid "Alt"
 #~ msgstr "Alt"
@@ -1257,32 +1375,68 @@ msgstr "Etätyöpöytäkatselin"
 #~ msgid "CleanupSignalHandler called"
 #~ msgstr "CleanupSignalHandler kutsuttu"
 
-#~ msgid "Could not convert the parameter-name %s to wchar_t* when reading from the Registry, the buffersize is to small."
-#~ msgstr "Parametrinimen %s muuntaminen wchar_t*-tyypiksi epäonnistui kun luetaan Windows-rekisteristä, puskurikoko on liian pieni."
+#~ msgid ""
+#~ "Could not convert the parameter-name %s to wchar_t* when reading from the "
+#~ "Registry, the buffersize is to small."
+#~ msgstr ""
+#~ "Parametrinimen %s muuntaminen wchar_t*-tyypiksi epäonnistui kun luetaan "
+#~ "Windows-rekisteristä, puskurikoko on liian pieni."
 
-#~ msgid "Could not convert the parameter-name %s to wchar_t* when writing to the Registry, the buffersize is to small."
-#~ msgstr "Parametrinimen %s muuntaminen wchar_t*-tyypiksi epäonnistui kun kirjoitetaan Windows-rekisteriin, puskurikoko on liian pieni."
+#~ msgid ""
+#~ "Could not convert the parameter-name %s to wchar_t* when writing to the "
+#~ "Registry, the buffersize is to small."
+#~ msgstr ""
+#~ "Parametrinimen %s muuntaminen wchar_t*-tyypiksi epäonnistui kun "
+#~ "kirjoitetaan Windows-rekisteriin, puskurikoko on liian pieni."
 
-#~ msgid "Could not convert the parameter-value %s to wchar_t* when writing to the Registry, the buffersize is to small."
-#~ msgstr "Parametriarvon %s muuntaminen wchar_t*-tyypiksi epäonnistui kun kirjoitetaan Windows-rekisteriin, puskurikoko on liian pieni."
+#~ msgid ""
+#~ "Could not convert the parameter-value %s to wchar_t* when writing to the "
+#~ "Registry, the buffersize is to small."
+#~ msgstr ""
+#~ "Parametriarvon %s muuntaminen wchar_t*-tyypiksi epäonnistui kun "
+#~ "kirjoitetaan Windows-rekisteriin, puskurikoko on liian pieni."
 
-#~ msgid "Could not convert the parameter-value for %s to utf8 char* when reading from the Registry, the buffer dest is to small."
-#~ msgstr "Parametriarvon %s muuntaminen utf8 char*-tyypiksi epäonnistui kun luetaan Windows-rekisteristä, puskurikohde on liian pieni."
+#~ msgid ""
+#~ "Could not convert the parameter-value for %s to utf8 char* when reading "
+#~ "from the Registry, the buffer dest is to small."
+#~ msgstr ""
+#~ "Parametriarvon %s muuntaminen utf8 char*-tyypiksi epäonnistui kun luetaan "
+#~ "Windows-rekisteristä, puskurikohde on liian pieni."
 
-#~ msgid "Could not read the line(%d) in the configuration file,the buffersize is to small."
-#~ msgstr "Rivin(%d) lukeminen asetustiedostosta epäonnistui, puskurikoko on liian pieni. "
+#~ msgid ""
+#~ "Could not read the line(%d) in the configuration file,the buffersize is "
+#~ "to small."
+#~ msgstr ""
+#~ "Rivin(%d) lukeminen asetustiedostosta epäonnistui, puskurikoko on liian "
+#~ "pieni. "
 
-#~ msgid "Decoding: The size of the buffer dest is to small, it needs to be 1 byte bigger."
-#~ msgstr "Koodauksen purku: Puskurikohteen koko on liian pieni, sen on oltava yhden tavun suurempi."
+#~ msgid ""
+#~ "Decoding: The size of the buffer dest is to small, it needs to be 1 byte "
+#~ "bigger."
+#~ msgstr ""
+#~ "Koodauksen purku: Puskurikohteen koko on liian pieni, sen on oltava yhden "
+#~ "tavun suurempi."
 
-#~ msgid "Encoding backslash: The size of the buffer dest is to small, it needs to be more than %d bytes bigger."
-#~ msgstr "Koodataan kenoviiva: Puskurikohteen koko on liian pieni, sen on oltava yli %d tavua suurempi."
+#~ msgid ""
+#~ "Encoding backslash: The size of the buffer dest is to small, it needs to "
+#~ "be more than %d bytes bigger."
+#~ msgstr ""
+#~ "Koodataan kenoviiva: Puskurikohteen koko on liian pieni, sen on oltava "
+#~ "yli %d tavua suurempi."
 
-#~ msgid "Encoding escape sequence: The size of the buffer dest is to small, it needs to be more than %d bytes bigger."
-#~ msgstr "Koodinvaihtosekvenssin koodaus: Puskurikohteen koko on liian pieni, sen on oltava yli %d tavua suurempi."
+#~ msgid ""
+#~ "Encoding escape sequence: The size of the buffer dest is to small, it "
+#~ "needs to be more than %d bytes bigger."
+#~ msgstr ""
+#~ "Koodinvaihtosekvenssin koodaus: Puskurikohteen koko on liian pieni, sen "
+#~ "on oltava yli %d tavua suurempi."
 
-#~ msgid "Encoding normal character: The size of the buffer dest is to small, it needs to be more than %d bytes bigger."
-#~ msgstr "Normaalin merkin koodaus: Puskurikohteen koko on liian pieni, sen on oltava yli %d tavua suurempi."
+#~ msgid ""
+#~ "Encoding normal character: The size of the buffer dest is to small, it "
+#~ "needs to be more than %d bytes bigger."
+#~ msgstr ""
+#~ "Normaalin merkin koodaus: Puskurikohteen koko on liian pieni, sen on "
+#~ "oltava yli %d tavua suurempi."
 
 #~ msgid "Error(%d) closing key:  Software\\TigerVNC\\vncviewer"
 #~ msgstr "Virhe(%d) suljettaessa avainta:  Software\\TigerVNC\\vncviewer"
@@ -1318,7 +1472,9 @@ msgstr "Etätyöpöytäkatselin"
 #~ msgstr "Avainkoodille %d (0x%04x) on annettu useita merkkejä: ’%s’"
 
 #~ msgid "The parameterArray contains a object of a invalid type at line %d."
-#~ msgstr "Komponentti parameterArray sisältää rivillä %d tyypiltään virheellisen objektin."
+#~ msgstr ""
+#~ "Komponentti parameterArray sisältää rivillä %d tyypiltään virheellisen "
+#~ "objektin."
 
 #~ msgid "The value of the parameter %s on line %d in file %s is invalid."
 #~ msgstr "Parametrin %s arvo rivillä %d tiedostossa %s on virheellinen."
@@ -1335,29 +1491,65 @@ msgstr "Etätyöpöytäkatselin"
 #~ msgid "Using default colormap and visual, %sdepth %d."
 #~ msgstr "Käytetään oletusvärikarttaa ja visuaalisuutta, %s-syvyys %d."
 
-#~ msgid "Could not convert the parameter-name %s to wchar_t* when reading from the Registry, the buffersize is too small."
-#~ msgstr "Parametrinimen %s muuntaminen wchar_t*-tyypiksi epäonnistui kun luetaan Registrystä, puskurikoko on liian pieni."
+#~ msgid ""
+#~ "Could not convert the parameter-name %s to wchar_t* when reading from the "
+#~ "Registry, the buffersize is too small."
+#~ msgstr ""
+#~ "Parametrinimen %s muuntaminen wchar_t*-tyypiksi epäonnistui kun luetaan "
+#~ "Registrystä, puskurikoko on liian pieni."
 
-#~ msgid "Could not convert the parameter-name %s to wchar_t* when writing to the Registry, the buffersize is too small."
-#~ msgstr "Parametrinimen %s muuntaminen wchar_t*-tyypiksi epäonnistui kun kirjoitetaan Registryyn, puskurikoko on liian pieni."
+#~ msgid ""
+#~ "Could not convert the parameter-name %s to wchar_t* when writing to the "
+#~ "Registry, the buffersize is too small."
+#~ msgstr ""
+#~ "Parametrinimen %s muuntaminen wchar_t*-tyypiksi epäonnistui kun "
+#~ "kirjoitetaan Registryyn, puskurikoko on liian pieni."
 
-#~ msgid "Could not convert the parameter-value %s to wchar_t* when writing to the Registry, the buffersize is too small."
-#~ msgstr "Parametriarvon %s muuntaminen wchar_t*-tyypiksi epäonnistui kun kirjoitetaan Registryyn, puskurikoko on liian pieni."
+#~ msgid ""
+#~ "Could not convert the parameter-value %s to wchar_t* when writing to the "
+#~ "Registry, the buffersize is too small."
+#~ msgstr ""
+#~ "Parametriarvon %s muuntaminen wchar_t*-tyypiksi epäonnistui kun "
+#~ "kirjoitetaan Registryyn, puskurikoko on liian pieni."
 
-#~ msgid "Could not convert the parameter-value for %s to utf8 char* when reading from the Registry, the buffer dest is too small."
-#~ msgstr "Parametriarvon %s muuntaminen utf8 char*-tyypiksi epäonnistui kun luetaan Registrystä, puskurikohde on liian pieni."
+#~ msgid ""
+#~ "Could not convert the parameter-value for %s to utf8 char* when reading "
+#~ "from the Registry, the buffer dest is too small."
+#~ msgstr ""
+#~ "Parametriarvon %s muuntaminen utf8 char*-tyypiksi epäonnistui kun luetaan "
+#~ "Registrystä, puskurikohde on liian pieni."
 
-#~ msgid "Decoding: The size of the buffer dest is too small, it needs to be 1 byte bigger."
-#~ msgstr "Koodauksen purku: Puskurikohteen koko on liian pieni, sen on oltava yhden merkin suurempi."
+#~ msgid ""
+#~ "Decoding: The size of the buffer dest is too small, it needs to be 1 byte "
+#~ "bigger."
+#~ msgstr ""
+#~ "Koodauksen purku: Puskurikohteen koko on liian pieni, sen on oltava yhden "
+#~ "merkin suurempi."
 
-#~ msgid "Encoding backslash: The size of the buffer dest is too small, it needs to be more than %d bytes bigger."
-#~ msgstr "Koodataan kenoviiva: Puskurikohteen koko on liian pieni, sen on oltava yli %d merkkiä suurempi."
+#~ msgid ""
+#~ "Encoding backslash: The size of the buffer dest is too small, it needs to "
+#~ "be more than %d bytes bigger."
+#~ msgstr ""
+#~ "Koodataan kenoviiva: Puskurikohteen koko on liian pieni, sen on oltava "
+#~ "yli %d merkkiä suurempi."
 
-#~ msgid "Encoding escape sequence: The size of the buffer dest is too small, it needs to be more than %d bytes bigger."
-#~ msgstr "Koodinvaihtosekvenssin koodaus: Puskurikohteen koko on liian pieni, sen on oltava yli %d merkkiä suurempi."
+#~ msgid ""
+#~ "Encoding escape sequence: The size of the buffer dest is too small, it "
+#~ "needs to be more than %d bytes bigger."
+#~ msgstr ""
+#~ "Koodinvaihtosekvenssin koodaus: Puskurikohteen koko on liian pieni, sen "
+#~ "on oltava yli %d merkkiä suurempi."
 
-#~ msgid "Encoding normal character: The size of the buffer dest is too small, it needs to be more than %d bytes bigger."
-#~ msgstr "Normaalin merkin koodaus: Puskurikohteen koko on liian pieni, sen on oltava yli %d merkkiä suurempi."
+#~ msgid ""
+#~ "Encoding normal character: The size of the buffer dest is too small, it "
+#~ "needs to be more than %d bytes bigger."
+#~ msgstr ""
+#~ "Normaalin merkin koodaus: Puskurikohteen koko on liian pieni, sen on "
+#~ "oltava yli %d merkkiä suurempi."
 
-#~ msgid "Could not read the line(%d) in the configuration file,the buffersize is too small."
-#~ msgstr "Rivin(%d) lukeminen asetustiedostossa epäonnistui, puskurikoko on liian pieni. "
+#~ msgid ""
+#~ "Could not read the line(%d) in the configuration file,the buffersize is "
+#~ "too small."
+#~ msgstr ""
+#~ "Rivin(%d) lukeminen asetustiedostossa epäonnistui, puskurikoko on liian "
+#~ "pieni. "

--- a/po/fr.po
+++ b/po/fr.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.12.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2022-12-15 16:35+0100\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2023-08-15 12:33+0200\n"
 "Last-Translator: Stéphane Aulery <lkppo@free.fr>\n"
 "Language-Team: French <traduc@traduc.org>\n"
@@ -38,7 +38,7 @@ msgstr "Connecté au socket %s"
 msgid "Connected to host %s port %d"
 msgstr "Connecté à l’hôte %s par le port %d"
 
-#: vncviewer/CConn.cxx:114
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -49,364 +49,426 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:159
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Nom du bureau : %.80s"
 
-#: vncviewer/CConn.cxx:164
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Hôte : %.80s port : %d"
 
-#: vncviewer/CConn.cxx:169
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Taille : %d x %d"
 
-#: vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Format de pixel : %s"
 
-#: vncviewer/CConn.cxx:184
-#, c-format
-msgid "(server default %s)"
-msgstr "(serveur par défaut %s)"
-
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Encodage demandé : %s"
 
-#: vncviewer/CConn.cxx:194
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Dernier encodage utilisé : %s"
 
-#: vncviewer/CConn.cxx:199
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Vitesse estimée de la connexion : %d kbit/s"
 
-#: vncviewer/CConn.cxx:204
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Version du protocol : %d.%d"
 
-#: vncviewer/CConn.cxx:209
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Méthode de sécurité : %s"
 
-#: vncviewer/CConn.cxx:270 vncviewer/CConn.cxx:272
-msgid "The connection was dropped by the server before the session could be established."
-msgstr "La connexion à été fermée par le serveur avant la la fin de l'ouverture de la session."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
+msgstr ""
+"La connexion à été fermée par le serveur avant la la fin de l'ouverture de "
+"la session."
 
-#: vncviewer/CConn.cxx:332
+#: vncviewer/CConn.cxx:258
 #, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "SetDesktopSize échoué : %d"
+msgid "Authentication failed: %s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:404
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "Opération SetColourMapEntries du serveur invalide !"
+#: vncviewer/CConn.cxx:259
+#, c-format
+msgid ""
+"Failed to authenticate with the server. Reason given by the server:\n"
+"\n"
+"%s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:512
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Débit %d kbit/s - %d pour une meilleure qualité"
 
-#: vncviewer/CConn.cxx:534
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "Débit %d ko/s - pleine couleur activée"
 
-#: vncviewer/CConn.cxx:537
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "Débit %d ko/s - pleine couleur désactivée"
 
-#: vncviewer/CConn.cxx:563
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Utilisation du format de pixel %s"
 
-#: vncviewer/DesktopWindow.cxx:145
+#: vncviewer/DesktopWindow.cxx:146
 msgid "Invalid geometry specified!"
 msgstr "Géométrie spécifiée invalide !"
 
-#: vncviewer/DesktopWindow.cxx:166
+#: vncviewer/DesktopWindow.cxx:167
 msgid "Reducing window size to fit on current monitor"
 msgstr "Réduction de la taille de la fenêtre pour l'adapter au moniteur actuel"
 
-#: vncviewer/DesktopWindow.cxx:648
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
-msgstr "Ajustement de la taille de la fenêtre pour éviter une demande accidentelle de plein écran"
+msgstr ""
+"Ajustement de la taille de la fenêtre pour éviter une demande accidentelle "
+"de plein écran"
 
-#: vncviewer/DesktopWindow.cxx:696
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Appuyez sur %s pour ouvrir le menu contextuel"
 
-#: vncviewer/DesktopWindow.cxx:1083 vncviewer/DesktopWindow.cxx:1091
-#: vncviewer/DesktopWindow.cxx:1111
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Échec de saisie clavier"
 
-#: vncviewer/DesktopWindow.cxx:1401
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
-msgstr "Calcul de sortie d’écran invalide pour la demande de redimensionnement !"
+msgstr ""
+"Calcul de sortie d’écran invalide pour la demande de redimensionnement !"
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "État invalide pour une émulation à 3 boutons"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:105
+#: vncviewer/KeyboardWin32.cxx:243
+#, c-format
+msgid "No scan code for extended virtual key 0x%02x"
+msgstr "Pas de scan code pour la clef virtuelle étendue 0x%02x"
+
+#: vncviewer/KeyboardWin32.cxx:245
+#, c-format
+msgid "No scan code for virtual key 0x%02x"
+msgstr "Pas de scan code pour la clef virtuelle 0x%02x"
+
+#: vncviewer/KeyboardWin32.cxx:251
+#, c-format
+msgid "Invalid scan code 0x%02x"
+msgstr "Scan code 0x%02x invalide"
+
+#: vncviewer/KeyboardWin32.cxx:263
+#, c-format
+msgid "No symbol for extended virtual key 0x%02x"
+msgstr "Pas de symbole pour la clef virtuelle étendue 0x%02x"
+
+#: vncviewer/KeyboardWin32.cxx:265
+#, c-format
+msgid "No symbol for virtual key 0x%02x"
+msgstr "Pas de symbole pour la clef virtuelle 0x%02x"
+
+#: vncviewer/KeyboardWin32.cxx:424
+#, c-format
+msgid "Failed to update keyboard LED state: %lu"
+msgstr "Échec de la mise à jour de l'état de la LED du clavier : %lu"
+
+#: vncviewer/KeyboardX11.cxx:123
+#, c-format
+msgid "No symbol for key code %d (in the current state)"
+msgstr "Pas de scan code pour le code clef %d (en l'état actuel)"
+
+#: vncviewer/KeyboardX11.cxx:148
+#, c-format
+msgid "Failed to get keyboard LED state: %d"
+msgstr "Impossible de récupérer l'état de la LED du clavier : %d"
+
+#: vncviewer/KeyboardX11.cxx:193
+msgid "Failed to update keyboard LED state"
+msgstr "Échec de la mise à jour de l'état de la LED du clavier"
+
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "Impossible de lire la configuration de l'écran"
 
-#: vncviewer/MonitorIndicesParameter.cxx:83
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "Configuration incorrecte de %s"
-
-#: vncviewer/MonitorIndicesParameter.cxx:91
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "L'index d'écran %d n'existe pas"
 
-#: vncviewer/MonitorIndicesParameter.cxx:169
-#: vncviewer/MonitorIndicesParameter.cxx:189
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "index d'écran '%s' incorrecte"
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
+msgid "TigerVNC options"
+msgstr ""
 
-#: vncviewer/MonitorIndicesParameter.cxx:177
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "Caractère inattendu '%c'"
-
-#: vncviewer/OptionsDialog.cxx:63
-msgid "VNC Viewer: Connection Options"
-msgstr "Visionneuse VNC : options de la connexion"
-
-#: vncviewer/OptionsDialog.cxx:89 vncviewer/ServerDialog.cxx:108
-#: vncviewer/vncviewer.cxx:417
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "Annuler"
 
-#: vncviewer/OptionsDialog.cxx:94 vncviewer/vncviewer.cxx:416
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "Ok"
 
-#: vncviewer/OptionsDialog.cxx:484
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "Compression"
 
-#: vncviewer/OptionsDialog.cxx:501
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "Sélection automatique"
 
-#: vncviewer/OptionsDialog.cxx:516
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "Encodage préféré"
 
-#: vncviewer/OptionsDialog.cxx:574
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "Niveau de couleur"
 
-#: vncviewer/OptionsDialog.cxx:585
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "Complet"
 
-#: vncviewer/OptionsDialog.cxx:592
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "Moyen"
 
-#: vncviewer/OptionsDialog.cxx:599
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "Bas"
 
-#: vncviewer/OptionsDialog.cxx:606
+#: vncviewer/OptionsDialog.cxx:635
 msgid "Very low"
 msgstr "Très bas"
 
-#: vncviewer/OptionsDialog.cxx:624
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "Niveau de compression personnalisé :"
 
-#: vncviewer/OptionsDialog.cxx:630
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "niveau (0=rapide, 9=optimale)"
 
-#: vncviewer/OptionsDialog.cxx:637
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "Autoriser la compression JPEG :"
 
-#: vncviewer/OptionsDialog.cxx:643
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "qualité (0=faible, 9=optimale)"
 
-#: vncviewer/OptionsDialog.cxx:654
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "Sécurité"
 
-#: vncviewer/OptionsDialog.cxx:676
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "Cryptage"
 
-#: vncviewer/OptionsDialog.cxx:687 vncviewer/OptionsDialog.cxx:750
-#: vncviewer/OptionsDialog.cxx:854
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "Aucun"
 
-#: vncviewer/OptionsDialog.cxx:694
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "TLS avec certificats anonymes"
 
-#: vncviewer/OptionsDialog.cxx:700
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "TLS avec certificat X509"
 
-#: vncviewer/OptionsDialog.cxx:707
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "Certificat du chemin pour X509 CA"
 
-#: vncviewer/OptionsDialog.cxx:714
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "Fichier du chemin pour X509 CRL"
 
-#: vncviewer/OptionsDialog.cxx:739
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "Authentification"
 
-#: vncviewer/OptionsDialog.cxx:756
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "VNC standard (non sécurisé et sans cryptage)"
 
-#: vncviewer/OptionsDialog.cxx:762
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "Nom d’utilisateur et mot de passe (non sécurisé et sans cryptage)"
 
-#: vncviewer/OptionsDialog.cxx:781
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "Entrée"
 
-#: vncviewer/OptionsDialog.cxx:794
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "Vue passive (ignorer la souris et le clavier)"
 
-#: vncviewer/OptionsDialog.cxx:801
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "Souris"
 
-#: vncviewer/OptionsDialog.cxx:815
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "Émulation du bouton de souris du milieu"
 
-#: vncviewer/OptionsDialog.cxx:821
-msgid "Show dot when no cursor"
-msgstr "Afficher un point s’il n’y a pas de curseur"
+#: vncviewer/OptionsDialog.cxx:880
+msgid "Show local cursor when not provided by server"
+msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:835
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
+msgid "Cursor type"
+msgstr ""
+
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
+msgid "Dot"
+msgstr ""
+
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
+msgid "System"
+msgstr ""
+
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "Clavier"
 
-#: vncviewer/OptionsDialog.cxx:849
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
 msgstr "Donner directement les clefs système au serveur (plein écran)"
 
-#: vncviewer/OptionsDialog.cxx:852
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "Menu clef"
 
-#: vncviewer/OptionsDialog.cxx:871
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "Presse-papiers"
 
-#: vncviewer/OptionsDialog.cxx:885
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "Accepter le presse-papier du serveur"
 
-#: vncviewer/OptionsDialog.cxx:893
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "Définir également la sélection principale"
 
-#: vncviewer/OptionsDialog.cxx:900
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "Envoyer le presse-papier au serveur"
 
-#: vncviewer/OptionsDialog.cxx:908
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "Envoyer la sélection principale vers le presse-papiers"
 
-#: vncviewer/OptionsDialog.cxx:927
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "Affichage"
 
-#: vncviewer/OptionsDialog.cxx:941
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "Mode d'affichage"
 
-#: vncviewer/OptionsDialog.cxx:956
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "Fenêtré"
 
-#: vncviewer/OptionsDialog.cxx:964
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "Plein écran sur l'écran actuel"
 
-#: vncviewer/OptionsDialog.cxx:972
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "Plein écran sur tous les écrans"
 
-#: vncviewer/OptionsDialog.cxx:980
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "Plein écran sur les écrans sélectionnés"
 
-#: vncviewer/OptionsDialog.cxx:1007
-msgid "Misc."
-msgstr "Divers"
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
+msgid "Miscellaneous"
+msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:1015
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "Partagé (ne pas déconnecter les autres visionneuses)"
 
-#: vncviewer/OptionsDialog.cxx:1021
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "Demander la reconnexion lorsqu'elle est perdue"
 
-#: vncviewer/ServerDialog.cxx:58
-msgid "VNC Viewer: Connection Details"
-msgstr "Visionneuse VNC : détails de la connexion"
-
-#: vncviewer/ServerDialog.cxx:65 vncviewer/ServerDialog.cxx:70
+#: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
 msgstr "Serveur VNC :"
 
-#: vncviewer/ServerDialog.cxx:81
+#: vncviewer/ServerDialog.cxx:80
 msgid "Options..."
 msgstr "Options…"
 
-#: vncviewer/ServerDialog.cxx:86
+#: vncviewer/ServerDialog.cxx:84
 msgid "Load..."
 msgstr "Chargement…"
 
-#: vncviewer/ServerDialog.cxx:91
-msgid "Save As..."
-msgstr "Enregistrer sous…"
+#: vncviewer/ServerDialog.cxx:88
+msgid "Save as..."
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:103
+#: vncviewer/ServerDialog.cxx:102
 msgid "About..."
 msgstr "À propos…"
 
-#: vncviewer/ServerDialog.cxx:113
+#: vncviewer/ServerDialog.cxx:111
 msgid "Connect"
 msgstr "Connexion"
 
-#: vncviewer/ServerDialog.cxx:145
+#: vncviewer/ServerDialog.cxx:147
 #, c-format
 msgid ""
 "Unable to load the server history:\n"
@@ -417,15 +479,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:173 vncviewer/ServerDialog.cxx:212
+#: vncviewer/ServerDialog.cxx:176 vncviewer/ServerDialog.cxx:216
 msgid "TigerVNC configuration (*.tigervnc)"
 msgstr "Configuration TigerVNC (*.tigervnc)"
 
-#: vncviewer/ServerDialog.cxx:174
+#: vncviewer/ServerDialog.cxx:177
 msgid "Select a TigerVNC configuration file"
 msgstr "Sélectionner un fichier de configuration TigerVNC"
 
-#: vncviewer/ServerDialog.cxx:196 vncviewer/vncviewer.cxx:552
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -436,24 +498,24 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:213
+#: vncviewer/ServerDialog.cxx:217
 msgid "Save the TigerVNC configuration to file"
 msgstr "Enregistrer le fichier de configuration TigerVNC"
 
-#: vncviewer/ServerDialog.cxx:239
+#: vncviewer/ServerDialog.cxx:243
 #, c-format
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "%s existe déjà. Souhaitez vous l'écraser ?"
 
-#: vncviewer/ServerDialog.cxx:240 vncviewer/vncviewer.cxx:414
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "Non"
 
-#: vncviewer/ServerDialog.cxx:240
+#: vncviewer/ServerDialog.cxx:244
 msgid "Overwrite"
 msgstr "Ecraser"
 
-#: vncviewer/ServerDialog.cxx:256
+#: vncviewer/ServerDialog.cxx:260
 #, c-format
 msgid ""
 "Unable to save the specified configuration file:\n"
@@ -464,7 +526,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:290
+#: vncviewer/ServerDialog.cxx:294
 #, c-format
 msgid ""
 "Unable to save the default configuration:\n"
@@ -475,7 +537,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:303
+#: vncviewer/ServerDialog.cxx:306
 #, c-format
 msgid ""
 "Unable to save the server history:\n"
@@ -486,230 +548,171 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:320 vncviewer/ServerDialog.cxx:387
-#: vncviewer/parameters.cxx:635 vncviewer/parameters.cxx:740
-#: vncviewer/vncviewer.cxx:459
-msgid "Could not obtain the home directory path"
-msgstr "Impossible de détecter le chemin du dossier personnel de l'utilisateur"
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
+msgid "Could not determine VNC state directory path"
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:333 vncviewer/ServerDialog.cxx:396
-#: vncviewer/parameters.cxx:646 vncviewer/parameters.cxx:753
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
-msgid "Could not open \"%s\": %s"
-msgstr "Impossible d'ouvrir \"%s\" : %s"
+msgid "Could not open \"%s\""
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:348 vncviewer/ServerDialog.cxx:356
-#: vncviewer/parameters.cxx:767 vncviewer/parameters.cxx:773
-#: vncviewer/parameters.cxx:804 vncviewer/parameters.cxx:833
-#: vncviewer/parameters.cxx:839
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
-msgid "Failed to read line %d in file %s: %s"
-msgstr "Impossible de lire la ligne %d du fichier %s : %s"
+msgid "Failed to read line %d in file \"%s\""
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:357 vncviewer/parameters.cxx:774
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "Ligne trop longue"
 
-#: vncviewer/UserDialog.cxx:98
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "Échec de l’ouverture du fichier mot de passe"
 
-#: vncviewer/UserDialog.cxx:118
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "Authentification VNC"
 
-#: vncviewer/UserDialog.cxx:125
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "Cette connexion est sécurisée"
 
-#: vncviewer/UserDialog.cxx:129
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "Cette connexion n'est pas sécurisée"
 
-#: vncviewer/UserDialog.cxx:146
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "Nom d’utilisateur :"
 
-#: vncviewer/UserDialog.cxx:159
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "Mot de passe :"
 
-#: vncviewer/UserDialog.cxx:198
-msgid "Authentication cancelled"
-msgstr "Authentification annulée"
+#: vncviewer/UserDialog.cxx:204
+msgid "Keep password for reconnect"
+msgstr ""
 
-#: vncviewer/Viewport.cxx:391
-#, c-format
-msgid "Failed to update keyboard LED state: %lu"
-msgstr "Échec de la mise à jour de l'état de la LED du clavier : %lu"
-
-#: vncviewer/Viewport.cxx:397 vncviewer/Viewport.cxx:403
-#, c-format
-msgid "Failed to update keyboard LED state: %d"
-msgstr "Échec de la mise à jour de l'état de la LED du clavier : %d"
-
-#: vncviewer/Viewport.cxx:433
-msgid "Failed to update keyboard LED state"
-msgstr "Échec de la mise à jour de l'état de la LED du clavier"
-
-#: vncviewer/Viewport.cxx:460 vncviewer/Viewport.cxx:468
-#: vncviewer/Viewport.cxx:485
-#, c-format
-msgid "Failed to get keyboard LED state: %d"
-msgstr "Impossible de récupérer l'état de la LED du clavier : %d"
-
-#: vncviewer/Viewport.cxx:849
-msgid "No key code specified on key press"
-msgstr "Aucun code de touche défini à l'enfoncement de touche"
-
-#: vncviewer/Viewport.cxx:1008
-#, c-format
-msgid "No scan code for extended virtual key 0x%02x"
-msgstr "Pas de scan code pour la clef virtuelle étendue 0x%02x"
-
-#: vncviewer/Viewport.cxx:1010
-#, c-format
-msgid "No scan code for virtual key 0x%02x"
-msgstr "Pas de scan code pour la clef virtuelle 0x%02x"
-
-#: vncviewer/Viewport.cxx:1016
-#, c-format
-msgid "Invalid scan code 0x%02x"
-msgstr "Scan code 0x%02x invalide"
-
-#: vncviewer/Viewport.cxx:1046
-#, c-format
-msgid "No symbol for extended virtual key 0x%02x"
-msgstr "Pas de symbole pour la clef virtuelle étendue 0x%02x"
-
-#: vncviewer/Viewport.cxx:1048
-#, c-format
-msgid "No symbol for virtual key 0x%02x"
-msgstr "Pas de symbole pour la clef virtuelle 0x%02x"
-
-#: vncviewer/Viewport.cxx:1154
-#, c-format
-msgid "No symbol for key code 0x%02x (in the current state)"
-msgstr "Pas de scan code pour le code clef 0x%02x (en l'état actuel)"
-
-#: vncviewer/Viewport.cxx:1187
-#, c-format
-msgid "No symbol for key code %d (in the current state)"
-msgstr "Pas de scan code pour le code clef %d (en l'état actuel)"
-
-#: vncviewer/Viewport.cxx:1247
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
-msgid "Dis&connect"
-msgstr "Dé&connecter"
+msgid "Disconn&ect"
+msgstr ""
 
-#: vncviewer/Viewport.cxx:1250
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "&Plein écran"
 
-#: vncviewer/Viewport.cxx:1253
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "&Réduire"
 
-#: vncviewer/Viewport.cxx:1255
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "Redimensionner la &fenêtre pour la session"
 
-#: vncviewer/Viewport.cxx:1260
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:1263
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:1269
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "Envoyer %s"
 
-#: vncviewer/Viewport.cxx:1275
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Envoyer Ctrl-Alt-&Sup"
 
-#: vncviewer/Viewport.cxx:1278
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "R&afraîchir l’écran"
 
-#: vncviewer/Viewport.cxx:1281
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&Options…"
 
-#: vncviewer/Viewport.cxx:1283
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "&Informations de connexion…"
 
-#: vncviewer/Viewport.cxx:1285
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "À propos de la visionneuse &TigerVNC…"
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:1374
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "Informations de la connexion VNC"
 
-#: vncviewer/Win32TouchHandler.cxx:47
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "La fenêtre est enregistrée pour le tactile au lieu des mouvements"
 
-#: vncviewer/Win32TouchHandler.cxx:81
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "Impossible de modifier la configuration des mouvements (erreur 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:93
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "Impossible de lire la configuration des mouvements (erreur 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:358
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr "Bouton de souris %d incorrecte (doit être un chiffre entre 1 et 7)."
 
-#: vncviewer/Win32TouchHandler.cxx:423
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
 msgstr "Touche inconnue 0x%x - impossible de générer un évênement clavier"
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:107
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
-msgstr "Impossible de lire le masque d'événement X Input 2 pour la fenêtre 0x%08lx"
+msgstr ""
+"Impossible de lire le masque d'événement X Input 2 pour la fenêtre 0x%08lx"
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr "La fenêtre 0x%08lx n'a pas de masque d'événement X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:114
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr "La fenêtre 0x%08lx a plus d'un masque d'événement X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "Échec de saisie souris %i"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-#: vncviewer/vncviewer.cxx:406 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC Viewer"
-msgstr "Visionneuse TigerVNC"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -717,95 +720,128 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr "Se connecter à un serveur VNC et afficher le bureau à distance"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
-msgstr "Virtual Network Computing (VNC) est un système d'affichage à distance qui permet de visualiser et d'interagir avec un environnement de bureau virtuel exécuté sur un autre ordinateur du réseau. À l'aide de VNC, vous pouvez exécuter des applications graphiques sur une machine distante et envoyer uniquement l'affichage de ces applications à votre périphérique local. Ce package contient un client qui vous permettra de vous connecter à d'autres bureaux exécutant un serveur VNC. VNC est indépendant de la plate-forme et prend en charge divers systèmes d'exploitation et architectures en tant que serveurs et clients."
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+"Virtual Network Computing (VNC) est un système d'affichage à distance qui "
+"permet de visualiser et d'interagir avec un environnement de bureau virtuel "
+"exécuté sur un autre ordinateur du réseau. À l'aide de VNC, vous pouvez "
+"exécuter des applications graphiques sur une machine distante et envoyer "
+"uniquement l'affichage de ces applications à votre périphérique local. Ce "
+"package contient un client qui vous permettra de vous connecter à d'autres "
+"bureaux exécutant un serveur VNC. VNC est indépendant de la plate-forme et "
+"prend en charge divers systèmes d'exploitation et architectures en tant que "
+"serveurs et clients."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
-msgstr "TigerVNC est une version optimisée pour la vitesse de VNC basée sur le code de RealVNC 4 et X.org. TigerVNC a commencé comme une réécriture de TightVNC pour les plates-formes Unix et Linux, puis il a pris son autonomie début de 2009 afin que TightVNC puisse se concentrer sur les plates-formes Windows. TigerVNC prend en charge une variante de l'encodage Tight qui tire sa rapidité de l'utilisation du codec JPEG libjpeg-turbo."
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+"TigerVNC est une version optimisée pour la vitesse de VNC basée sur le code "
+"de RealVNC 4 et X.org. TigerVNC a commencé comme une réécriture de TightVNC "
+"pour les plates-formes Unix et Linux, puis il a pris son autonomie début de "
+"2009 afin que TightVNC puisse se concentrer sur les plates-formes Windows. "
+"TigerVNC prend en charge une variante de l'encodage Tight qui tire sa "
+"rapidité de l'utilisation du codec JPEG libjpeg-turbo."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC Viewer connection to a CentOS machine"
-msgstr "Connexion de TigerVNC Viewer à une machine CentOS"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC Viewer connection to a macOS machine"
-msgstr "Connexion de TigerVNC Viewer à une machine macOS"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC Viewer connection to a Windows machine"
-msgstr "Connexion de TigerVNC Viewer à une machine Windows"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
-#: vncviewer/parameters.cxx:308 vncviewer/parameters.cxx:333
-#: vncviewer/parameters.cxx:350 vncviewer/parameters.cxx:390
-#: vncviewer/parameters.cxx:410
+#. developer_name tag deprecated with Appstream 1.0
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
+msgid "The TigerVNC team"
+msgstr ""
+
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "Le nom du paramètre était trop long"
 
-#: vncviewer/parameters.cxx:312 vncviewer/parameters.cxx:317
-#: vncviewer/parameters.cxx:368
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "Le paramètre est trop long"
 
-#: vncviewer/parameters.cxx:375 vncviewer/parameters.cxx:696
-#: vncviewer/parameters.cxx:818
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "Format invalide ou valeur trop grande"
 
-#: vncviewer/parameters.cxx:429 vncviewer/parameters.cxx:460
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "Impossible de créer la clef de registre"
 
-#: vncviewer/parameters.cxx:448 vncviewer/parameters.cxx:503
-#: vncviewer/parameters.cxx:545 vncviewer/parameters.cxx:612
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "Impossible de fermer la clef de registre"
 
-#: vncviewer/parameters.cxx:466 vncviewer/parameters.cxx:483
-#: vncviewer/parameters.cxx:654 vncviewer/parameters.cxx:664
-#: vncviewer/parameters.cxx:675
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "Échec de l'enregistrement de \"%s\" : %s"
 
-#: vncviewer/parameters.cxx:479 vncviewer/parameters.cxx:567
-#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:714
-msgid "Unknown parameter type"
-msgstr "Type de paramètre inconnu"
-
-#: vncviewer/parameters.cxx:496
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "Échec de la suppression de \"%s\" : %s"
 
-#: vncviewer/parameters.cxx:518 vncviewer/parameters.cxx:590
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "Impossible d’ouvrir la clef de registre"
 
-#: vncviewer/parameters.cxx:535
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "Impossible de lire l'entrée de l'historique du serveur %d : %s"
 
-#: vncviewer/parameters.cxx:571 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "Impossible de lire le paramètre \"%s\" : %s"
 
-#: vncviewer/parameters.cxx:655 vncviewer/parameters.cxx:666
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
+msgid "Could not determine VNC config directory path"
+msgstr ""
+
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "Impossible d'encoder le paramètre"
 
-#: vncviewer/parameters.cxx:783
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "Fichier de configuration %s dans un format invalide"
 
-#: vncviewer/parameters.cxx:805
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "Format invalide"
 
-#: vncviewer/parameters.cxx:840
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "Paramètre inconnu"
 
@@ -827,61 +863,63 @@ msgstr "Impossible de créer le gestionnaire de touche : %s"
 #: vncviewer/touch.cxx:188
 #, c-format
 msgid "Couldn't attach event handler to window (error 0x%x)"
-msgstr "Impossible d'attacher le gestionnaire d'événement à la fenêtre (erreur 0x%x)"
+msgstr ""
+"Impossible d'attacher le gestionnaire d'événement à la fenêtre (erreur 0x%x)"
 
-#: vncviewer/touch.cxx:212
+#: vncviewer/touch.cxx:215
 msgid "Failed to get event data for X Input event"
 msgstr "Impossible de lire les données d'un évènement X Input"
 
-#: vncviewer/touch.cxx:225
+#: vncviewer/touch.cxx:228
 msgid "X Input event for unknown window"
 msgstr "Événement X Input pour une fenêtre inconnue"
 
-#: vncviewer/touch.cxx:251
+#: vncviewer/touch.cxx:254
 msgid "X Input extension not available."
 msgstr "Extension X Input indisponible"
 
-#: vncviewer/touch.cxx:258
+#: vncviewer/touch.cxx:261
 msgid "X Input 2 (or newer) is not available."
 msgstr "X Input 2 indisponible ou de version incompatible"
 
-#: vncviewer/touch.cxx:263
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
-msgstr "X Input 2 indisponible ou de version incompatible. Le tactile ne sera pas pris en charge."
+#: vncviewer/touch.cxx:266
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+"X Input 2 indisponible ou de version incompatible. Le tactile ne sera pas "
+"pris en charge."
 
-#: vncviewer/vncviewer.cxx:107
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC Viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
-"Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+"Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"Visionneuse TigerVNC v%s\n"
-"Compilé sur : %s\n"
-"Copyright © 1999-%d L’équipe de TigerVNC et beaucoup d’autres (voir README.rst)\n"
-"Voir https://www.tigervnc.org pour plus d’informations sur TigerVNC."
 
-#: vncviewer/vncviewer.cxx:161
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
 "\n"
 "%s"
 msgstr ""
-"Une erreur inattendue s'est produite pendant la communication avec le serveur :\n"
+"Une erreur inattendue s'est produite pendant la communication avec le "
+"serveur :\n"
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:177
-msgid "About TigerVNC Viewer"
-msgstr "À propos de la visionneuse TigerVNC"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:198
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "Erreur FLTK interne. Procédure de sortie."
 
-#: vncviewer/vncviewer.cxx:217
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -892,79 +930,167 @@ msgstr ""
 "\n"
 "Se reconnecter ?"
 
-#: vncviewer/vncviewer.cxx:248 vncviewer/vncviewer.cxx:260
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Une erreur a démarré une nouvelle visionneuse TigerVNC : %s"
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:269
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC Viewer will now exit."
-msgstr "Signal de fin %d reçu. La visionneuse TigerVNC va se fermer."
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:415
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "Oui"
 
-#: vncviewer/vncviewer.cxx:418
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "Fermer"
 
-#: vncviewer/vncviewer.cxx:423
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "À propos"
 
-#: vncviewer/vncviewer.cxx:426
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "Cacher"
 
-#: vncviewer/vncviewer.cxx:429
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "Quitter"
 
-#: vncviewer/vncviewer.cxx:433
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "Services"
 
-#: vncviewer/vncviewer.cxx:434
-msgid "Hide Others"
-msgstr "Cacher les autres"
+#: vncviewer/vncviewer.cxx:413
+msgid "Hide others"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:435
-msgid "Show All"
-msgstr "Afficher tout"
+#: vncviewer/vncviewer.cxx:414
+msgid "Show all"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:444
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "&Fichier"
 
-#: vncviewer/vncviewer.cxx:447
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "&Nouvelle connexion"
 
-#: vncviewer/vncviewer.cxx:463
+#: vncviewer/vncviewer.cxx:449
 #, c-format
-msgid "Could not create VNC home directory: %s"
-msgstr "Impossible de créer le répertoire VNC de départ : %s"
+msgid ""
+"\n"
+"Usage: %s [parameters] [host][:displayNum]\n"
+"       %s [parameters] [host][::port]\n"
+"       %s [parameters] [unix socket]\n"
+"       %s [parameters] -listen [port]\n"
+"       %s [parameters] [.tigervnc file]\n"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:562
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
-msgstr "FullScreenAllMonitors est obsolète, définissez FullScreenMode avec la valeur 'all' à la place"
+#: vncviewer/vncviewer.cxx:464
+#, c-format
+msgid ""
+"\n"
+"Options:\n"
+"\n"
+"  -display Xdisplay  - Specifies the X display for the viewer window\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
+"                       man page for details.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:471
+#, c-format
+msgid ""
+"\n"
+"Parameters can be turned on with -<param> or off with -<param>=0\n"
+"Parameters which take a value can be specified as -<param> <value>\n"
+"Other valid forms are <param>=<value> -<param>=<value> --<param>=<value>\n"
+"Parameter names are case-insensitive.  The parameters are:\n"
+"\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+"FullScreenAllMonitors est obsolète, définissez FullScreenMode avec la valeur "
+"'all' à la place"
+
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:556
+#, c-format
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:561
+#, c-format
+msgid "Could not create VNC config directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:567
+msgid "Could not determine VNC data directory path"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:573
+#, c-format
+msgid "Could not create VNC data directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:585
+#, c-format
+msgid "Could not create VNC state directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:704
+#, c-format
+msgid "%s: Unrecognized option '%s'\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
+#, c-format
+msgid "See '%s --help' for more information.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:713
+#, c-format
+msgid "%s: Extra argument '%s'\n"
+msgstr ""
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:768 vncviewer/vncviewer.cxx:769
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "Les paramètres -listen et -via sont incompatibles"
 
-#: vncviewer/vncviewer.cxx:783
+#: vncviewer/vncviewer.cxx:764
+msgid "Unable to listen for incoming connections"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "Écoute du port %d"
 
-#: vncviewer/vncviewer.cxx:816
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -975,9 +1101,142 @@ msgstr ""
 "\n"
 "%s"
 
+#: vncviewer/vncviewer.cxx:816
+#, c-format
+msgid ""
+"Failure setting up encrypted tunnel:\n"
+"\n"
+"%s"
+msgstr ""
+
 #: vncviewer/vncviewer.desktop.in.in:4
-msgid "Remote Desktop Viewer"
-msgstr "Visionneuse de bureau à distance"
+msgid "Remote desktop viewer"
+msgstr ""
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(serveur par défaut %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "SetDesktopSize échoué : %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "Opération SetColourMapEntries du serveur invalide !"
+
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "Configuration incorrecte de %s"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "index d'écran '%s' incorrecte"
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "Caractère inattendu '%c'"
+
+#~ msgid "VNC Viewer: Connection Options"
+#~ msgstr "Visionneuse VNC : options de la connexion"
+
+#~ msgid "Show dot when no cursor"
+#~ msgstr "Afficher un point s’il n’y a pas de curseur"
+
+#~ msgid "Misc."
+#~ msgstr "Divers"
+
+#~ msgid "VNC Viewer: Connection Details"
+#~ msgstr "Visionneuse VNC : détails de la connexion"
+
+#~ msgid "Save As..."
+#~ msgstr "Enregistrer sous…"
+
+#~ msgid "Could not obtain the home directory path"
+#~ msgstr ""
+#~ "Impossible de détecter le chemin du dossier personnel de l'utilisateur"
+
+#, c-format
+#~ msgid "Could not open \"%s\": %s"
+#~ msgstr "Impossible d'ouvrir \"%s\" : %s"
+
+#, c-format
+#~ msgid "Failed to read line %d in file %s: %s"
+#~ msgstr "Impossible de lire la ligne %d du fichier %s : %s"
+
+#~ msgid "Authentication cancelled"
+#~ msgstr "Authentification annulée"
+
+#, c-format
+#~ msgid "Failed to update keyboard LED state: %d"
+#~ msgstr "Échec de la mise à jour de l'état de la LED du clavier : %d"
+
+#~ msgid "No key code specified on key press"
+#~ msgstr "Aucun code de touche défini à l'enfoncement de touche"
+
+#, c-format
+#~ msgid "No symbol for key code 0x%02x (in the current state)"
+#~ msgstr "Pas de scan code pour le code clef 0x%02x (en l'état actuel)"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "Dis&connect"
+#~ msgstr "Dé&connecter"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "À propos de la visionneuse &TigerVNC…"
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "Visionneuse TigerVNC"
+
+#~ msgid "TigerVNC Viewer connection to a CentOS machine"
+#~ msgstr "Connexion de TigerVNC Viewer à une machine CentOS"
+
+#~ msgid "TigerVNC Viewer connection to a macOS machine"
+#~ msgstr "Connexion de TigerVNC Viewer à une machine macOS"
+
+#~ msgid "TigerVNC Viewer connection to a Windows machine"
+#~ msgstr "Connexion de TigerVNC Viewer à une machine Windows"
+
+#~ msgid "Unknown parameter type"
+#~ msgstr "Type de paramètre inconnu"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC Viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "Visionneuse TigerVNC v%s\n"
+#~ "Compilé sur : %s\n"
+#~ "Copyright © 1999-%d L’équipe de TigerVNC et beaucoup d’autres (voir "
+#~ "README.rst)\n"
+#~ "Voir https://www.tigervnc.org pour plus d’informations sur TigerVNC."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "À propos de la visionneuse TigerVNC"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Une erreur a démarré une nouvelle visionneuse TigerVNC : %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC Viewer will now exit."
+#~ msgstr "Signal de fin %d reçu. La visionneuse TigerVNC va se fermer."
+
+#~ msgid "Hide Others"
+#~ msgstr "Cacher les autres"
+
+#~ msgid "Show All"
+#~ msgstr "Afficher tout"
+
+#, c-format
+#~ msgid "Could not create VNC home directory: %s"
+#~ msgstr "Impossible de créer le répertoire VNC de départ : %s"
+
+#~ msgid "Remote Desktop Viewer"
+#~ msgstr "Visionneuse de bureau à distance"
 
 #~ msgid "Failed to get monitor name because X11 RandR could not be found"
 #~ msgstr "Impossible de lire le nom de l'écran car X11 RandR est introuvable"
@@ -986,7 +1245,9 @@ msgstr "Visionneuse de bureau à distance"
 #~ msgstr "Impossible de lire les informations de l'écran cathodique %d"
 
 #~ msgid "Failed to get information about output %d for CRTC %d"
-#~ msgstr "Impossible de lire les informations à propos de %d sur l'écran cathodique %d"
+#~ msgstr ""
+#~ "Impossible de lire les informations à propos de %d sur l'écran cathodique "
+#~ "%d"
 
 #~ msgid "Screen"
 #~ msgstr "Écran"
@@ -1027,7 +1288,8 @@ msgstr "Visionneuse de bureau à distance"
 #~ msgstr "Masquer le &menu"
 
 #~ msgid "Failed to write parameter %s of type %s to the registry: %ld"
-#~ msgstr "Impossible d’écrire le paramètre %s de type %s dans le registre : %ld"
+#~ msgstr ""
+#~ "Impossible d’écrire le paramètre %s de type %s dans le registre : %ld"
 
 #~ msgid "The name of the parameter %s was too large to read from the registry"
 #~ msgstr "Le nom du paramètre %s était trop long pour lire le registre"
@@ -1035,20 +1297,30 @@ msgstr "Visionneuse de bureau à distance"
 #~ msgid "The parameter %s was too large to read from the registry"
 #~ msgstr "Le paramètre %s était trop long pour le lire depuis le registre"
 
-#~ msgid "Failed to write configuration file, can't obtain home directory path."
-#~ msgstr "Impossible d'écrire le fichier de configuration, impossible d'obtenir le chemin du répertoire personnel."
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Impossible d'écrire le fichier de configuration, impossible d'obtenir le "
+#~ "chemin du répertoire personnel."
 
 #~ msgid "Failed to write configuration file, can't open %s: %s"
-#~ msgstr "Impossible d'écrire le fichier de configuration, impossible d’ouvrir %s : %s"
+#~ msgstr ""
+#~ "Impossible d'écrire le fichier de configuration, impossible d’ouvrir %s : "
+#~ "%s"
 
 #~ msgid "Failed to read configuration file, can't obtain home directory path."
-#~ msgstr "Impossible de lire le fichier de configuration, impossible d’obtenir le chemin du répertoire personnel."
+#~ msgstr ""
+#~ "Impossible de lire le fichier de configuration, impossible d’obtenir le "
+#~ "chemin du répertoire personnel."
 
 #~ msgid "Unknown parameter %s on line %d in file %s"
 #~ msgstr "Paramètre %s inconnu à la ligne %d du fichier %s"
 
-#~ msgid "Could not create VNC home directory: can't obtain home directory path."
-#~ msgstr "Impossible de créer le répertoire VNC de départ : impossible d’obtenir le chemin du répertoire de départ."
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
+#~ msgstr ""
+#~ "Impossible de créer le répertoire VNC de départ : impossible d’obtenir le "
+#~ "chemin du répertoire de départ."
 
 #~ msgid "tigervnc"
 #~ msgstr "tigervnc"

--- a/po/fur.po
+++ b/po/fur.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.13.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2024-06-20 15:01+0200\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2024-10-03 17:59+0000\n"
 "Last-Translator: Fabio T. <f.t.public@gmail.com>\n"
 "Language-Team: Friulian <f.t.public@gmail.com>\n"
@@ -20,17 +20,17 @@ msgstr ""
 "X-Editor: HaiPO 2.0 beta\n"
 "X-Generator: Poedit 1.8.12\n"
 
-#: vncviewer/CConn.cxx:99
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "Conetût al socket %s"
 
-#: vncviewer/CConn.cxx:106
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "Conetût al host %s puarte %d"
 
-#: vncviewer/CConn.cxx:111
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -41,85 +41,88 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:155
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Non scritori: %.80s"
 
-#: vncviewer/CConn.cxx:160
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Host: %.80s puarte: %d"
 
-#: vncviewer/CConn.cxx:165
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Dimension: %d × %d"
 
-#: vncviewer/CConn.cxx:173
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Formât pixel: %s"
 
-#: vncviewer/CConn.cxx:180
-#, c-format
-msgid "(server default %s)"
-msgstr "(predefinît dal servidôr %s)"
-
-#: vncviewer/CConn.cxx:185
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Codifiche domandade: %s"
 
-#: vncviewer/CConn.cxx:190
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Ultime codifiche doprade: %s"
 
-#: vncviewer/CConn.cxx:195
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Stime velocitât linie: %d kbit/s"
 
-#: vncviewer/CConn.cxx:200
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Version protocol: %d.%d"
 
-#: vncviewer/CConn.cxx:205
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Metodi sigurece: %s"
 
-#: vncviewer/CConn.cxx:266 vncviewer/CConn.cxx:268
-msgid "The connection was dropped by the server before the session could be established."
-msgstr "La conession e je stade molade dal servidôr prime che la session e fos stade stabilide."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
+msgstr ""
+"La conession e je stade molade dal servidôr prime che la session e fos stade "
+"stabilide."
 
-#: vncviewer/CConn.cxx:326
+#: vncviewer/CConn.cxx:258
 #, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "SetDesktopSize falît: %d"
+msgid "Authentication failed: %s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:399
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "SetColourMapEntries no valit dal servidôr!"
+#: vncviewer/CConn.cxx:259
+#, c-format
+msgid ""
+"Failed to authenticate with the server. Reason given by the server:\n"
+"\n"
+"%s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:507
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Puartade %d kbit/s - si passe ae cualitât %d"
 
-#: vncviewer/CConn.cxx:529
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "Puartade %d kbit/s - plen colôr al è cumò abilitât"
 
-#: vncviewer/CConn.cxx:532
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "Puartade %d kbit/s - plen colôr al è cumò disabilitât"
 
-#: vncviewer/CConn.cxx:558
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Si dopre il formât pixel %s"
@@ -132,273 +135,332 @@ msgstr "Gjeometrie specificade no valide!"
 msgid "Reducing window size to fit on current monitor"
 msgstr "Daûr a ridusi la dimension dal barcon par adatâle al visôr atuâl"
 
-#: vncviewer/DesktopWindow.cxx:648
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
-msgstr "Daûr a justâ la dimension dal barcon par evitâ richiestis acidentâls di plen visôr"
+msgstr ""
+"Daûr a justâ la dimension dal barcon par evitâ richiestis acidentâls di plen "
+"visôr"
 
-#: vncviewer/DesktopWindow.cxx:696
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Frache %s par vierzi il menù contestuâl"
 
-#: vncviewer/DesktopWindow.cxx:1097 vncviewer/DesktopWindow.cxx:1105
-#: vncviewer/DesktopWindow.cxx:1125
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Nol è stât pussibil caturâ la tastiere"
 
-#: vncviewer/DesktopWindow.cxx:1415
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
-msgstr "Disposizion dal schermi elaborade no valide pe richieste di ridimensionament!"
+msgstr ""
+"Disposizion dal schermi elaborade no valide pe richieste di ridimensionament!"
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "Stât no valit pe emulazion dai 3 botons"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:102
+#: vncviewer/KeyboardWin32.cxx:243
+#, c-format
+msgid "No scan code for extended virtual key 0x%02x"
+msgstr "Nissun codiç di scansion pal tast virtuâl estindût 0x%02x"
+
+#: vncviewer/KeyboardWin32.cxx:245
+#, c-format
+msgid "No scan code for virtual key 0x%02x"
+msgstr "Nissun codic di scansion pal tast virtuâl 0x%02x"
+
+#: vncviewer/KeyboardWin32.cxx:251
+#, c-format
+msgid "Invalid scan code 0x%02x"
+msgstr "Codiç di scansion 0x%02x no valit"
+
+#: vncviewer/KeyboardWin32.cxx:263
+#, c-format
+msgid "No symbol for extended virtual key 0x%02x"
+msgstr "Nissun simbul pal tast virtuâl estindût 0x%02x"
+
+#: vncviewer/KeyboardWin32.cxx:265
+#, c-format
+msgid "No symbol for virtual key 0x%02x"
+msgstr "Nissun simbul pal tast virtuâl 0x%02x"
+
+#: vncviewer/KeyboardWin32.cxx:424
+#, c-format
+msgid "Failed to update keyboard LED state: %lu"
+msgstr "Impussibil inzornâ il stât dai LEDs de tastiere: %lu"
+
+#: vncviewer/KeyboardX11.cxx:123
+#, c-format
+msgid "No symbol for key code %d (in the current state)"
+msgstr "Nissun simbul pal codiç dal tast %d (tal stât atuâl)"
+
+#: vncviewer/KeyboardX11.cxx:148
+#, c-format
+msgid "Failed to get keyboard LED state: %d"
+msgstr "Nol è stât pussibil otignî il stât dai LEDs de tastiere: %d"
+
+#: vncviewer/KeyboardX11.cxx:193
+msgid "Failed to update keyboard LED state"
+msgstr "Impussibil inzornâ il stât dai LEDs de tastiere"
+
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "Impussibil otignî la configurazion dal visôr di sisteme"
 
-#: vncviewer/MonitorIndicesParameter.cxx:80
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "E je stade specificade une configurazion no valide par %s"
-
-#: vncviewer/MonitorIndicesParameter.cxx:88
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "La tabele dal visôr %d no esist"
 
-#: vncviewer/MonitorIndicesParameter.cxx:166
-#: vncviewer/MonitorIndicesParameter.cxx:186
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "Tabele dal visôr '%s' no valide"
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
+msgid "TigerVNC options"
+msgstr ""
 
-#: vncviewer/MonitorIndicesParameter.cxx:174
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "Caratar '%c' inspietât"
-
-#: vncviewer/OptionsDialog.cxx:64
-msgid "TigerVNC Options"
-msgstr "Opzions di TigerVNC"
-
-#: vncviewer/OptionsDialog.cxx:97 vncviewer/ServerDialog.cxx:102
-#: vncviewer/vncviewer.cxx:395
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "Anule"
 
-#: vncviewer/OptionsDialog.cxx:102 vncviewer/vncviewer.cxx:394
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "Va ben"
 
-#: vncviewer/OptionsDialog.cxx:502
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "Compression"
 
-#: vncviewer/OptionsDialog.cxx:518
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "Selezione in automatic"
 
-#: vncviewer/OptionsDialog.cxx:529
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "Codifiche preferide"
 
-#: vncviewer/OptionsDialog.cxx:590
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "Nivel colôr"
 
-#: vncviewer/OptionsDialog.cxx:602
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "Totâl"
 
-#: vncviewer/OptionsDialog.cxx:609
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "Medi"
 
-#: vncviewer/OptionsDialog.cxx:616
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "Bas"
 
-#: vncviewer/OptionsDialog.cxx:623
+#: vncviewer/OptionsDialog.cxx:635
 msgid "Very low"
 msgstr "Une vore bas"
 
-#: vncviewer/OptionsDialog.cxx:645
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "Nivel compression personalizât:"
 
-#: vncviewer/OptionsDialog.cxx:652
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "nivel (0=svelt, 9=miôr)"
 
-#: vncviewer/OptionsDialog.cxx:659
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "Permet compression JPEG:"
 
-#: vncviewer/OptionsDialog.cxx:666
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "cualitât (0=puore, 9=miore)"
 
-#: vncviewer/OptionsDialog.cxx:677
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "Sigurece"
 
-#: vncviewer/OptionsDialog.cxx:691
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "Cifradure"
 
-#: vncviewer/OptionsDialog.cxx:703 vncviewer/OptionsDialog.cxx:770
-#: vncviewer/OptionsDialog.cxx:876
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "Nissun"
 
-#: vncviewer/OptionsDialog.cxx:710
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "TLS cun certificâts anonims"
 
-#: vncviewer/OptionsDialog.cxx:716
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "TLS cun certificâts X509"
 
-#: vncviewer/OptionsDialog.cxx:723
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "Percors pal certificât X509 CA"
 
-#: vncviewer/OptionsDialog.cxx:730
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "Percors pal file X509 CRL"
 
-#: vncviewer/OptionsDialog.cxx:758
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "Autenticazion"
 
-#: vncviewer/OptionsDialog.cxx:776
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "VNC standard (no sigûr cence cifradure)"
 
-#: vncviewer/OptionsDialog.cxx:782
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "Non utent e password (no sigûr cence cifradure)"
 
-#: vncviewer/OptionsDialog.cxx:805
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "Input"
 
-#: vncviewer/OptionsDialog.cxx:818
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "Viôt e vonde (ignore mouse e tastiere)"
 
-#: vncviewer/OptionsDialog.cxx:825
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "Mouse"
 
-#: vncviewer/OptionsDialog.cxx:837
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "Emule boton centrâl dal mouse"
 
-#: vncviewer/OptionsDialog.cxx:843
-msgid "Show dot when no cursor"
-msgstr "Mostre un pont se nol è il cursôr"
+#: vncviewer/OptionsDialog.cxx:880
+msgid "Show local cursor when not provided by server"
+msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:859
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
+msgid "Cursor type"
+msgstr ""
+
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
+msgid "Dot"
+msgstr ""
+
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
+msgid "System"
+msgstr ""
+
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "Tastiere"
 
-#: vncviewer/OptionsDialog.cxx:871
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
 msgstr "Mande i tascj di sisteme drets al servidôr (plen visôr)"
 
-#: vncviewer/OptionsDialog.cxx:874
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "Tast Menù"
 
-#: vncviewer/OptionsDialog.cxx:895
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "Notis"
 
-#: vncviewer/OptionsDialog.cxx:907
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "Acete notis dal servidôr"
 
-#: vncviewer/OptionsDialog.cxx:915
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "Stabilìs ancje la selezion primarie"
 
-#: vncviewer/OptionsDialog.cxx:922
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "Invie lis notis al servidôr"
 
-#: vncviewer/OptionsDialog.cxx:930
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "Invie la selezion primarie come notis"
 
-#: vncviewer/OptionsDialog.cxx:951
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "Schermi"
 
-#: vncviewer/OptionsDialog.cxx:965
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "Modalitât schermi"
 
-#: vncviewer/OptionsDialog.cxx:978
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "In barcon"
 
-#: vncviewer/OptionsDialog.cxx:986
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "Plen schermi sul visôr corint"
 
-#: vncviewer/OptionsDialog.cxx:994
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "Plen-schermi su ducj i visôrs"
 
-#: vncviewer/OptionsDialog.cxx:1002
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "Plen scermi sui visôrs selezionâts"
 
-#: vncviewer/OptionsDialog.cxx:1031
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
 msgid "Miscellaneous"
 msgstr "Variis"
 
-#: vncviewer/OptionsDialog.cxx:1039
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "Condividût (no sta disconeti chei altris visualizadôrs)"
 
-#: vncviewer/OptionsDialog.cxx:1045
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "Domande di tornâ a coneti ai erôrs di conession"
 
-#: vncviewer/ServerDialog.cxx:58
-msgid "VNC Viewer: Connection Details"
-msgstr "Visualizadôr VNC: Detais conession"
-
-#: vncviewer/ServerDialog.cxx:68
+#: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
 msgstr "Servidôr VNC:"
 
-#: vncviewer/ServerDialog.cxx:75
+#: vncviewer/ServerDialog.cxx:80
 msgid "Options..."
 msgstr "Opzions..."
 
-#: vncviewer/ServerDialog.cxx:79
+#: vncviewer/ServerDialog.cxx:84
 msgid "Load..."
 msgstr "Cjarie..."
 
-#: vncviewer/ServerDialog.cxx:83
-msgid "Save As..."
-msgstr "Salve come..."
+#: vncviewer/ServerDialog.cxx:88
+msgid "Save as..."
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:97
+#: vncviewer/ServerDialog.cxx:102
 msgid "About..."
 msgstr "Informazions..."
 
-#: vncviewer/ServerDialog.cxx:106
+#: vncviewer/ServerDialog.cxx:111
 msgid "Connect"
 msgstr "Conet"
 
-#: vncviewer/ServerDialog.cxx:143
+#: vncviewer/ServerDialog.cxx:147
 #, c-format
 msgid ""
 "Unable to load the server history:\n"
@@ -409,15 +471,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:172 vncviewer/ServerDialog.cxx:212
+#: vncviewer/ServerDialog.cxx:176 vncviewer/ServerDialog.cxx:216
 msgid "TigerVNC configuration (*.tigervnc)"
 msgstr "Configurazion di TigerVNC (*.tighervnc)"
 
-#: vncviewer/ServerDialog.cxx:173
+#: vncviewer/ServerDialog.cxx:177
 msgid "Select a TigerVNC configuration file"
 msgstr "Selezione un file di configurazion di TigerVNC"
 
-#: vncviewer/ServerDialog.cxx:195 vncviewer/vncviewer.cxx:515
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -428,24 +490,24 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:213
+#: vncviewer/ServerDialog.cxx:217
 msgid "Save the TigerVNC configuration to file"
 msgstr "Save la configurazion di TigerVNC su file"
 
-#: vncviewer/ServerDialog.cxx:239
+#: vncviewer/ServerDialog.cxx:243
 #, c-format
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "%s al esist za. Sorescrivilu?"
 
-#: vncviewer/ServerDialog.cxx:240 vncviewer/vncviewer.cxx:392
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "No"
 
-#: vncviewer/ServerDialog.cxx:240
+#: vncviewer/ServerDialog.cxx:244
 msgid "Overwrite"
 msgstr "Sorescrîf"
 
-#: vncviewer/ServerDialog.cxx:256
+#: vncviewer/ServerDialog.cxx:260
 #, c-format
 msgid ""
 "Unable to save the specified configuration file:\n"
@@ -456,7 +518,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:290
+#: vncviewer/ServerDialog.cxx:294
 #, c-format
 msgid ""
 "Unable to save the default configuration:\n"
@@ -467,7 +529,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:303
+#: vncviewer/ServerDialog.cxx:306
 #, c-format
 msgid ""
 "Unable to save the server history:\n"
@@ -478,228 +540,170 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:320 vncviewer/ServerDialog.cxx:386
-msgid "Could not obtain the state directory path"
-msgstr "Impussibil otignî il percors de cartele dal stât"
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
+msgid "Could not determine VNC state directory path"
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:332 vncviewer/ServerDialog.cxx:394
-#: vncviewer/parameters.cxx:644 vncviewer/parameters.cxx:750
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
-msgid "Could not open \"%s\": %s"
-msgstr "Impussibil vierzi \"%s\": %s"
+msgid "Could not open \"%s\""
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:347 vncviewer/ServerDialog.cxx:355
-#: vncviewer/parameters.cxx:764 vncviewer/parameters.cxx:770
-#: vncviewer/parameters.cxx:801 vncviewer/parameters.cxx:830
-#: vncviewer/parameters.cxx:836
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
-msgid "Failed to read line %d in file %s: %s"
-msgstr "No si è rivâts a lei la rie %d intal file %s: %s"
+msgid "Failed to read line %d in file \"%s\""
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:356 vncviewer/parameters.cxx:771
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "Rie masse lungje"
 
-#: vncviewer/UserDialog.cxx:99
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "No si è rivâts a vierzi il file de password"
 
-#: vncviewer/UserDialog.cxx:118
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "Autenticazion VNC"
 
-#: vncviewer/UserDialog.cxx:125
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "Cheste conession e je sigure"
 
-#: vncviewer/UserDialog.cxx:129
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "Cheste conession no je sigure"
 
-#: vncviewer/UserDialog.cxx:151
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "Non utent:"
 
-#: vncviewer/UserDialog.cxx:164
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "Password:"
 
-#: vncviewer/UserDialog.cxx:207
-msgid "Authentication cancelled"
-msgstr "Autenticazion anulade"
+#: vncviewer/UserDialog.cxx:204
+msgid "Keep password for reconnect"
+msgstr ""
 
-#: vncviewer/Viewport.cxx:390
-#, c-format
-msgid "Failed to update keyboard LED state: %lu"
-msgstr "Impussibil inzornâ il stât dai LEDs de tastiere: %lu"
-
-#: vncviewer/Viewport.cxx:396 vncviewer/Viewport.cxx:402
-#, c-format
-msgid "Failed to update keyboard LED state: %d"
-msgstr "Nol è stât pussibil inzornâ il stât dai LEDs de tastiere: %d"
-
-#: vncviewer/Viewport.cxx:432
-msgid "Failed to update keyboard LED state"
-msgstr "Impussibil inzornâ il stât dai LEDs de tastiere"
-
-#: vncviewer/Viewport.cxx:459 vncviewer/Viewport.cxx:467
-#: vncviewer/Viewport.cxx:484
-#, c-format
-msgid "Failed to get keyboard LED state: %d"
-msgstr "Nol è stât pussibil otignî il stât dai LEDs de tastiere: %d"
-
-#: vncviewer/Viewport.cxx:839
-msgid "No key code specified on key press"
-msgstr "Nissun codiç di tast specificât ae pression dal tast"
-
-#: vncviewer/Viewport.cxx:990
-#, c-format
-msgid "No scan code for extended virtual key 0x%02x"
-msgstr "Nissun codiç di scansion pal tast virtuâl estindût 0x%02x"
-
-#: vncviewer/Viewport.cxx:992
-#, c-format
-msgid "No scan code for virtual key 0x%02x"
-msgstr "Nissun codic di scansion pal tast virtuâl 0x%02x"
-
-#: vncviewer/Viewport.cxx:998
-#, c-format
-msgid "Invalid scan code 0x%02x"
-msgstr "Codiç di scansion 0x%02x no valit"
-
-#: vncviewer/Viewport.cxx:1028
-#, c-format
-msgid "No symbol for extended virtual key 0x%02x"
-msgstr "Nissun simbul pal tast virtuâl estindût 0x%02x"
-
-#: vncviewer/Viewport.cxx:1030
-#, c-format
-msgid "No symbol for virtual key 0x%02x"
-msgstr "Nissun simbul pal tast virtuâl 0x%02x"
-
-#: vncviewer/Viewport.cxx:1136
-#, c-format
-msgid "No symbol for key code 0x%02x (in the current state)"
-msgstr "Nissun simbul pal codiç dal tast 0x%02x (tal stât atuâl)"
-
-#: vncviewer/Viewport.cxx:1169
-#, c-format
-msgid "No symbol for key code %d (in the current state)"
-msgstr "Nissun simbul pal codiç dal tast %d (tal stât atuâl)"
-
-#: vncviewer/Viewport.cxx:1229
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
 msgid "Disconn&ect"
 msgstr "Discon&et"
 
-#: vncviewer/Viewport.cxx:1232
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "&Plen visôr"
 
-#: vncviewer/Viewport.cxx:1235
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "Im&piçulìs"
 
-#: vncviewer/Viewport.cxx:1237
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "Cambie dimension al &barcon ae session"
 
-#: vncviewer/Viewport.cxx:1242
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:1245
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:1251
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "Invie %s"
 
-#: vncviewer/Viewport.cxx:1257
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Invie Ctrl-Alt-&Del"
 
-#: vncviewer/Viewport.cxx:1260
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "Inzo&rne schermi"
 
-#: vncviewer/Viewport.cxx:1263
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&Opzions..."
 
-#: vncviewer/Viewport.cxx:1265
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "&Informazions conession..."
 
-#: vncviewer/Viewport.cxx:1267
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "Informazions su Visualizadôr &TigerVNC"
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:1356
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "Informazions conession VNC"
 
-#: vncviewer/Win32TouchHandler.cxx:47
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "Windows al è regjistrât pes tocjadis invezit dai mots"
 
-#: vncviewer/Win32TouchHandler.cxx:82
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "Nol è stât pussibil stabilî la configurazion dai mots (erôr 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:94
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "Nol è stât pussibil otignî informazions dai mots (erôr 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:359
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr "Boton %d dal mouse no valit, al scugne sei un numar tra 1 e 7."
 
-#: vncviewer/Win32TouchHandler.cxx:424
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
 msgstr "Tast 0x%x no gjestît - impussibil gjenerâ un event di tastiere."
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:108
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
 msgstr "Impussibil otignî la mascare dai events X Input 2 pal barcon 0x%08lx"
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr "Il barcon 0x%08lx nol à une mascare dai events X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:115
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr "Il barcon 0x%08lx al à plui di une mascare dai events X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "Nol è stât pussibil caturâ il dispositîf %i"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-#: vncviewer/vncviewer.cxx:389 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC Viewer"
-msgstr "Visualizadôr TigerVNC"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -707,156 +711,185 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr "Conet a un servidôr VNC e visualize il scritori lontan"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
-msgstr "Virtual Network Computing (VNC) al è un sisteme par visualizâ di lontan che ti permet di viodi e interagjî cuntun ambient di scritori virtuâl che al zire suntun altri computer in rêt. Doprant VNC tu puedis eseguî aplicazions grafichis suntune machine lontane e inviâ dome la visualizazion di chestis aplicazions al to dispositîf locâl. Chest pachet al conten un client che ti permetarà di fâti coneti a un altri scritori che al eseguìs un servidôr VNC. VNC al è indipendent des plateformis e al supuarte varis sistemis operatîfs e architeturis, sedi come servidôrs che come clients."
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+"Virtual Network Computing (VNC) al è un sisteme par visualizâ di lontan che "
+"ti permet di viodi e interagjî cuntun ambient di scritori virtuâl che al "
+"zire suntun altri computer in rêt. Doprant VNC tu puedis eseguî aplicazions "
+"grafichis suntune machine lontane e inviâ dome la visualizazion di chestis "
+"aplicazions al to dispositîf locâl. Chest pachet al conten un client che ti "
+"permetarà di fâti coneti a un altri scritori che al eseguìs un servidôr VNC. "
+"VNC al è indipendent des plateformis e al supuarte varis sistemis operatîfs "
+"e architeturis, sedi come servidôrs che come clients."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
-msgstr "TigerVNC e je une version a alte velocitât di VNC, basade su RealVNC 4 e lis basis dal codiç di X.org. TigerVNC al è scomençât tant che tentatîf di svilup de prossime gjenerazion di TightVNC pes plateformis Unix e Linux, ma si è separât dal so progjet gjenitôr sul scomençâ dal 2009. In cheste maniere TightVNC al à podût concentrâsi su lis plateformis Windows. TigerVNC al supuarte une variante de codifiche Tight che e je une vore acelerade dal ûs dal codificadôr JPEG llibjpeg-turbo."
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+"TigerVNC e je une version a alte velocitât di VNC, basade su RealVNC 4 e lis "
+"basis dal codiç di X.org. TigerVNC al è scomençât tant che tentatîf di "
+"svilup de prossime gjenerazion di TightVNC pes plateformis Unix e Linux, ma "
+"si è separât dal so progjet gjenitôr sul scomençâ dal 2009. In cheste "
+"maniere TightVNC al à podût concentrâsi su lis plateformis Windows. TigerVNC "
+"al supuarte une variante de codifiche Tight che e je une vore acelerade dal "
+"ûs dal codificadôr JPEG llibjpeg-turbo."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC Viewer connection to a CentOS machine"
-msgstr "Conession di Visualizadôr TigerVNC a une machine CentOS"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC Viewer connection to a macOS machine"
-msgstr "Conession di Visualizadôr TigerVNC a une machine macOS"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC Viewer connection to a Windows machine"
-msgstr "Conession di Visualizadôr TigerVNC a une machine Windows"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
-#: vncviewer/parameters.cxx:307 vncviewer/parameters.cxx:332
-#: vncviewer/parameters.cxx:349 vncviewer/parameters.cxx:389
-#: vncviewer/parameters.cxx:409
+#. developer_name tag deprecated with Appstream 1.0
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
+msgid "The TigerVNC team"
+msgstr ""
+
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "Il non dal parametri al è masse grant"
 
-#: vncviewer/parameters.cxx:311 vncviewer/parameters.cxx:316
-#: vncviewer/parameters.cxx:367
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "Il parametri al è masse grant"
 
-#: vncviewer/parameters.cxx:374 vncviewer/parameters.cxx:694
-#: vncviewer/parameters.cxx:815
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "Formât no valit o valôr masse larc"
 
-#: vncviewer/parameters.cxx:428 vncviewer/parameters.cxx:459
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "Nol è stât pussibil creâ clâf dal regjistri"
 
-#: vncviewer/parameters.cxx:447 vncviewer/parameters.cxx:502
-#: vncviewer/parameters.cxx:544 vncviewer/parameters.cxx:611
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "Nol è stât pussibil sierâ la clâf dal regjistri"
 
-#: vncviewer/parameters.cxx:465 vncviewer/parameters.cxx:482
-#: vncviewer/parameters.cxx:652 vncviewer/parameters.cxx:662
-#: vncviewer/parameters.cxx:673
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "Nol è stât pussibil salvâ \"%s\": %s"
 
-#: vncviewer/parameters.cxx:478 vncviewer/parameters.cxx:566
-#: vncviewer/parameters.cxx:675 vncviewer/parameters.cxx:712
-msgid "Unknown parameter type"
-msgstr "Gjenar di parametri no cognossût"
-
-#: vncviewer/parameters.cxx:495
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "Nol è stât pussibil gjavâ \"%s\": %s"
 
-#: vncviewer/parameters.cxx:517 vncviewer/parameters.cxx:589
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "Nol è stât pussibil vierzi la clâf dal regjistri"
 
-#: vncviewer/parameters.cxx:534
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "Nol è stât pussibil lei la vôs %d de cronologjie dal servidôr: %s"
 
-#: vncviewer/parameters.cxx:570 vncviewer/parameters.cxx:600
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "Nol è stât pussibil lei il parametri \"%s\": %s"
 
-#: vncviewer/parameters.cxx:634 vncviewer/parameters.cxx:738
-msgid "Could not obtain the config directory path"
-msgstr "Impussibil otignî il percors de cartele di configurazion"
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
+msgid "Could not determine VNC config directory path"
+msgstr ""
 
-#: vncviewer/parameters.cxx:653 vncviewer/parameters.cxx:664
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "Impussibil codificâ il parametri"
 
-#: vncviewer/parameters.cxx:780
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "Il file di configurazion %s al è intun formât no valit"
 
-#: vncviewer/parameters.cxx:802
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "Formât no valit"
 
-#: vncviewer/parameters.cxx:837
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "Parametri no cognossût"
 
-#: vncviewer/touch.cxx:76
+#: vncviewer/touch.cxx:75
 #, c-format
 msgid "Got message (0x%x) for an unhandled window"
 msgstr "Ricevût messaç (0x%x) par un barcon no gjestît"
 
-#: vncviewer/touch.cxx:139 vncviewer/touch.cxx:161
+#: vncviewer/touch.cxx:138 vncviewer/touch.cxx:160
 #, c-format
 msgid "Invalid window 0x%08lx specified for pointer grab"
 msgstr "Specificât barcon 0x%08lx no valit pe cature dal pontadôr"
 
-#: vncviewer/touch.cxx:184 vncviewer/touch.cxx:185
+#: vncviewer/touch.cxx:183 vncviewer/touch.cxx:184
 #, c-format
 msgid "Failed to create touch handler: %s"
 msgstr "Nol è stât pussibil creâ un gjestôr pes tocjadis: %s"
 
-#: vncviewer/touch.cxx:189
+#: vncviewer/touch.cxx:188
 #, c-format
 msgid "Couldn't attach event handler to window (error 0x%x)"
 msgstr "Nol è stât pussibil zontâ al barcon il gjestôr dai events (erôr 0x%x)"
 
-#: vncviewer/touch.cxx:216
+#: vncviewer/touch.cxx:215
 msgid "Failed to get event data for X Input event"
 msgstr "Impussibil otignî i dâts dai events pal event X Input"
 
-#: vncviewer/touch.cxx:229
+#: vncviewer/touch.cxx:228
 msgid "X Input event for unknown window"
 msgstr "Event X Input par un barcon no cognossût"
 
-#: vncviewer/touch.cxx:255
+#: vncviewer/touch.cxx:254
 msgid "X Input extension not available."
 msgstr "Estension di X Input no disponibile."
 
-#: vncviewer/touch.cxx:262
+#: vncviewer/touch.cxx:261
 msgid "X Input 2 (or newer) is not available."
 msgstr "X Input 2 (o plui resint) nol è disponibil."
 
-#: vncviewer/touch.cxx:267
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
-msgstr "X Input 2.2 (o plui resint) nol è disponibil. I mots tatii no saran supuartâts."
+#: vncviewer/touch.cxx:266
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+"X Input 2.2 (o plui resint) nol è disponibil. I mots tatii no saran "
+"supuartâts."
 
-#: vncviewer/vncviewer.cxx:104
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC Viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
-"Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+"Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"Visualizadôr TigerVNC v%s\n"
-"Compilât su: %s\n"
-"Copyright (C) 1999-%d Il grup di TigerVNC e tancj altris (viôt README.rst)\n"
-"Viôt https://www.tigervnc.org par informazions su TigerVNC."
 
-#: vncviewer/vncviewer.cxx:158
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -867,15 +900,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:174
-msgid "About TigerVNC Viewer"
-msgstr "Informazions su Visualizadôr TigerVNC"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:195
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "Erôr FLTK interni. Daûr a jessî."
 
-#: vncviewer/vncviewer.cxx:214
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -886,102 +919,168 @@ msgstr ""
 "\n"
 "Cirî di tornâ a coneti?"
 
-#: vncviewer/vncviewer.cxx:245 vncviewer/vncviewer.cxx:257
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Erôr tal inviâ un gnûf Visualizadôr TigerVNC: %s"
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:266
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC Viewer will now exit."
-msgstr "Il segnâl di terminazion %d al è stât ricevût. Il visualizadôr TigerVNC al jessarà cumò."
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:393
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "Sì"
 
-#: vncviewer/vncviewer.cxx:396
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "Siere"
 
-#: vncviewer/vncviewer.cxx:401
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "Informazions"
 
-#: vncviewer/vncviewer.cxx:404
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "Plate"
 
-#: vncviewer/vncviewer.cxx:407
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "Jes"
 
-#: vncviewer/vncviewer.cxx:411
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "Servizis"
 
-#: vncviewer/vncviewer.cxx:412
-msgid "Hide Others"
-msgstr "Plate altris"
-
 #: vncviewer/vncviewer.cxx:413
-msgid "Show All"
-msgstr "Mostre dut"
+msgid "Hide others"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:422
+#: vncviewer/vncviewer.cxx:414
+msgid "Show all"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "&File"
 
-#: vncviewer/vncviewer.cxx:425
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "&Gnove conession"
 
-#: vncviewer/vncviewer.cxx:525
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
-msgstr "FullScreenAllMonitors al è deplorât, al so puest met FullScreenMode a 'all'"
-
-#: vncviewer/vncviewer.cxx:721
-msgid "~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
-msgstr "~/.vnc al è deplorât, consulte 'man vncviewer' pai percors dulà lâ a migrâ."
-
-#: vncviewer/vncviewer.cxx:725
+#: vncviewer/vncviewer.cxx:449
 #, c-format
-msgid "%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC location."
-msgstr "%%APPDATA%%\\vnc al è deplorât, passe ae posizion %%APPDATA%%\\TigerVNC."
+msgid ""
+"\n"
+"Usage: %s [parameters] [host][:displayNum]\n"
+"       %s [parameters] [host][::port]\n"
+"       %s [parameters] [unix socket]\n"
+"       %s [parameters] -listen [port]\n"
+"       %s [parameters] [.tigervnc file]\n"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:730
+#: vncviewer/vncviewer.cxx:464
 #, c-format
-msgid "Could not create VNC config directory: %s"
-msgstr "Impussibil creâ la cartele di configurazion di VNC: %s"
+msgid ""
+"\n"
+"Options:\n"
+"\n"
+"  -display Xdisplay  - Specifies the X display for the viewer window\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
+"                       man page for details.\n"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:735
+#: vncviewer/vncviewer.cxx:471
 #, c-format
-msgid "Could not create VNC data directory: %s"
-msgstr "Impussibil creâ la cartele dai dâts di VNC: %s"
+msgid ""
+"\n"
+"Parameters can be turned on with -<param> or off with -<param>=0\n"
+"Parameters which take a value can be specified as -<param> <value>\n"
+"Other valid forms are <param>=<value> -<param>=<value> --<param>=<value>\n"
+"Parameter names are case-insensitive.  The parameters are:\n"
+"\n"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:740
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+"FullScreenAllMonitors al è deplorât, al so puest met FullScreenMode a 'all'"
+
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+"~/.vnc al è deplorât, consulte 'man vncviewer' pai percors dulà lâ a migrâ."
+
+#: vncviewer/vncviewer.cxx:556
 #, c-format
-msgid "Could not create VNC state directory: %s"
-msgstr "Impussibil creâ la cartele dal stât di VNC: %s"
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+"%%APPDATA%%\\vnc al è deplorât, passe ae posizion %%APPDATA%%\\TigerVNC."
+
+#: vncviewer/vncviewer.cxx:561
+#, c-format
+msgid "Could not create VNC config directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:567
+msgid "Could not determine VNC data directory path"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:573
+#, c-format
+msgid "Could not create VNC data directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:585
+#, c-format
+msgid "Could not create VNC state directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:704
+#, c-format
+msgid "%s: Unrecognized option '%s'\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
+#, c-format
+msgid "See '%s --help' for more information.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:713
+#, c-format
+msgid "%s: Extra argument '%s'\n"
+msgstr ""
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:755 vncviewer/vncviewer.cxx:756
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "Parametris -listen e -via no son compatibii"
 
-#: vncviewer/vncviewer.cxx:770
+#: vncviewer/vncviewer.cxx:764
 msgid "Unable to listen for incoming connections"
 msgstr "Impussibil scoltâ lis conessions in jentrade"
 
-#: vncviewer/vncviewer.cxx:772
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "In scolte su la puarte %d"
 
-#: vncviewer/vncviewer.cxx:805
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -992,9 +1091,147 @@ msgstr ""
 "\n"
 "%s"
 
+#: vncviewer/vncviewer.cxx:816
+#, c-format
+msgid ""
+"Failure setting up encrypted tunnel:\n"
+"\n"
+"%s"
+msgstr ""
+
 #: vncviewer/vncviewer.desktop.in.in:4
-msgid "Remote Desktop Viewer"
-msgstr "Visualizadôr di scritori lontan"
+msgid "Remote desktop viewer"
+msgstr ""
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(predefinît dal servidôr %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "SetDesktopSize falît: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "SetColourMapEntries no valit dal servidôr!"
+
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "E je stade specificade une configurazion no valide par %s"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "Tabele dal visôr '%s' no valide"
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "Caratar '%c' inspietât"
+
+#~ msgid "TigerVNC Options"
+#~ msgstr "Opzions di TigerVNC"
+
+#~ msgid "Show dot when no cursor"
+#~ msgstr "Mostre un pont se nol è il cursôr"
+
+#~ msgid "VNC Viewer: Connection Details"
+#~ msgstr "Visualizadôr VNC: Detais conession"
+
+#~ msgid "Save As..."
+#~ msgstr "Salve come..."
+
+#~ msgid "Could not obtain the state directory path"
+#~ msgstr "Impussibil otignî il percors de cartele dal stât"
+
+#, c-format
+#~ msgid "Could not open \"%s\": %s"
+#~ msgstr "Impussibil vierzi \"%s\": %s"
+
+#, c-format
+#~ msgid "Failed to read line %d in file %s: %s"
+#~ msgstr "No si è rivâts a lei la rie %d intal file %s: %s"
+
+#~ msgid "Authentication cancelled"
+#~ msgstr "Autenticazion anulade"
+
+#, c-format
+#~ msgid "Failed to update keyboard LED state: %d"
+#~ msgstr "Nol è stât pussibil inzornâ il stât dai LEDs de tastiere: %d"
+
+#~ msgid "No key code specified on key press"
+#~ msgstr "Nissun codiç di tast specificât ae pression dal tast"
+
+#, c-format
+#~ msgid "No symbol for key code 0x%02x (in the current state)"
+#~ msgstr "Nissun simbul pal codiç dal tast 0x%02x (tal stât atuâl)"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "Informazions su Visualizadôr &TigerVNC"
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "Visualizadôr TigerVNC"
+
+#~ msgid "TigerVNC Viewer connection to a CentOS machine"
+#~ msgstr "Conession di Visualizadôr TigerVNC a une machine CentOS"
+
+#~ msgid "TigerVNC Viewer connection to a macOS machine"
+#~ msgstr "Conession di Visualizadôr TigerVNC a une machine macOS"
+
+#~ msgid "TigerVNC Viewer connection to a Windows machine"
+#~ msgstr "Conession di Visualizadôr TigerVNC a une machine Windows"
+
+#~ msgid "Unknown parameter type"
+#~ msgstr "Gjenar di parametri no cognossût"
+
+#~ msgid "Could not obtain the config directory path"
+#~ msgstr "Impussibil otignî il percors de cartele di configurazion"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC Viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "Visualizadôr TigerVNC v%s\n"
+#~ "Compilât su: %s\n"
+#~ "Copyright (C) 1999-%d Il grup di TigerVNC e tancj altris (viôt README."
+#~ "rst)\n"
+#~ "Viôt https://www.tigervnc.org par informazions su TigerVNC."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "Informazions su Visualizadôr TigerVNC"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Erôr tal inviâ un gnûf Visualizadôr TigerVNC: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC Viewer will now exit."
+#~ msgstr ""
+#~ "Il segnâl di terminazion %d al è stât ricevût. Il visualizadôr TigerVNC "
+#~ "al jessarà cumò."
+
+#~ msgid "Hide Others"
+#~ msgstr "Plate altris"
+
+#~ msgid "Show All"
+#~ msgstr "Mostre dut"
+
+#, c-format
+#~ msgid "Could not create VNC config directory: %s"
+#~ msgstr "Impussibil creâ la cartele di configurazion di VNC: %s"
+
+#, c-format
+#~ msgid "Could not create VNC data directory: %s"
+#~ msgstr "Impussibil creâ la cartele dai dâts di VNC: %s"
+
+#, c-format
+#~ msgid "Could not create VNC state directory: %s"
+#~ msgstr "Impussibil creâ la cartele dal stât di VNC: %s"
+
+#~ msgid "Remote Desktop Viewer"
+#~ msgstr "Visualizadôr di scritori lontan"
 
 #~ msgid "VNC Viewer: Connection Options"
 #~ msgstr "Visualizadôr VNC: Opzions conession"
@@ -1080,7 +1317,8 @@ msgstr "Visualizadôr di scritori lontan"
 #~ msgstr "Nome i visôrs a colôrs vêrs a son supuartâts"
 
 #~ msgid "Failed to write parameter %s of type %s to the registry: %ld"
-#~ msgstr "No si è rivâts a scrivi il parametri %s di gjenar %s sul regjistri: %ld"
+#~ msgstr ""
+#~ "No si è rivâts a scrivi il parametri %s di gjenar %s sul regjistri: %ld"
 
 #~ msgid "The name of the parameter %s was too large to read from the registry"
 #~ msgstr "Il non dal parametri %s al jere masse larc par lei dal regjistri"
@@ -1088,17 +1326,26 @@ msgstr "Visualizadôr di scritori lontan"
 #~ msgid "The parameter %s was too large to read from the registry"
 #~ msgstr "Il parametri %s al jere masse larc par lei dal regjistri"
 
-#~ msgid "Failed to write configuration file, can't obtain home directory path."
-#~ msgstr "No si è rivâts a scrivi il file di configurazion, impussibil otignî il percors de cartele cjase."
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "No si è rivâts a scrivi il file di configurazion, impussibil otignî il "
+#~ "percors de cartele cjase."
 
 #~ msgid "Failed to write configuration file, can't open %s: %s"
-#~ msgstr "No si è rivâts a scrivi il file di configurazion, impussibil vierzi %s: %s"
+#~ msgstr ""
+#~ "No si è rivâts a scrivi il file di configurazion, impussibil vierzi %s: %s"
 
 #~ msgid "Failed to read configuration file, can't obtain home directory path."
-#~ msgstr "No si è rivâts a lei il file di configurazion, impussibil otignî il percors de cartele cjase."
+#~ msgstr ""
+#~ "No si è rivâts a lei il file di configurazion, impussibil otignî il "
+#~ "percors de cartele cjase."
 
 #~ msgid "Unknown parameter %s on line %d in file %s"
 #~ msgstr "Parametri %s no cognossût ae rie %d intal file %s"
 
-#~ msgid "Could not create VNC home directory: can't obtain home directory path."
-#~ msgstr "Impussibil creâ la cartele cjase di VNC: Impussibil otignî il percors de cartele cjase."
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
+#~ msgstr ""
+#~ "Impussibil creâ la cartele cjase di VNC: Impussibil otignî il percors de "
+#~ "cartele cjase."

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc-1.13.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2024-06-20 15:01+0200\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2024-06-21 10:14+0300\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
 "Language-Team: Hebrew <heb-bugzap@hamakor.org.il>\n"
@@ -15,21 +15,22 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : n==2 ? 1 : n>10 && n%10==0 ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : n==2 ? 1 : n>10 && n%10==0 ? "
+"2 : 3);\n"
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: vncviewer/CConn.cxx:99
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "מחובר לשקע %s"
 
-#: vncviewer/CConn.cxx:106
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "מחובר למארח %s פתחה %d"
 
-#: vncviewer/CConn.cxx:111
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -42,85 +43,86 @@ msgstr ""
 "‬\n"
 "‏‫%s"
 
-#: vncviewer/CConn.cxx:155
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "שם שולחן העבודה %.80s"
 
-#: vncviewer/CConn.cxx:160
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "מארח: %.80s פתחה: %d"
 
-#: vncviewer/CConn.cxx:165
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "גודל: %d x %d"
 
-#: vncviewer/CConn.cxx:173
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "תצורת פיקסלים: %s"
 
-#: vncviewer/CConn.cxx:180
-#, c-format
-msgid "(server default %s)"
-msgstr "(בררת המחדל של השרת %s)"
-
-#: vncviewer/CConn.cxx:185
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "קידוד נדרש: %s"
 
-#: vncviewer/CConn.cxx:190
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "קידוד אחרון: %s"
 
-#: vncviewer/CConn.cxx:195
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "הערכת מהירות הקו: %d קסל״ש"
 
-#: vncviewer/CConn.cxx:200
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "גרסת פרוטוקול: %d.%d"
 
-#: vncviewer/CConn.cxx:205
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "שיטת אבטחה: %s"
 
-#: vncviewer/CConn.cxx:266 vncviewer/CConn.cxx:268
-msgid "The connection was dropped by the server before the session could be established."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
 msgstr "החיבור נקטע מצד השרת בטרם יצירת החיבור הראשוני."
 
-#: vncviewer/CConn.cxx:326
+#: vncviewer/CConn.cxx:258
 #, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "‫SetDesktopSize נכשלה: %d"
+msgid "Authentication failed: %s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:399
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "‫SetColourMapEntries שגוי מהשרת!"
+#: vncviewer/CConn.cxx:259
+#, c-format
+msgid ""
+"Failed to authenticate with the server. Reason given by the server:\n"
+"\n"
+"%s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:507
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "תפוקה %d קסל״ש - האיכות תוחלף לכדי %d"
 
-#: vncviewer/CConn.cxx:529
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "‫תפוקה %d קסל״ש - צבע מלא פעיל מעתה"
 
-#: vncviewer/CConn.cxx:532
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "‫תפוקה %d קסל״ש - צבע מלא מושבת מעתה"
 
-#: vncviewer/CConn.cxx:558
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "נעשה שימוש בתצורת פיקסלים %s"
@@ -133,273 +135,329 @@ msgstr "הממדים שצוינו שגויים!"
 msgid "Reducing window size to fit on current monitor"
 msgstr "החלון מוקטן כדי להתאים לגודל המסך הנוכחי"
 
-#: vncviewer/DesktopWindow.cxx:648
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
 msgstr "Adjusting window size to avoid accidental full-screen request"
 
-#: vncviewer/DesktopWindow.cxx:696
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "לחיצה על %s תפתח את תפריט ההקשר"
 
-#: vncviewer/DesktopWindow.cxx:1097 vncviewer/DesktopWindow.cxx:1105
-#: vncviewer/DesktopWindow.cxx:1125
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "לכידת המקלדת נכשלה"
 
-#: vncviewer/DesktopWindow.cxx:1415
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
 msgstr "חושבה פריסת מסך שגויה לבקשת שינוי הגודל!"
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "מצב שגוי להדמיית 3 כפתורים"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:102
+#: vncviewer/KeyboardWin32.cxx:243
+#, c-format
+msgid "No scan code for extended virtual key 0x%02x"
+msgstr "אין קוד סריקה למקש הווירטואלי המורחב 0x%02x"
+
+#: vncviewer/KeyboardWin32.cxx:245
+#, c-format
+msgid "No scan code for virtual key 0x%02x"
+msgstr "‫אין קוד סריקה למקש הווירטואלי 0x%02x"
+
+#: vncviewer/KeyboardWin32.cxx:251
+#, c-format
+msgid "Invalid scan code 0x%02x"
+msgstr "קוד סריקה שגוי 0x%02x"
+
+#: vncviewer/KeyboardWin32.cxx:263
+#, c-format
+msgid "No symbol for extended virtual key 0x%02x"
+msgstr "אין סימן למקש הווירטואלי המורחב 0x%02x"
+
+#: vncviewer/KeyboardWin32.cxx:265
+#, c-format
+msgid "No symbol for virtual key 0x%02x"
+msgstr "אין סימן למקש הווירטואלי 0x%02x"
+
+#: vncviewer/KeyboardWin32.cxx:424
+#, c-format
+msgid "Failed to update keyboard LED state: %lu"
+msgstr "עדכון מצב נורית המקלדת נכשל: %lu"
+
+#: vncviewer/KeyboardX11.cxx:123
+#, c-format
+msgid "No symbol for key code %d (in the current state)"
+msgstr "אין סימן לקוד המקש %d (במצב הנוכחי)"
+
+#: vncviewer/KeyboardX11.cxx:148
+#, c-format
+msgid "Failed to get keyboard LED state: %d"
+msgstr "קבלת מצב נורית המקלדת נכשלה: %d"
+
+#: vncviewer/KeyboardX11.cxx:193
+msgid "Failed to update keyboard LED state"
+msgstr "עדכון מצב נורית המקלדת נכשל"
+
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "קבלת הגדרות צג המערכת נכשלה"
 
-#: vncviewer/MonitorIndicesParameter.cxx:80
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "צוינו הגדרות שגויות עבור %s"
-
-#: vncviewer/MonitorIndicesParameter.cxx:88
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "מפתח צג %d לא קיים"
 
-#: vncviewer/MonitorIndicesParameter.cxx:166
-#: vncviewer/MonitorIndicesParameter.cxx:186
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "מפתח הצג ‚%s’ שגוי"
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
+msgid "TigerVNC options"
+msgstr ""
 
-#: vncviewer/MonitorIndicesParameter.cxx:174
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "התו ‚%c’ אינו צפוי"
-
-#: vncviewer/OptionsDialog.cxx:64
-msgid "TigerVNC Options"
-msgstr "אפשרויות TigerVNC"
-
-#: vncviewer/OptionsDialog.cxx:97 vncviewer/ServerDialog.cxx:102
-#: vncviewer/vncviewer.cxx:395
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "ביטול"
 
-#: vncviewer/OptionsDialog.cxx:102 vncviewer/vncviewer.cxx:394
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "אישור"
 
-#: vncviewer/OptionsDialog.cxx:502
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "דחיסה"
 
-#: vncviewer/OptionsDialog.cxx:518
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "בחירה אוטומטית"
 
-#: vncviewer/OptionsDialog.cxx:529
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "קידוד מועדף"
 
-#: vncviewer/OptionsDialog.cxx:590
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "רמת צבע"
 
-#: vncviewer/OptionsDialog.cxx:602
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "מלאה"
 
-#: vncviewer/OptionsDialog.cxx:609
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "בינונית"
 
-#: vncviewer/OptionsDialog.cxx:616
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "נמוכה"
 
-#: vncviewer/OptionsDialog.cxx:623
+#: vncviewer/OptionsDialog.cxx:635
 msgid "Very low"
 msgstr "נמוכה מאוד"
 
-#: vncviewer/OptionsDialog.cxx:645
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "רמת דחיבה מותאמת אישית:"
 
-#: vncviewer/OptionsDialog.cxx:652
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "רמה (0=מהירה, 9=מיטבית)"
 
-#: vncviewer/OptionsDialog.cxx:659
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "לאפשר דחיסת JPEG:"
 
-#: vncviewer/OptionsDialog.cxx:666
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "איכות (0=עלובה, 9=מיטבית)"
 
-#: vncviewer/OptionsDialog.cxx:677
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "אבטחה"
 
-#: vncviewer/OptionsDialog.cxx:691
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "הצפנה"
 
-#: vncviewer/OptionsDialog.cxx:703 vncviewer/OptionsDialog.cxx:770
-#: vncviewer/OptionsDialog.cxx:876
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "ללא"
 
-#: vncviewer/OptionsDialog.cxx:710
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "‫TLS עם אישורים אלמוניים"
 
-#: vncviewer/OptionsDialog.cxx:716
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "‫TLS עם אישורי X509"
 
-#: vncviewer/OptionsDialog.cxx:723
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "נתיב לאישורי X509 של רשות אישורים"
 
-#: vncviewer/OptionsDialog.cxx:730
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "נתיב לקובץ X509 CRL"
 
-#: vncviewer/OptionsDialog.cxx:758
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "אימות"
 
-#: vncviewer/OptionsDialog.cxx:776
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "רגיל של VNC (בלתי מאובטח וללא הצפנה)"
 
-#: vncviewer/OptionsDialog.cxx:782
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "שם משתמש וססמה (בלתי מאובטח וללא הצפנה)"
 
-#: vncviewer/OptionsDialog.cxx:805
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "קלט"
 
-#: vncviewer/OptionsDialog.cxx:818
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "להציג בלבד (להתעלם מהעכבר ומהמקלדת)"
 
-#: vncviewer/OptionsDialog.cxx:825
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "עכבר"
 
-#: vncviewer/OptionsDialog.cxx:837
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "הדמיית כפתור עכבר אמצעי"
 
-#: vncviewer/OptionsDialog.cxx:843
-msgid "Show dot when no cursor"
-msgstr "להציג נקודה כשאין סמן"
+#: vncviewer/OptionsDialog.cxx:880
+msgid "Show local cursor when not provided by server"
+msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:859
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
+msgid "Cursor type"
+msgstr ""
+
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
+msgid "Dot"
+msgstr ""
+
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
+msgid "System"
+msgstr ""
+
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "מקלדת"
 
-#: vncviewer/OptionsDialog.cxx:871
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
 msgstr "להעביר את מקשי המערכת ישירות לשרת (מסך מלא)"
 
-#: vncviewer/OptionsDialog.cxx:874
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "מקש תפריט"
 
-#: vncviewer/OptionsDialog.cxx:895
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "לוח גזירים"
 
-#: vncviewer/OptionsDialog.cxx:907
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "לקבל לוח גזירים מהשרת"
 
-#: vncviewer/OptionsDialog.cxx:915
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "להגדיר גם את הבחירה העיקרית"
 
-#: vncviewer/OptionsDialog.cxx:922
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "לשלוח לוח גזירים לשרת"
 
-#: vncviewer/OptionsDialog.cxx:930
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "לשלוח את הבחירה העיקרית כלוח כזירים"
 
-#: vncviewer/OptionsDialog.cxx:951
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "תצוגה"
 
-#: vncviewer/OptionsDialog.cxx:965
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "מצב תצוגה"
 
-#: vncviewer/OptionsDialog.cxx:978
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "בחלון"
 
-#: vncviewer/OptionsDialog.cxx:986
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "מסך מלא בצג הנוכחי"
 
-#: vncviewer/OptionsDialog.cxx:994
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "מסך מלא על כל הצגים"
 
-#: vncviewer/OptionsDialog.cxx:1002
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "מסך מלא בצגים נבחרים"
 
-#: vncviewer/OptionsDialog.cxx:1031
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
 msgid "Miscellaneous"
 msgstr "שונות"
 
-#: vncviewer/OptionsDialog.cxx:1039
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "משותף (לא לנתק צופים אחרים)"
 
-#: vncviewer/OptionsDialog.cxx:1045
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "לבקש להתחבר מחדש כשיש תקלות חיבור"
 
-#: vncviewer/ServerDialog.cxx:58
-msgid "VNC Viewer: Connection Details"
-msgstr "מציג VNC: פרטי התחברות"
-
-#: vncviewer/ServerDialog.cxx:68
+#: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
 msgstr "שרת VNC:"
 
-#: vncviewer/ServerDialog.cxx:75
+#: vncviewer/ServerDialog.cxx:80
 msgid "Options..."
 msgstr "אפשרויות…"
 
-#: vncviewer/ServerDialog.cxx:79
+#: vncviewer/ServerDialog.cxx:84
 msgid "Load..."
 msgstr "לטעון…"
 
-#: vncviewer/ServerDialog.cxx:83
-msgid "Save As..."
-msgstr "לשמור בשם…"
+#: vncviewer/ServerDialog.cxx:88
+msgid "Save as..."
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:97
+#: vncviewer/ServerDialog.cxx:102
 msgid "About..."
 msgstr "על אודות…"
 
-#: vncviewer/ServerDialog.cxx:106
+#: vncviewer/ServerDialog.cxx:111
 msgid "Connect"
 msgstr "התחברות"
 
-#: vncviewer/ServerDialog.cxx:143
+#: vncviewer/ServerDialog.cxx:147
 #, c-format
 msgid ""
 "Unable to load the server history:\n"
@@ -412,15 +470,15 @@ msgstr ""
 "‬\n"
 "‏‫%s"
 
-#: vncviewer/ServerDialog.cxx:172 vncviewer/ServerDialog.cxx:212
+#: vncviewer/ServerDialog.cxx:176 vncviewer/ServerDialog.cxx:216
 msgid "TigerVNC configuration (*.tigervnc)"
 msgstr "הגדרות TigerVNC‏ (‎*.tigervnc)"
 
-#: vncviewer/ServerDialog.cxx:173
+#: vncviewer/ServerDialog.cxx:177
 msgid "Select a TigerVNC configuration file"
 msgstr "נא לבחור קובץ הגדרות של TigerVNC"
 
-#: vncviewer/ServerDialog.cxx:195 vncviewer/vncviewer.cxx:515
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -433,24 +491,24 @@ msgstr ""
 "‬\n"
 "‏‫%s"
 
-#: vncviewer/ServerDialog.cxx:213
+#: vncviewer/ServerDialog.cxx:217
 msgid "Save the TigerVNC configuration to file"
 msgstr "לשמור את הגדרות ה־TigerVNC לקובץ"
 
-#: vncviewer/ServerDialog.cxx:239
+#: vncviewer/ServerDialog.cxx:243
 #, c-format
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "‫%s כבר קיים. לשכתב עליו?"
 
-#: vncviewer/ServerDialog.cxx:240 vncviewer/vncviewer.cxx:392
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "לא"
 
-#: vncviewer/ServerDialog.cxx:240
+#: vncviewer/ServerDialog.cxx:244
 msgid "Overwrite"
 msgstr "לשכתב"
 
-#: vncviewer/ServerDialog.cxx:256
+#: vncviewer/ServerDialog.cxx:260
 #, c-format
 msgid ""
 "Unable to save the specified configuration file:\n"
@@ -463,7 +521,7 @@ msgstr ""
 "‬\n"
 "‏‫%s"
 
-#: vncviewer/ServerDialog.cxx:290
+#: vncviewer/ServerDialog.cxx:294
 #, c-format
 msgid ""
 "Unable to save the default configuration:\n"
@@ -476,7 +534,7 @@ msgstr ""
 "‬\n"
 "‏‫%s"
 
-#: vncviewer/ServerDialog.cxx:303
+#: vncviewer/ServerDialog.cxx:306
 #, c-format
 msgid ""
 "Unable to save the server history:\n"
@@ -489,228 +547,170 @@ msgstr ""
 "‬\n"
 "‏‫%s"
 
-#: vncviewer/ServerDialog.cxx:320 vncviewer/ServerDialog.cxx:386
-msgid "Could not obtain the state directory path"
-msgstr "לא ניתן לקבל את נתיב תיקיית המצב"
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
+msgid "Could not determine VNC state directory path"
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:332 vncviewer/ServerDialog.cxx:394
-#: vncviewer/parameters.cxx:644 vncviewer/parameters.cxx:750
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
-msgid "Could not open \"%s\": %s"
-msgstr "לא ניתן לפתוח את „%s”:‏ %s"
+msgid "Could not open \"%s\""
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:347 vncviewer/ServerDialog.cxx:355
-#: vncviewer/parameters.cxx:764 vncviewer/parameters.cxx:770
-#: vncviewer/parameters.cxx:801 vncviewer/parameters.cxx:830
-#: vncviewer/parameters.cxx:836
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
-msgid "Failed to read line %d in file %s: %s"
-msgstr "קריאת השורה %d בקובץ %s נכשלה: %s"
+msgid "Failed to read line %d in file \"%s\""
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:356 vncviewer/parameters.cxx:771
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "השורה ארוכה מדי"
 
-#: vncviewer/UserDialog.cxx:99
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "פתיחת קובץ הססמה נכשלה"
 
-#: vncviewer/UserDialog.cxx:118
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "אימות VNC"
 
-#: vncviewer/UserDialog.cxx:125
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "החיבור מאובטח"
 
-#: vncviewer/UserDialog.cxx:129
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "החיבור אינו מאובטח"
 
-#: vncviewer/UserDialog.cxx:151
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "שם משתמש:"
 
-#: vncviewer/UserDialog.cxx:164
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "ססמה:"
 
-#: vncviewer/UserDialog.cxx:207
-msgid "Authentication cancelled"
-msgstr "האימות נכשל"
+#: vncviewer/UserDialog.cxx:204
+msgid "Keep password for reconnect"
+msgstr ""
 
-#: vncviewer/Viewport.cxx:390
-#, c-format
-msgid "Failed to update keyboard LED state: %lu"
-msgstr "עדכון מצב נורית המקלדת נכשל: %lu"
-
-#: vncviewer/Viewport.cxx:396 vncviewer/Viewport.cxx:402
-#, c-format
-msgid "Failed to update keyboard LED state: %d"
-msgstr "עדכון מצב נורית המקלדת נכשל: %d"
-
-#: vncviewer/Viewport.cxx:432
-msgid "Failed to update keyboard LED state"
-msgstr "עדכון מצב נורית המקלדת נכשל"
-
-#: vncviewer/Viewport.cxx:459 vncviewer/Viewport.cxx:467
-#: vncviewer/Viewport.cxx:484
-#, c-format
-msgid "Failed to get keyboard LED state: %d"
-msgstr "קבלת מצב נורית המקלדת נכשלה: %d"
-
-#: vncviewer/Viewport.cxx:839
-msgid "No key code specified on key press"
-msgstr "לא צוין קוד מקש עם לחיצה על מקש"
-
-#: vncviewer/Viewport.cxx:990
-#, c-format
-msgid "No scan code for extended virtual key 0x%02x"
-msgstr "אין קוד סריקה למקש הווירטואלי המורחב 0x%02x"
-
-#: vncviewer/Viewport.cxx:992
-#, c-format
-msgid "No scan code for virtual key 0x%02x"
-msgstr "‫אין קוד סריקה למקש הווירטואלי 0x%02x"
-
-#: vncviewer/Viewport.cxx:998
-#, c-format
-msgid "Invalid scan code 0x%02x"
-msgstr "קוד סריקה שגוי 0x%02x"
-
-#: vncviewer/Viewport.cxx:1028
-#, c-format
-msgid "No symbol for extended virtual key 0x%02x"
-msgstr "אין סימן למקש הווירטואלי המורחב 0x%02x"
-
-#: vncviewer/Viewport.cxx:1030
-#, c-format
-msgid "No symbol for virtual key 0x%02x"
-msgstr "אין סימן למקש הווירטואלי 0x%02x"
-
-#: vncviewer/Viewport.cxx:1136
-#, c-format
-msgid "No symbol for key code 0x%02x (in the current state)"
-msgstr "אין סימן לקוד המקש 0x%02x (במצב הנוכחי)"
-
-#: vncviewer/Viewport.cxx:1169
-#, c-format
-msgid "No symbol for key code %d (in the current state)"
-msgstr "אין סימן לקוד המקש %d (במצב הנוכחי)"
-
-#: vncviewer/Viewport.cxx:1229
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
 msgid "Disconn&ect"
 msgstr "&ניתוק"
 
-#: vncviewer/Viewport.cxx:1232
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "מ&סך מלא"
 
-#: vncviewer/Viewport.cxx:1235
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "מ&זעור"
 
-#: vncviewer/Viewport.cxx:1237
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "שינוי &גודל החלון להפעלה"
 
-#: vncviewer/Viewport.cxx:1242
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:1245
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:1251
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "לשלוח %s"
 
-#: vncviewer/Viewport.cxx:1257
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "לשלוח Ctrl-Alt-&Del"
 
-#: vncviewer/Viewport.cxx:1260
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "&רענון המסך"
 
-#: vncviewer/Viewport.cxx:1263
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&אפשרויות…"
 
-#: vncviewer/Viewport.cxx:1265
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "&פרטי ההתחברות…"
 
-#: vncviewer/Viewport.cxx:1267
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "&על המציג TigerVNC…"
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:1356
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "פרטי חיבור VNC"
 
-#: vncviewer/Win32TouchHandler.cxx:47
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "החלון רשום למגע במקום למחוות"
 
-#: vncviewer/Win32TouchHandler.cxx:82
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "קביעת הגדרות המחוות נכשלה (שגיאה 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:94
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "קבלת פרטי המחווה נכשלה (שגיאה 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:359
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr "כפתור העכבר %d שגוי, חייב להיות מספר בין 1 ל־7."
 
-#: vncviewer/Win32TouchHandler.cxx:424
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
 msgstr "מקש 0x%x לא מטופל - לא ניתן לייצר אירוע מקלדת."
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:108
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
 msgstr "לא ניתן לקבל מסכת אירועים של X Input 2 לחלון 0x%08lx"
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr "לחלון 0x%08lx אין מסכת אירועים של X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:115
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr "לחלון 0x%08lx יש יותר ממסכת אירועים אחת של X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "לכידת ההתקן %i נכשלה"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-#: vncviewer/vncviewer.cxx:389 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC Viewer"
-msgstr "המציג TigerVNC"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -718,156 +718,179 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr "התחברות לשרת VNC והצגת שולחן עבודה מרוחק"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
-msgstr "מחשוב רשת וירטואלי (VNC) היא מערכת תצוגה מרחוק שמאפשרת לצפות ולתפעל סביבת שולחן עבודה וירטואלית שרצה על גבי מחשב אחר ברשת. באמצעות VNC אפשר להריץ יישומים גרפיים על מכונה מרוחקת ולשלוח רק את התצוגה מהיישומים האלה למכשיר המקומי שלך. החבילה הזאת מכילה לקוח שיאפשר לך להתחבר לשולחנות עבודה אחרים שמריצים שרת VNC. ל־VNC אין תלות במערכת הפעלה כזאת או אחרת והיא תומכת במגוון מערכות הפעלה וסוגי מעבדים הן מצד השרת והן מצד הלקוח."
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+"מחשוב רשת וירטואלי (VNC) היא מערכת תצוגה מרחוק שמאפשרת לצפות ולתפעל סביבת "
+"שולחן עבודה וירטואלית שרצה על גבי מחשב אחר ברשת. באמצעות VNC אפשר להריץ "
+"יישומים גרפיים על מכונה מרוחקת ולשלוח רק את התצוגה מהיישומים האלה למכשיר "
+"המקומי שלך. החבילה הזאת מכילה לקוח שיאפשר לך להתחבר לשולחנות עבודה אחרים "
+"שמריצים שרת VNC. ל־VNC אין תלות במערכת הפעלה כזאת או אחרת והיא תומכת במגוון "
+"מערכות הפעלה וסוגי מעבדים הן מצד השרת והן מצד הלקוח."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
-msgstr "שTigerVNC היא גרסה מהירה של VNC שמבוססת ביסודה על קוד המקור של RealVNC ושל X.Org. מיזם TigerVNC החל כמאמץ פיתוח לדור הבא של TightVNC לפלטפורמות יוניקס ולינוקס אך הוא פוצל ממיזם ההורה שלו בתחילת 2009 כדי לאפשר ל־TightVNC להתמקד בתמיכה ב־Windows. ב־TigerVNC יש תמיכה במגוון של הצפנות Tight שמואצות על ידי השימוש במפענח JPEG בשם libjpeg-turbo."
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+"שTigerVNC היא גרסה מהירה של VNC שמבוססת ביסודה על קוד המקור של RealVNC ושל X."
+"Org. מיזם TigerVNC החל כמאמץ פיתוח לדור הבא של TightVNC לפלטפורמות יוניקס "
+"ולינוקס אך הוא פוצל ממיזם ההורה שלו בתחילת 2009 כדי לאפשר ל־TightVNC להתמקד "
+"בתמיכה ב־Windows. ב־TigerVNC יש תמיכה במגוון של הצפנות Tight שמואצות על ידי "
+"השימוש במפענח JPEG בשם libjpeg-turbo."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC Viewer connection to a CentOS machine"
-msgstr "התחברות מציג VNC למכונת CentOS"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC Viewer connection to a macOS machine"
-msgstr "התחברות מציג VNC למכונת macOS"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC Viewer connection to a Windows machine"
-msgstr "חיבור מציג VNC למכונת Windows"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
-#: vncviewer/parameters.cxx:307 vncviewer/parameters.cxx:332
-#: vncviewer/parameters.cxx:349 vncviewer/parameters.cxx:389
-#: vncviewer/parameters.cxx:409
+#. developer_name tag deprecated with Appstream 1.0
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
+msgid "The TigerVNC team"
+msgstr ""
+
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "שם המשתנה גדול מדי"
 
-#: vncviewer/parameters.cxx:311 vncviewer/parameters.cxx:316
-#: vncviewer/parameters.cxx:367
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "המשתנה גדול מדי"
 
-#: vncviewer/parameters.cxx:374 vncviewer/parameters.cxx:694
-#: vncviewer/parameters.cxx:815
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "תצורה שגויה או שהערך גדול מדי"
 
-#: vncviewer/parameters.cxx:428 vncviewer/parameters.cxx:459
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "יצירת המפתח ברשומות נכשלה"
 
-#: vncviewer/parameters.cxx:447 vncviewer/parameters.cxx:502
-#: vncviewer/parameters.cxx:544 vncviewer/parameters.cxx:611
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "סגירת מפתח הרשומות נכשלה"
 
-#: vncviewer/parameters.cxx:465 vncviewer/parameters.cxx:482
-#: vncviewer/parameters.cxx:652 vncviewer/parameters.cxx:662
-#: vncviewer/parameters.cxx:673
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "השמירה של „%s” נכשלה: %s"
 
-#: vncviewer/parameters.cxx:478 vncviewer/parameters.cxx:566
-#: vncviewer/parameters.cxx:675 vncviewer/parameters.cxx:712
-msgid "Unknown parameter type"
-msgstr "סוג המשתנה אינו ידוע"
-
-#: vncviewer/parameters.cxx:495
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "ההסרה של „%s” נכשלה: %s"
 
-#: vncviewer/parameters.cxx:517 vncviewer/parameters.cxx:589
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "פתיחת מפתח הרשומות נכשלה"
 
-#: vncviewer/parameters.cxx:534
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "קריאת רשומה %d בהיסטוריית השרת נכשלה: %s"
 
-#: vncviewer/parameters.cxx:570 vncviewer/parameters.cxx:600
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "קריאת המשתנה „%s” נכשלה: %s"
 
-#: vncviewer/parameters.cxx:634 vncviewer/parameters.cxx:738
-msgid "Could not obtain the config directory path"
-msgstr "לא ניתן לקבל את נתיב תיקיית ההגדרות"
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
+msgid "Could not determine VNC config directory path"
+msgstr ""
 
-#: vncviewer/parameters.cxx:653 vncviewer/parameters.cxx:664
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "לא ניתן לקודד את המשתנים"
 
-#: vncviewer/parameters.cxx:780
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "המבנה של קובץ ההגדרות %s שגוי"
 
-#: vncviewer/parameters.cxx:802
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "תצורה שגויה"
 
-#: vncviewer/parameters.cxx:837
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "משתנה לא ידוע"
 
-#: vncviewer/touch.cxx:76
+#: vncviewer/touch.cxx:75
 #, c-format
 msgid "Got message (0x%x) for an unhandled window"
 msgstr "התקבלה הודעה (0x%x) לחלון לא מטופל"
 
-#: vncviewer/touch.cxx:139 vncviewer/touch.cxx:161
+#: vncviewer/touch.cxx:138 vncviewer/touch.cxx:160
 #, c-format
 msgid "Invalid window 0x%08lx specified for pointer grab"
 msgstr "צוין חלון שגוי 0x%08lx ללכידת סמן"
 
-#: vncviewer/touch.cxx:184 vncviewer/touch.cxx:185
+#: vncviewer/touch.cxx:183 vncviewer/touch.cxx:184
 #, c-format
 msgid "Failed to create touch handler: %s"
 msgstr "יצירת המטפל באירועי מגע נכשלה: %s"
 
-#: vncviewer/touch.cxx:189
+#: vncviewer/touch.cxx:188
 #, c-format
 msgid "Couldn't attach event handler to window (error 0x%x)"
 msgstr "הצמדת מטפל האירועים לחלון לא צלחה (שגיאה 0x%x)"
 
-#: vncviewer/touch.cxx:216
+#: vncviewer/touch.cxx:215
 msgid "Failed to get event data for X Input event"
 msgstr "קבלת נתוני האירוע של אירוע X Input נכשלה"
 
-#: vncviewer/touch.cxx:229
+#: vncviewer/touch.cxx:228
 msgid "X Input event for unknown window"
 msgstr "אירוע X Input לחלון בלתי מוכר"
 
-#: vncviewer/touch.cxx:255
+#: vncviewer/touch.cxx:254
 msgid "X Input extension not available."
 msgstr "הרחבת X Input אינה זמינה."
 
-#: vncviewer/touch.cxx:262
+#: vncviewer/touch.cxx:261
 msgid "X Input 2 (or newer) is not available."
 msgstr "‫X Input 2 (ומעלה) אינו זמין."
 
-#: vncviewer/touch.cxx:267
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
+#: vncviewer/touch.cxx:266
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
 msgstr "‫X Input 2.2 (ומעלה) אינו זמין. לא תהיה תמיכה במחוות מגע."
 
-#: vncviewer/vncviewer.cxx:104
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC Viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
-"Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+"Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"מציג TigerVNC‏ גרסה%s\n"
-"‫נבנה על גבי: %s\n"
-"‫כל הזכויות שמורות (C) 1999‏-%d לצוות TigerVNC ועוד רבים וטובים (ניתן לעיין ב־README.rst)\n"
-"‬‫למידע על TigerVNC מומלץ לפנות אל https://www.tigervnc.org."
 
-#: vncviewer/vncviewer.cxx:158
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -880,15 +903,15 @@ msgstr ""
 "‬\n"
 "‏‫%s"
 
-#: vncviewer/vncviewer.cxx:174
-msgid "About TigerVNC Viewer"
-msgstr "על אודות המציג TigerVNC"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:195
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "שגיאת FLTK פנימית. מתבצעת יציאה."
 
-#: vncviewer/vncviewer.cxx:214
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -901,102 +924,169 @@ msgstr ""
 "‬\n"
 "‫לנסות להתחבר מחדש?"
 
-#: vncviewer/vncviewer.cxx:245 vncviewer/vncviewer.cxx:257
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "שגיאה בהצגת מציג TigerVNC חדש: %s"
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:266
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC Viewer will now exit."
-msgstr "התקבל אות חיסול %d. מציג TigerVNC יסתיים כעת."
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:393
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "כן"
 
-#: vncviewer/vncviewer.cxx:396
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "סגירה"
 
-#: vncviewer/vncviewer.cxx:401
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "על אודות"
 
-#: vncviewer/vncviewer.cxx:404
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "להסתיר"
 
-#: vncviewer/vncviewer.cxx:407
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "יציאה"
 
-#: vncviewer/vncviewer.cxx:411
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "שירותים"
 
-#: vncviewer/vncviewer.cxx:412
-msgid "Hide Others"
-msgstr "להסתיר אחרים"
-
 #: vncviewer/vncviewer.cxx:413
-msgid "Show All"
-msgstr "להציג הכול"
+msgid "Hide others"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:422
+#: vncviewer/vncviewer.cxx:414
+msgid "Show all"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "&קובץ"
 
-#: vncviewer/vncviewer.cxx:425
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "&התחברות חדשה"
 
-#: vncviewer/vncviewer.cxx:525
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
-msgstr "השימוש בהגדרה FullScreenAllMonitors הופסק, יש להגדיר את FullScreenMode לערך ‚all’ במקום"
-
-#: vncviewer/vncviewer.cxx:721
-msgid "~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
-msgstr "השימוש ב־‎~/.vnc הופסק, נא לפנות למדריך ‚man vncviewer’ לאיתור הנתיבים שיש לעבור אליהם."
-
-#: vncviewer/vncviewer.cxx:725
+#: vncviewer/vncviewer.cxx:449
 #, c-format
-msgid "%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC location."
+msgid ""
+"\n"
+"Usage: %s [parameters] [host][:displayNum]\n"
+"       %s [parameters] [host][::port]\n"
+"       %s [parameters] [unix socket]\n"
+"       %s [parameters] -listen [port]\n"
+"       %s [parameters] [.tigervnc file]\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:464
+#, c-format
+msgid ""
+"\n"
+"Options:\n"
+"\n"
+"  -display Xdisplay  - Specifies the X display for the viewer window\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
+"                       man page for details.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:471
+#, c-format
+msgid ""
+"\n"
+"Parameters can be turned on with -<param> or off with -<param>=0\n"
+"Parameters which take a value can be specified as -<param> <value>\n"
+"Other valid forms are <param>=<value> -<param>=<value> --<param>=<value>\n"
+"Parameter names are case-insensitive.  The parameters are:\n"
+"\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+"השימוש בהגדרה FullScreenAllMonitors הופסק, יש להגדיר את FullScreenMode לערך "
+"‚all’ במקום"
+
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+"השימוש ב־‎~/.vnc הופסק, נא לפנות למדריך ‚man vncviewer’ לאיתור הנתיבים שיש "
+"לעבור אליהם."
+
+#: vncviewer/vncviewer.cxx:556
+#, c-format
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
 msgstr "השימוש ב־%%APPDATA%%\\vnc הופסק, נא לעבור למקום %%APPDATA%%\\TigerVNC."
 
-#: vncviewer/vncviewer.cxx:730
+#: vncviewer/vncviewer.cxx:561
 #, c-format
-msgid "Could not create VNC config directory: %s"
-msgstr "לא ניתן ליצור את תיקיית ההגדרות של VNC:‏ %s"
+msgid "Could not create VNC config directory \"%s\": %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:735
-#, c-format
-msgid "Could not create VNC data directory: %s"
-msgstr "לא ניתן ליצור את תיקיית הנתונים של VNC:‏ %s"
+#: vncviewer/vncviewer.cxx:567
+msgid "Could not determine VNC data directory path"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:740
+#: vncviewer/vncviewer.cxx:573
 #, c-format
-msgid "Could not create VNC state directory: %s"
-msgstr "לא ניתן ליצור את תיקיית המצה של VNC:‏ %s"
+msgid "Could not create VNC data directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:585
+#, c-format
+msgid "Could not create VNC state directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:704
+#, c-format
+msgid "%s: Unrecognized option '%s'\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
+#, c-format
+msgid "See '%s --help' for more information.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:713
+#, c-format
+msgid "%s: Extra argument '%s'\n"
+msgstr ""
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:755 vncviewer/vncviewer.cxx:756
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "המשתנים ‎-listen ו־‎-via לא מתאימים יחד"
 
-#: vncviewer/vncviewer.cxx:770
+#: vncviewer/vncviewer.cxx:764
 msgid "Unable to listen for incoming connections"
 msgstr "לא ניתן להאזין לחיבורים נכנסים"
 
-#: vncviewer/vncviewer.cxx:772
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "בהאזנה בפתחה %d"
 
-#: vncviewer/vncviewer.cxx:805
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -1009,9 +1099,145 @@ msgstr ""
 "‬\n"
 "‏‫%s"
 
+#: vncviewer/vncviewer.cxx:816
+#, c-format
+msgid ""
+"Failure setting up encrypted tunnel:\n"
+"\n"
+"%s"
+msgstr ""
+
 #: vncviewer/vncviewer.desktop.in.in:4
-msgid "Remote Desktop Viewer"
-msgstr "מציג שולחנות עבודה מרוחקים"
+msgid "Remote desktop viewer"
+msgstr ""
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(בררת המחדל של השרת %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "‫SetDesktopSize נכשלה: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "‫SetColourMapEntries שגוי מהשרת!"
+
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "צוינו הגדרות שגויות עבור %s"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "מפתח הצג ‚%s’ שגוי"
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "התו ‚%c’ אינו צפוי"
+
+#~ msgid "TigerVNC Options"
+#~ msgstr "אפשרויות TigerVNC"
+
+#~ msgid "Show dot when no cursor"
+#~ msgstr "להציג נקודה כשאין סמן"
+
+#~ msgid "VNC Viewer: Connection Details"
+#~ msgstr "מציג VNC: פרטי התחברות"
+
+#~ msgid "Save As..."
+#~ msgstr "לשמור בשם…"
+
+#~ msgid "Could not obtain the state directory path"
+#~ msgstr "לא ניתן לקבל את נתיב תיקיית המצב"
+
+#, c-format
+#~ msgid "Could not open \"%s\": %s"
+#~ msgstr "לא ניתן לפתוח את „%s”:‏ %s"
+
+#, c-format
+#~ msgid "Failed to read line %d in file %s: %s"
+#~ msgstr "קריאת השורה %d בקובץ %s נכשלה: %s"
+
+#~ msgid "Authentication cancelled"
+#~ msgstr "האימות נכשל"
+
+#, c-format
+#~ msgid "Failed to update keyboard LED state: %d"
+#~ msgstr "עדכון מצב נורית המקלדת נכשל: %d"
+
+#~ msgid "No key code specified on key press"
+#~ msgstr "לא צוין קוד מקש עם לחיצה על מקש"
+
+#, c-format
+#~ msgid "No symbol for key code 0x%02x (in the current state)"
+#~ msgstr "אין סימן לקוד המקש 0x%02x (במצב הנוכחי)"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "&על המציג TigerVNC…"
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "המציג TigerVNC"
+
+#~ msgid "TigerVNC Viewer connection to a CentOS machine"
+#~ msgstr "התחברות מציג VNC למכונת CentOS"
+
+#~ msgid "TigerVNC Viewer connection to a macOS machine"
+#~ msgstr "התחברות מציג VNC למכונת macOS"
+
+#~ msgid "TigerVNC Viewer connection to a Windows machine"
+#~ msgstr "חיבור מציג VNC למכונת Windows"
+
+#~ msgid "Unknown parameter type"
+#~ msgstr "סוג המשתנה אינו ידוע"
+
+#~ msgid "Could not obtain the config directory path"
+#~ msgstr "לא ניתן לקבל את נתיב תיקיית ההגדרות"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC Viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "מציג TigerVNC‏ גרסה%s\n"
+#~ "‫נבנה על גבי: %s\n"
+#~ "‫כל הזכויות שמורות (C) 1999‏-%d לצוות TigerVNC ועוד רבים וטובים (ניתן לעיין "
+#~ "ב־README.rst)\n"
+#~ "‬‫למידע על TigerVNC מומלץ לפנות אל https://www.tigervnc.org."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "על אודות המציג TigerVNC"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "שגיאה בהצגת מציג TigerVNC חדש: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC Viewer will now exit."
+#~ msgstr "התקבל אות חיסול %d. מציג TigerVNC יסתיים כעת."
+
+#~ msgid "Hide Others"
+#~ msgstr "להסתיר אחרים"
+
+#~ msgid "Show All"
+#~ msgstr "להציג הכול"
+
+#, c-format
+#~ msgid "Could not create VNC config directory: %s"
+#~ msgstr "לא ניתן ליצור את תיקיית ההגדרות של VNC:‏ %s"
+
+#, c-format
+#~ msgid "Could not create VNC data directory: %s"
+#~ msgstr "לא ניתן ליצור את תיקיית הנתונים של VNC:‏ %s"
+
+#, c-format
+#~ msgid "Could not create VNC state directory: %s"
+#~ msgstr "לא ניתן ליצור את תיקיית המצה של VNC:‏ %s"
+
+#~ msgid "Remote Desktop Viewer"
+#~ msgstr "מציג שולחנות עבודה מרוחקים"
 
 #~ msgid "VNC Viewer: Connection Options"
 #~ msgstr "מציג VNC: אפשרויות התחברות"
@@ -1075,7 +1301,8 @@ msgstr "מציג שולחנות עבודה מרוחקים"
 #~ msgid "The parameter %s was too large to read from the registry"
 #~ msgstr "המשתנה %s היה גדול מכדי לקרוא מהרשומות"
 
-#~ msgid "Failed to write configuration file, can't obtain home directory path."
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
 #~ msgstr "כתיבת קובץ ההגדרות נכשלה, אי אפשר לקבל את נתיב תיקיית הבית."
 
 #~ msgid "Failed to write configuration file, can't open %s: %s"
@@ -1087,7 +1314,8 @@ msgstr "מציג שולחנות עבודה מרוחקים"
 #~ msgid "Unknown parameter %s on line %d in file %s"
 #~ msgstr "משתנה לא ידוע %s בשורה %d בקובץ %s"
 
-#~ msgid "Could not create VNC home directory: can't obtain home directory path."
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
 #~ msgstr "לא ניתן ליצור תיקיית בית VNC: לא ניתן לקבל את נתיב תיקיית הבית."
 
 #~ msgid "tigervnc"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.9.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2019-10-18 10:14+0200\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2019-11-23 23:25+0100\n"
 "Last-Translator: Balázs Úr <ur.balazs@fsf.hu>\n"
 "Language-Team: Hungarian <translation-team-hu@lists.sourceforge.net>\n"
@@ -19,703 +19,1253 @@ msgstr ""
 "X-Generator: Lokalize 19.04.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: vncviewer/CConn.cxx:99
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "Kapcsolódva a(z) %s foglalathoz"
 
-#: vncviewer/CConn.cxx:106
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "Kapcsolódva a(z) %s géphez a következő porton: %d"
 
-#: vncviewer/CConn.cxx:157
+#: vncviewer/CConn.cxx:115
+#, c-format
+msgid ""
+"Failed to connect to \"%s\":\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Asztal neve: %.80s"
 
-#: vncviewer/CConn.cxx:162
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Gép: %.80s port: %d"
 
-#: vncviewer/CConn.cxx:167
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Méret: %d x %d"
 
-#: vncviewer/CConn.cxx:175
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Képpontformátum: %s"
 
-#: vncviewer/CConn.cxx:182
-#, c-format
-msgid "(server default %s)"
-msgstr "(kiszolgáló alapértéke: %s)"
-
-#: vncviewer/CConn.cxx:187
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Kért kódolás: %s"
 
-#: vncviewer/CConn.cxx:192
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Legutóbb használt kódolás: %s"
 
-#: vncviewer/CConn.cxx:197
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Vonali sebesség becslés: %d kbit/s"
 
-#: vncviewer/CConn.cxx:202
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Protokollverzió: %d.%d"
 
-#: vncviewer/CConn.cxx:207
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Biztonsági módszer: %s"
 
-#: vncviewer/CConn.cxx:324
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
+msgstr ""
+
+#: vncviewer/CConn.cxx:258
 #, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "Az asztal méretének beállítása sikertelen: %d"
+msgid "Authentication failed: %s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:372
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "Érvénytelen színtérkép-bejegyzések beállítás a kiszolgálóról!"
+#: vncviewer/CConn.cxx:259
+#, c-format
+msgid ""
+"Failed to authenticate with the server. Reason given by the server:\n"
+"\n"
+"%s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:480
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Áteresztőképesség %d kbit/s – váltás a(z) %d. minőségre"
 
-#: vncviewer/CConn.cxx:502
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "Áteresztőképesség %d kbit/s – a teljes szín most engedélyezve"
 
-#: vncviewer/CConn.cxx:505
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "Áteresztőképesség %d kbit/s – a teljes szín most letiltva"
 
-#: vncviewer/CConn.cxx:531
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "%s képpontformátum használata"
 
-#: vncviewer/DesktopWindow.cxx:122
+#: vncviewer/DesktopWindow.cxx:146
 msgid "Invalid geometry specified!"
 msgstr "Érvénytelen geometria lett megadva!"
 
-#: vncviewer/DesktopWindow.cxx:495
-msgid "Adjusting window size to avoid accidental full screen request"
-msgstr "Ablakméret igazítása az esetleges teljes képernyős kérés elkerüléséhez"
+#: vncviewer/DesktopWindow.cxx:167
+msgid "Reducing window size to fit on current monitor"
+msgstr ""
 
-#: vncviewer/DesktopWindow.cxx:539
+#: vncviewer/DesktopWindow.cxx:681
+msgid "Adjusting window size to avoid accidental full-screen request"
+msgstr ""
+
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Nyomja meg a(z) %s billentyűt a helyi menü megnyitásához"
 
-#: vncviewer/DesktopWindow.cxx:836 vncviewer/DesktopWindow.cxx:844
-#: vncviewer/DesktopWindow.cxx:864
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "A billentyűzet elfogása sikertelen"
 
-#: vncviewer/DesktopWindow.cxx:938
-msgid "Failure grabbing mouse"
-msgstr "Az egér elfogása sikertelen"
-
-#: vncviewer/DesktopWindow.cxx:1162
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
 msgstr "Érvénytelen számított képernyő elrendezés az átméretezési kérésnél!"
 
-#: vncviewer/OptionsDialog.cxx:57
-msgid "VNC Viewer: Connection Options"
-msgstr "VNC megjelenítő: kapcsolat beállításai"
-
-#: vncviewer/OptionsDialog.cxx:83 vncviewer/ServerDialog.cxx:91
-#: vncviewer/vncviewer.cxx:282
-msgid "Cancel"
-msgstr "Mégse"
-
-#: vncviewer/OptionsDialog.cxx:88 vncviewer/vncviewer.cxx:281
-msgid "OK"
-msgstr "OK"
-
-#: vncviewer/OptionsDialog.cxx:423
-msgid "Compression"
-msgstr "Tömörítés"
-
-#: vncviewer/OptionsDialog.cxx:439
-msgid "Auto select"
-msgstr "Automatikus kiválasztás"
-
-#: vncviewer/OptionsDialog.cxx:451
-msgid "Preferred encoding"
-msgstr "Előnyben részesített kódolás"
-
-#: vncviewer/OptionsDialog.cxx:499
-msgid "Color level"
-msgstr "Színszint"
-
-#: vncviewer/OptionsDialog.cxx:510
-msgid "Full (all available colors)"
-msgstr "Teljes (az összes elérhető szín)"
-
-#: vncviewer/OptionsDialog.cxx:517
-msgid "Medium (256 colors)"
-msgstr "Közepes (256 szín)"
-
-#: vncviewer/OptionsDialog.cxx:524
-msgid "Low (64 colors)"
-msgstr "Alacsony (64 szín)"
-
-#: vncviewer/OptionsDialog.cxx:531
-msgid "Very low (8 colors)"
-msgstr "Nagyon alacsony (8 szín)"
-
-#: vncviewer/OptionsDialog.cxx:548
-msgid "Custom compression level:"
-msgstr "Egyéni tömörítési szint:"
-
-#: vncviewer/OptionsDialog.cxx:554
-msgid "level (1=fast, 6=best [4-6 are rarely useful])"
-msgstr "szint (1=gyors, 6=legjobb [4-6 ritkán hasznos])"
-
-#: vncviewer/OptionsDialog.cxx:561
-msgid "Allow JPEG compression:"
-msgstr "JPEG tömörítés engedélyezése:"
-
-#: vncviewer/OptionsDialog.cxx:567
-msgid "quality (0=poor, 9=best)"
-msgstr "minőség (0=szegényes, 9=legjobb)"
-
-#: vncviewer/OptionsDialog.cxx:578
-msgid "Security"
-msgstr "Biztonság"
-
-#: vncviewer/OptionsDialog.cxx:593
-msgid "Encryption"
-msgstr "Titkosítás"
-
-#: vncviewer/OptionsDialog.cxx:604 vncviewer/OptionsDialog.cxx:657
-#: vncviewer/OptionsDialog.cxx:737
-msgid "None"
-msgstr "Nincs"
-
-#: vncviewer/OptionsDialog.cxx:610
-msgid "TLS with anonymous certificates"
-msgstr "TLS névtelen tanúsítványokkal"
-
-#: vncviewer/OptionsDialog.cxx:616
-msgid "TLS with X509 certificates"
-msgstr "TLS X509 tanúsítványokkal"
-
-#: vncviewer/OptionsDialog.cxx:623
-msgid "Path to X509 CA certificate"
-msgstr "Útvonal az X509 CA tanúsítványhoz"
-
-#: vncviewer/OptionsDialog.cxx:630
-msgid "Path to X509 CRL file"
-msgstr "Útvonal az X509 CRL fájlhoz"
-
-#: vncviewer/OptionsDialog.cxx:646
-msgid "Authentication"
-msgstr "Hitelesítés"
-
-#: vncviewer/OptionsDialog.cxx:663
-msgid "Standard VNC (insecure without encryption)"
-msgstr "Szabványos VNC (titkosítás nélkül nem biztonságos)"
-
-#: vncviewer/OptionsDialog.cxx:669
-msgid "Username and password (insecure without encryption)"
-msgstr "Felhasználónév és jelszó (titkosítás nélkül nem biztonságos)"
-
-#: vncviewer/OptionsDialog.cxx:688
-msgid "Input"
-msgstr "Bemenet"
-
-#: vncviewer/OptionsDialog.cxx:696
-msgid "View only (ignore mouse and keyboard)"
-msgstr "Csak megtekintés (egér és billentyűzet mellőzése)"
-
-#: vncviewer/OptionsDialog.cxx:702
-msgid "Accept clipboard from server"
-msgstr "Vágólap elfogadása a kiszolgálóról"
-
-#: vncviewer/OptionsDialog.cxx:710
-msgid "Also set primary selection"
-msgstr "Elsődleges kijelölés beállítása"
-
-#: vncviewer/OptionsDialog.cxx:717
-msgid "Send clipboard to server"
-msgstr "Vágólap küldése a kiszolgálónak"
-
-#: vncviewer/OptionsDialog.cxx:725
-msgid "Send primary selection as clipboard"
-msgstr "Elsődleges kijelölés küldése vágólapként"
-
-#: vncviewer/OptionsDialog.cxx:732
-msgid "Pass system keys directly to server (full screen)"
-msgstr "Rendszerbillentyűk közvetlen átadása a kiszolgálónak (teljes képernyő)"
-
-#: vncviewer/OptionsDialog.cxx:735
-msgid "Menu key"
-msgstr "Menü billentyű"
-
-#: vncviewer/OptionsDialog.cxx:751
-msgid "Screen"
-msgstr "Képernyő"
-
-#: vncviewer/OptionsDialog.cxx:759
-msgid "Resize remote session on connect"
-msgstr "Távoli munkamenet átméretezése kapcsolódáskor"
-
-#: vncviewer/OptionsDialog.cxx:772
-msgid "Resize remote session to the local window"
-msgstr "Távoli munkamenet átméretezése a helyi ablakhoz"
-
-#: vncviewer/OptionsDialog.cxx:778
-msgid "Full-screen mode"
-msgstr "Teljes képernyős mód"
-
-#: vncviewer/OptionsDialog.cxx:784
-msgid "Enable full-screen mode over all monitors"
-msgstr "Teljes képernyős mód engedélyezése az összes kijelzőn"
-
-#: vncviewer/OptionsDialog.cxx:793
-msgid "Misc."
-msgstr "Egyéb"
-
-#: vncviewer/OptionsDialog.cxx:801
-msgid "Shared (don't disconnect other viewers)"
-msgstr "Megosztott (ne válassza le a többi nézőt)"
-
-#: vncviewer/OptionsDialog.cxx:807
-msgid "Show dot when no cursor"
-msgstr "Pont megjelenítése, ha nincs kurzor"
-
-#: vncviewer/ServerDialog.cxx:42
-msgid "VNC Viewer: Connection Details"
-msgstr "VNC megjelenítő: kapcsolat részletei"
-
-#: vncviewer/ServerDialog.cxx:49 vncviewer/ServerDialog.cxx:54
-msgid "VNC server:"
-msgstr "VNC kiszolgáló:"
-
-#: vncviewer/ServerDialog.cxx:64
-msgid "Options..."
-msgstr "Beállítások…"
-
-#: vncviewer/ServerDialog.cxx:69
-msgid "Load..."
-msgstr "Betöltés…"
-
-#: vncviewer/ServerDialog.cxx:74
-msgid "Save As..."
-msgstr "Mentés másként…"
-
-#: vncviewer/ServerDialog.cxx:86
-msgid "About..."
-msgstr "Névjegy…"
-
-#: vncviewer/ServerDialog.cxx:96
-msgid "Connect"
-msgstr "Kapcsolódás"
-
-#: vncviewer/ServerDialog.cxx:137 vncviewer/ServerDialog.cxx:171
-msgid "TigerVNC configuration (*.tigervnc)"
-msgstr "TigerVNC-beállítás (*.tigervnc)"
-
-#: vncviewer/ServerDialog.cxx:138
-msgid "Select a TigerVNC configuration file"
-msgstr "Válasszon egy TigerVNC-beállítófájlt"
-
-#: vncviewer/ServerDialog.cxx:172
-msgid "Save the TigerVNC configuration to file"
-msgstr "A TigerVNC-beállítás mentése fájlba"
-
-#: vncviewer/ServerDialog.cxx:197
-#, c-format
-msgid "%s already exists. Do you want to overwrite?"
-msgstr "A(z) %s már létezik. Szeretné felülírni?"
-
-#: vncviewer/ServerDialog.cxx:198 vncviewer/vncviewer.cxx:279
-msgid "No"
-msgstr "Nem"
-
-#: vncviewer/ServerDialog.cxx:198
-msgid "Overwrite"
-msgstr "Felülírás"
-
-#: vncviewer/UserDialog.cxx:85
-msgid "Opening password file failed"
-msgstr "A jelszófájl megnyitása sikertelen"
-
-#: vncviewer/UserDialog.cxx:105
-msgid "VNC authentication"
-msgstr "VNC hitelesítés"
-
-#: vncviewer/UserDialog.cxx:112
-msgid "This connection is secure"
-msgstr "Ez a kapcsolat biztonságos"
-
-#: vncviewer/UserDialog.cxx:116
-msgid "This connection is not secure"
-msgstr "Ez a kapcsolat nem biztonságos"
-
-#: vncviewer/UserDialog.cxx:133
-msgid "Username:"
-msgstr "Felhasználónév:"
-
-#: vncviewer/UserDialog.cxx:146
-msgid "Password:"
-msgstr "Jelszó:"
-
-#: vncviewer/UserDialog.cxx:185
-msgid "Authentication cancelled"
-msgstr "Hitelesítés megszakítva"
-
-#: vncviewer/Viewport.cxx:389
-#, c-format
-msgid "Failed to update keyboard LED state: %lu"
-msgstr "Nem sikerült frissíteni a billentyűzet LED állapotát: %lu"
-
-#: vncviewer/Viewport.cxx:395 vncviewer/Viewport.cxx:401
-#, c-format
-msgid "Failed to update keyboard LED state: %d"
-msgstr "Nem sikerült frissíteni a billentyűzet LED állapotát: %d"
-
-#: vncviewer/Viewport.cxx:431
-msgid "Failed to update keyboard LED state"
-msgstr "Nem sikerült frissíteni a billentyűzet LED állapotát"
-
-#: vncviewer/Viewport.cxx:458 vncviewer/Viewport.cxx:466
-#: vncviewer/Viewport.cxx:483
-#, c-format
-msgid "Failed to get keyboard LED state: %d"
-msgstr "Nem sikerült lekérni a billentyűzet LED állapotát: %d"
-
-#: vncviewer/Viewport.cxx:833
-msgid "No key code specified on key press"
-msgstr "Nincs billentyűkód megadva a billentyűzetlenyomáskor"
-
-#: vncviewer/Viewport.cxx:982
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
+msgid "Invalid state for 3 button emulation"
+msgstr ""
+
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "Nincs keresőkód a kiterjesztett virtuális billentyűhöz: 0x%02x"
 
-#: vncviewer/Viewport.cxx:984
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "Nincs keresőkód a virtuális billentyűhöz: 0x%02x"
 
-#: vncviewer/Viewport.cxx:990
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "Érvénytelen keresőkód: 0x%02x"
 
-#: vncviewer/Viewport.cxx:1020
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "Nincs szimbólum a kiterjesztett virtuális billentyűhöz: 0x%02x"
 
-#: vncviewer/Viewport.cxx:1022
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "Nincs szimbólum a virtuális billentyűhöz: 0x%02x"
 
-#: vncviewer/Viewport.cxx:1115
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
-msgid "No symbol for key code 0x%02x (in the current state)"
-msgstr "Nincs szimbólum a billentyűkódhoz: 0x%02x (a jelenlegi állapotban)"
+msgid "Failed to update keyboard LED state: %lu"
+msgstr "Nem sikerült frissíteni a billentyűzet LED állapotát: %lu"
 
-#: vncviewer/Viewport.cxx:1148
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "Nincs szimbólum a billentyűkódhoz: %d (a jelenlegi állapotban)"
 
-#: vncviewer/Viewport.cxx:1199
-msgctxt "ContextMenu|"
-msgid "E&xit viewer"
-msgstr "&Kilépés a megjelenítőből"
+#: vncviewer/KeyboardX11.cxx:148
+#, c-format
+msgid "Failed to get keyboard LED state: %d"
+msgstr "Nem sikerült lekérni a billentyűzet LED állapotát: %d"
 
-#: vncviewer/Viewport.cxx:1202
+#: vncviewer/KeyboardX11.cxx:193
+msgid "Failed to update keyboard LED state"
+msgstr "Nem sikerült frissíteni a billentyűzet LED állapotát"
+
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
+msgid "Failed to get system monitor configuration"
+msgstr ""
+
+#: vncviewer/MonitorIndicesParameter.cxx:73
+#, c-format
+msgid "Monitor index %d does not exist"
+msgstr ""
+
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
+msgid "TigerVNC options"
+msgstr ""
+
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
+msgid "Cancel"
+msgstr "Mégse"
+
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
+msgid "OK"
+msgstr "OK"
+
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
+msgid "Compression"
+msgstr "Tömörítés"
+
+#: vncviewer/OptionsDialog.cxx:524
+msgid "Auto select"
+msgstr "Automatikus kiválasztás"
+
+#: vncviewer/OptionsDialog.cxx:536
+msgid "Preferred encoding"
+msgstr "Előnyben részesített kódolás"
+
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
+msgid "Color level"
+msgstr "Színszint"
+
+#: vncviewer/OptionsDialog.cxx:611
+msgid "Full"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:619
+msgid "Medium"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:627
+msgid "Low"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:635
+msgid "Very low"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:658
+msgid "Custom compression level:"
+msgstr "Egyéni tömörítési szint:"
+
+#: vncviewer/OptionsDialog.cxx:666
+msgid "level (0=fast, 9=best)"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:674
+msgid "Allow JPEG compression:"
+msgstr "JPEG tömörítés engedélyezése:"
+
+#: vncviewer/OptionsDialog.cxx:682
+msgid "quality (0=poor, 9=best)"
+msgstr "minőség (0=szegényes, 9=legjobb)"
+
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
+msgid "Security"
+msgstr "Biztonság"
+
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
+msgid "Encryption"
+msgstr "Titkosítás"
+
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
+msgid "None"
+msgstr "Nincs"
+
+#: vncviewer/OptionsDialog.cxx:730
+msgid "TLS with anonymous certificates"
+msgstr "TLS névtelen tanúsítványokkal"
+
+#: vncviewer/OptionsDialog.cxx:737
+msgid "TLS with X509 certificates"
+msgstr "TLS X509 tanúsítványokkal"
+
+#: vncviewer/OptionsDialog.cxx:745
+msgid "Path to X509 CA certificate"
+msgstr "Útvonal az X509 CA tanúsítványhoz"
+
+#: vncviewer/OptionsDialog.cxx:753
+msgid "Path to X509 CRL file"
+msgstr "Útvonal az X509 CRL fájlhoz"
+
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
+msgid "Authentication"
+msgstr "Hitelesítés"
+
+#: vncviewer/OptionsDialog.cxx:802
+msgid "Standard VNC (insecure without encryption)"
+msgstr "Szabványos VNC (titkosítás nélkül nem biztonságos)"
+
+#: vncviewer/OptionsDialog.cxx:809
+msgid "Username and password (insecure without encryption)"
+msgstr "Felhasználónév és jelszó (titkosítás nélkül nem biztonságos)"
+
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
+msgid "Input"
+msgstr "Bemenet"
+
+#: vncviewer/OptionsDialog.cxx:852
+msgid "View only (ignore mouse and keyboard)"
+msgstr "Csak megtekintés (egér és billentyűzet mellőzése)"
+
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
+msgid "Mouse"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:873
+msgid "Emulate middle mouse button"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:880
+msgid "Show local cursor when not provided by server"
+msgstr ""
+
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
+msgid "Cursor type"
+msgstr ""
+
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
+msgid "Dot"
+msgstr ""
+
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
+msgid "System"
+msgstr ""
+
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
+msgid "Keyboard"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:925
+msgid "Pass system keys directly to server (full screen)"
+msgstr "Rendszerbillentyűk közvetlen átadása a kiszolgálónak (teljes képernyő)"
+
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
+msgid "Menu key"
+msgstr "Menü billentyű"
+
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
+msgid "Clipboard"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:968
+msgid "Accept clipboard from server"
+msgstr "Vágólap elfogadása a kiszolgálóról"
+
+#: vncviewer/OptionsDialog.cxx:977
+msgid "Also set primary selection"
+msgstr "Elsődleges kijelölés beállítása"
+
+#: vncviewer/OptionsDialog.cxx:985
+msgid "Send clipboard to server"
+msgstr "Vágólap küldése a kiszolgálónak"
+
+#: vncviewer/OptionsDialog.cxx:994
+msgid "Send primary selection as clipboard"
+msgstr "Elsődleges kijelölés küldése vágólapként"
+
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
+msgid "Display"
+msgstr ""
+
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
+msgid "Display mode"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1045
+msgid "Windowed"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1054
+msgid "Full screen on current monitor"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1063
+msgid "Full screen on all monitors"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1072
+msgid "Full screen on selected monitor(s)"
+msgstr ""
+
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
+msgid "Miscellaneous"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1111
+msgid "Shared (don't disconnect other viewers)"
+msgstr "Megosztott (ne válassza le a többi nézőt)"
+
+#: vncviewer/OptionsDialog.cxx:1118
+msgid "Ask to reconnect on connection errors"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:73
+msgid "VNC server:"
+msgstr "VNC kiszolgáló:"
+
+#: vncviewer/ServerDialog.cxx:80
+msgid "Options..."
+msgstr "Beállítások…"
+
+#: vncviewer/ServerDialog.cxx:84
+msgid "Load..."
+msgstr "Betöltés…"
+
+#: vncviewer/ServerDialog.cxx:88
+msgid "Save as..."
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:102
+msgid "About..."
+msgstr "Névjegy…"
+
+#: vncviewer/ServerDialog.cxx:111
+msgid "Connect"
+msgstr "Kapcsolódás"
+
+#: vncviewer/ServerDialog.cxx:147
+#, c-format
+msgid ""
+"Unable to load the server history:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:176 vncviewer/ServerDialog.cxx:216
+msgid "TigerVNC configuration (*.tigervnc)"
+msgstr "TigerVNC-beállítás (*.tigervnc)"
+
+#: vncviewer/ServerDialog.cxx:177
+msgid "Select a TigerVNC configuration file"
+msgstr "Válasszon egy TigerVNC-beállítófájlt"
+
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
+#, c-format
+msgid ""
+"Unable to load the specified configuration file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:217
+msgid "Save the TigerVNC configuration to file"
+msgstr "A TigerVNC-beállítás mentése fájlba"
+
+#: vncviewer/ServerDialog.cxx:243
+#, c-format
+msgid "%s already exists. Do you want to overwrite?"
+msgstr "A(z) %s már létezik. Szeretné felülírni?"
+
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
+msgid "No"
+msgstr "Nem"
+
+#: vncviewer/ServerDialog.cxx:244
+msgid "Overwrite"
+msgstr "Felülírás"
+
+#: vncviewer/ServerDialog.cxx:260
+#, c-format
+msgid ""
+"Unable to save the specified configuration file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:294
+#, c-format
+msgid ""
+"Unable to save the default configuration:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:306
+#, c-format
+msgid ""
+"Unable to save the server history:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
+msgid "Could not determine VNC state directory path"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
+#, c-format
+msgid "Could not open \"%s\""
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
+#, c-format
+msgid "Failed to read line %d in file \"%s\""
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
+msgid "Line too long"
+msgstr "Túl hosszú sor"
+
+#: vncviewer/UserDialog.cxx:130
+msgid "Opening password file failed"
+msgstr "A jelszófájl megnyitása sikertelen"
+
+#: vncviewer/UserDialog.cxx:150
+msgid "VNC authentication"
+msgstr "VNC hitelesítés"
+
+#: vncviewer/UserDialog.cxx:157
+msgid "This connection is secure"
+msgstr "Ez a kapcsolat biztonságos"
+
+#: vncviewer/UserDialog.cxx:161
+msgid "This connection is not secure"
+msgstr "Ez a kapcsolat nem biztonságos"
+
+#: vncviewer/UserDialog.cxx:183
+msgid "Username:"
+msgstr "Felhasználónév:"
+
+#: vncviewer/UserDialog.cxx:196
+msgid "Password:"
+msgstr "Jelszó:"
+
+#: vncviewer/UserDialog.cxx:204
+msgid "Keep password for reconnect"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:749
+msgctxt "ContextMenu|"
+msgid "Disconn&ect"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "&Teljes képernyő"
 
-#: vncviewer/Viewport.cxx:1205
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "Minimali&zálás"
 
-#: vncviewer/Viewport.cxx:1207
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "&Ablak átméretezése a munkamenethez"
 
-#: vncviewer/Viewport.cxx:1212
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:1215
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:1221
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "%s küldése"
 
-#: vncviewer/Viewport.cxx:1227
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Ctrl+Alt+&Del küldése"
 
-#: vncviewer/Viewport.cxx:1230
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "Képernyő &frissítése"
 
-#: vncviewer/Viewport.cxx:1233
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&Beállítások…"
 
-#: vncviewer/Viewport.cxx:1235
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "Kapcsolat&információk…"
 
-#: vncviewer/Viewport.cxx:1237
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "A &TigerVNC megjelenítő névjegye…"
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:1240
-msgctxt "ContextMenu|"
-msgid "Dismiss &menu"
-msgstr "&Menü eltüntetése"
-
-#: vncviewer/Viewport.cxx:1329
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "VNC kapcsolatinformációk"
 
-#: vncviewer/parameters.cxx:278 vncviewer/parameters.cxx:312
-#, c-format
-msgid "The name of the parameter %s was too large to write to the registry"
-msgstr "A(z) %s paraméter neve túl nagy volt a regisztrációs adatbázisba történő íráshoz"
-
-#: vncviewer/parameters.cxx:284 vncviewer/parameters.cxx:291
-#, c-format
-msgid "The parameter %s was too large to write to the registry"
-msgstr "A(z) %s paraméter túl nagy volt a regisztrációs adatbázisba történő íráshoz"
-
-#: vncviewer/parameters.cxx:297 vncviewer/parameters.cxx:318
-#, c-format
-msgid "Failed to write parameter %s of type %s to the registry: %ld"
-msgstr "Nem sikerült a(z) %2$s típusú %1$s paraméter írása a regisztrációs adatbázisba: %3$ld"
-
-#: vncviewer/parameters.cxx:334 vncviewer/parameters.cxx:377
-#, c-format
-msgid "The name of the parameter %s was too large to read from the registry"
-msgstr "A(z) %s paraméter neve túl nagy volt a regisztrációs adatbázisból történő olvasáshoz"
-
-#: vncviewer/parameters.cxx:346 vncviewer/parameters.cxx:386
-#, c-format
-msgid "Failed to read parameter %s from the registry: %ld"
-msgstr "Nem sikerült a(z) %s paraméter olvasása a regisztrációs adatbázisból: %ld"
-
-#: vncviewer/parameters.cxx:357
-#, c-format
-msgid "The parameter %s was too large to read from the registry"
-msgstr "A(z) %s paraméter túl nagy volt a regisztrációs adatbázisból történő olvasáshoz"
-
-#: vncviewer/parameters.cxx:406
-#, c-format
-msgid "Failed to create registry key: %ld"
-msgstr "Nem sikerült létrehozni a regisztrációs adatbázis kulcsot: %ld"
-
-#: vncviewer/parameters.cxx:420 vncviewer/parameters.cxx:469
-#: vncviewer/parameters.cxx:532 vncviewer/parameters.cxx:666
-#, c-format
-msgid "Unknown parameter type for parameter %s"
-msgstr "Ismeretlen paramétertípus a(z) %s paraméternél"
-
-#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:476
-#, c-format
-msgid "Failed to close registry key: %ld"
-msgstr "Nem sikerült lezárni a regisztrációs adatbázis kulcsot: %ld"
-
-#: vncviewer/parameters.cxx:443
-#, c-format
-msgid "Failed to open registry key: %ld"
-msgstr "Nem sikerült megnyitni a regisztrációs adatbázis kulcsot: %ld"
-
-#: vncviewer/parameters.cxx:500
-msgid "Failed to write configuration file, can't obtain home directory path."
-msgstr "Nem sikerült kiírni a beállítófájlt, nem lehet megszerezni a saját könyvtár útvonalát."
-
-#: vncviewer/parameters.cxx:514
-#, c-format
-msgid "Failed to write configuration file, can't open %s: %s"
-msgstr "Nem sikerült kiírni a beállítófájlt, nem lehet megnyitni: %s: %s"
-
-#: vncviewer/parameters.cxx:559
-msgid "Failed to read configuration file, can't obtain home directory path."
-msgstr "Nem sikerült beolvasni a beállítófájlt, nem lehet megszerezni a saját könyvtár útvonalát."
-
-#: vncviewer/parameters.cxx:573
-#, c-format
-msgid "Failed to read configuration file, can't open %s: %s"
-msgstr "Nem sikerült beolvasni a beállítófájlt, nem lehet megnyitni: %s: %s"
-
-#: vncviewer/parameters.cxx:586 vncviewer/parameters.cxx:591
-#: vncviewer/parameters.cxx:616 vncviewer/parameters.cxx:629
-#: vncviewer/parameters.cxx:645
-#, c-format
-msgid "Failed to read line %d in file %s: %s"
-msgstr "Nem sikerült a(z) %d. sort olvasni a(z) %s fájlban: %s"
-
-#: vncviewer/parameters.cxx:592
-msgid "Line too long"
-msgstr "Túl hosszú sor"
-
-#: vncviewer/parameters.cxx:599
-#, c-format
-msgid "Configuration file %s is in an invalid format"
-msgstr "A(z) %s beállítófájl érvénytelen formátumú"
-
-#: vncviewer/parameters.cxx:617
-msgid "Invalid format"
-msgstr "Érvénytelen formátum"
-
-#: vncviewer/parameters.cxx:630 vncviewer/parameters.cxx:646
-msgid "Invalid format or too large value"
-msgstr "Érvénytelen formátum vagy túl nagy érték"
-
-#: vncviewer/parameters.cxx:673
-#, c-format
-msgid "Unknown parameter %s on line %d in file %s"
-msgstr "Ismeretlen %s paraméter a(z) %d. sornál a(z) %s fájlban"
-
-#: vncviewer/vncviewer.cxx:100
-#, c-format
-msgid ""
-"TigerVNC Viewer %d-bit v%s\n"
-"Built on: %s\n"
-"Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
-"See https://www.tigervnc.org for information on TigerVNC."
+#: vncviewer/Win32TouchHandler.cxx:49
+msgid "Window is registered for touch instead of gestures"
 msgstr ""
-"TigerVNC megjelenítő: %d bites, %s verzió\n"
-"Összeállítva: %s\n"
-"Copyright (C) 1999-%d TigerVNC csapat és sokan mások (lásd: README.rst)\n"
-"Nézze meg a https://www.tigervnc.org oldalt a TigerVNC információiért."
 
-#: vncviewer/vncviewer.cxx:127
-msgid "About TigerVNC Viewer"
-msgstr "A TigerVNC megjelenítő névjegye"
-
-#: vncviewer/vncviewer.cxx:140
-msgid "Internal FLTK error. Exiting."
-msgstr "Belső FLTK hiba. Kilépés."
-
-#: vncviewer/vncviewer.cxx:158 vncviewer/vncviewer.cxx:170
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Hiba az új TigerVNC megjelenítő indításakor: %s"
+msgid "Failed to set gesture configuration (error 0x%x)"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:179
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC Viewer will now exit."
-msgstr "%d befejezési szignál érkezett. A TigerVNC megjelenítő most ki fog lépni."
+msgid "Failed to get gesture information (error 0x%x)"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:271 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC Viewer"
-msgstr "TigerVNC megjelenítő"
-
-#: vncviewer/vncviewer.cxx:280
-msgid "Yes"
-msgstr "Igen"
-
-#: vncviewer/vncviewer.cxx:283
-msgid "Close"
-msgstr "Bezárás"
-
-#: vncviewer/vncviewer.cxx:288
-msgid "About"
-msgstr "Névjegy"
-
-#: vncviewer/vncviewer.cxx:291
-msgid "Hide"
-msgstr "Elrejtés"
-
-#: vncviewer/vncviewer.cxx:294
-msgid "Quit"
-msgstr "Kilépés"
-
-#: vncviewer/vncviewer.cxx:298
-msgid "Services"
-msgstr "Szolgáltatások"
-
-#: vncviewer/vncviewer.cxx:299
-msgid "Hide Others"
-msgstr "Egyebek elrejtése"
-
-#: vncviewer/vncviewer.cxx:300
-msgid "Show All"
-msgstr "Összes megjelenítése"
-
-#: vncviewer/vncviewer.cxx:309
-msgctxt "SysMenu|"
-msgid "&File"
-msgstr "&Fájl"
-
-#: vncviewer/vncviewer.cxx:312
-msgctxt "SysMenu|File|"
-msgid "&New Connection"
-msgstr "Új &kapcsolat"
-
-#: vncviewer/vncviewer.cxx:324
-msgid "Could not create VNC home directory: can't obtain home directory path."
-msgstr "Nem sikerült létrehozni a VNC saját könyvtárát: nem lehet megszerezni a saját könyvtár útvonalát."
-
-#: vncviewer/vncviewer.cxx:329
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
-msgid "Could not create VNC home directory: %s."
-msgstr "Nem sikerült létrehozni a VNC saját könyvtárát: %s"
+msgid "Invalid mouse button %d, must be a number between 1 and 7."
+msgstr ""
 
-#. TRANSLATORS: "Parameters" are command line arguments, or settings
-#. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:602 vncviewer/vncviewer.cxx:604
-msgid "Parameters -listen and -via are incompatible"
-msgstr "A -listen és a -via paraméterek összeférhetetlenek"
-
-#: vncviewer/vncviewer.cxx:619
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
-msgid "Listening on port %d"
-msgstr "Figyelés ezen a porton: %d"
+msgid "Unhandled key 0x%x - can't generate keyboard event."
+msgstr ""
 
-#: vncviewer/vncviewer.desktop.in.in:4
-msgid "Remote Desktop Viewer"
-msgstr "Távoli asztal megjelenítő"
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
+#, c-format
+msgid "Unable to get X Input 2 event mask for window 0x%08lx"
+msgstr ""
 
+#: vncviewer/XInputTouchHandler.cxx:105
+#, c-format
+msgid "Window 0x%08lx has no X Input 2 event mask"
+msgstr ""
+
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
+#, c-format
+msgid "Window 0x%08lx has more than one X Input 2 event mask"
+msgstr ""
+
+#: vncviewer/XInputTouchHandler.cxx:144
+#, c-format
+msgid "Failure grabbing device %i"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
 msgid "Connect to VNC server and display remote desktop"
 msgstr "Kapcsolódás VNC-kiszolgálóhoz és távoli asztal megjelenítése"
 
-#: vncviewer/vncviewer.desktop.in.in:7
-msgid "tigervnc"
-msgstr "tigervnc"
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
+
+#. developer_name tag deprecated with Appstream 1.0
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
+msgid "The TigerVNC team"
+msgstr ""
+
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
+msgid "The name of the parameter is too large"
+msgstr ""
+
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
+msgid "The parameter is too large"
+msgstr ""
+
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
+msgid "Invalid format or too large value"
+msgstr "Érvénytelen formátum vagy túl nagy érték"
+
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
+msgid "Failed to create registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
+msgid "Failed to close registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
+#, c-format
+msgid "Failed to save \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
+#, c-format
+msgid "Failed to remove \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
+msgid "Failed to open registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:635
+#, c-format
+msgid "Failed to read server history entry %d: %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
+#, c-format
+msgid "Failed to read parameter \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
+msgid "Could not determine VNC config directory path"
+msgstr ""
+
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
+msgid "Could not encode parameter"
+msgstr ""
+
+#: vncviewer/parameters.cxx:872
+#, c-format
+msgid "Configuration file %s is in an invalid format"
+msgstr "A(z) %s beállítófájl érvénytelen formátumú"
+
+#: vncviewer/parameters.cxx:895
+msgid "Invalid format"
+msgstr "Érvénytelen formátum"
+
+#: vncviewer/parameters.cxx:939
+msgid "Unknown parameter"
+msgstr ""
+
+#: vncviewer/touch.cxx:75
+#, c-format
+msgid "Got message (0x%x) for an unhandled window"
+msgstr ""
+
+#: vncviewer/touch.cxx:138 vncviewer/touch.cxx:160
+#, c-format
+msgid "Invalid window 0x%08lx specified for pointer grab"
+msgstr ""
+
+#: vncviewer/touch.cxx:183 vncviewer/touch.cxx:184
+#, c-format
+msgid "Failed to create touch handler: %s"
+msgstr ""
+
+#: vncviewer/touch.cxx:188
+#, c-format
+msgid "Couldn't attach event handler to window (error 0x%x)"
+msgstr ""
+
+#: vncviewer/touch.cxx:215
+msgid "Failed to get event data for X Input event"
+msgstr ""
+
+#: vncviewer/touch.cxx:228
+msgid "X Input event for unknown window"
+msgstr ""
+
+#: vncviewer/touch.cxx:254
+msgid "X Input extension not available."
+msgstr ""
+
+#: vncviewer/touch.cxx:261
+msgid "X Input 2 (or newer) is not available."
+msgstr ""
+
+#: vncviewer/touch.cxx:266
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:103
+#, c-format
+msgid ""
+"TigerVNC v%s\n"
+"Built on: %s\n"
+"Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+"See https://www.tigervnc.org for information on TigerVNC."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:157
+#, c-format
+msgid ""
+"An unexpected error occurred when communicating with the server:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:194
+msgid "Internal FLTK error. Exiting."
+msgstr "Belső FLTK hiba. Kilépés."
+
+#: vncviewer/vncviewer.cxx:213
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"Attempt to reconnect?"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
+#, c-format
+msgid "Error starting new connection: %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:265
+#, c-format
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:394
+msgid "Yes"
+msgstr "Igen"
+
+#: vncviewer/vncviewer.cxx:397
+msgid "Close"
+msgstr "Bezárás"
+
+#: vncviewer/vncviewer.cxx:402
+msgid "About"
+msgstr "Névjegy"
+
+#: vncviewer/vncviewer.cxx:405
+msgid "Hide"
+msgstr "Elrejtés"
+
+#: vncviewer/vncviewer.cxx:408
+msgid "Quit"
+msgstr "Kilépés"
+
+#: vncviewer/vncviewer.cxx:412
+msgid "Services"
+msgstr "Szolgáltatások"
+
+#: vncviewer/vncviewer.cxx:413
+msgid "Hide others"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:414
+msgid "Show all"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:423
+msgctxt "SysMenu|"
+msgid "&File"
+msgstr "&Fájl"
+
+#: vncviewer/vncviewer.cxx:426
+msgctxt "SysMenu|File|"
+msgid "&New Connection"
+msgstr "Új &kapcsolat"
+
+#: vncviewer/vncviewer.cxx:449
+#, c-format
+msgid ""
+"\n"
+"Usage: %s [parameters] [host][:displayNum]\n"
+"       %s [parameters] [host][::port]\n"
+"       %s [parameters] [unix socket]\n"
+"       %s [parameters] -listen [port]\n"
+"       %s [parameters] [.tigervnc file]\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:464
+#, c-format
+msgid ""
+"\n"
+"Options:\n"
+"\n"
+"  -display Xdisplay  - Specifies the X display for the viewer window\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
+"                       man page for details.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:471
+#, c-format
+msgid ""
+"\n"
+"Parameters can be turned on with -<param> or off with -<param>=0\n"
+"Parameters which take a value can be specified as -<param> <value>\n"
+"Other valid forms are <param>=<value> -<param>=<value> --<param>=<value>\n"
+"Parameter names are case-insensitive.  The parameters are:\n"
+"\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:556
+#, c-format
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:561
+#, c-format
+msgid "Could not create VNC config directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:567
+msgid "Could not determine VNC data directory path"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:573
+#, c-format
+msgid "Could not create VNC data directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:585
+#, c-format
+msgid "Could not create VNC state directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:704
+#, c-format
+msgid "%s: Unrecognized option '%s'\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
+#, c-format
+msgid "See '%s --help' for more information.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:713
+#, c-format
+msgid "%s: Extra argument '%s'\n"
+msgstr ""
+
+#. TRANSLATORS: "Parameters" are command line arguments, or settings
+#. from a file or the Windows registry.
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
+msgid "Parameters -listen and -via are incompatible"
+msgstr "A -listen és a -via paraméterek összeférhetetlenek"
+
+#: vncviewer/vncviewer.cxx:764
+msgid "Unable to listen for incoming connections"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:766
+#, c-format
+msgid "Listening on port %d"
+msgstr "Figyelés ezen a porton: %d"
+
+#: vncviewer/vncviewer.cxx:795
+#, c-format
+msgid ""
+"Failure waiting for incoming VNC connection:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:816
+#, c-format
+msgid ""
+"Failure setting up encrypted tunnel:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.desktop.in.in:4
+msgid "Remote desktop viewer"
+msgstr ""
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(kiszolgáló alapértéke: %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "Az asztal méretének beállítása sikertelen: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "Érvénytelen színtérkép-bejegyzések beállítás a kiszolgálóról!"
+
+#~ msgid "Adjusting window size to avoid accidental full screen request"
+#~ msgstr ""
+#~ "Ablakméret igazítása az esetleges teljes képernyős kérés elkerüléséhez"
+
+#~ msgid "Failure grabbing mouse"
+#~ msgstr "Az egér elfogása sikertelen"
+
+#~ msgid "VNC Viewer: Connection Options"
+#~ msgstr "VNC megjelenítő: kapcsolat beállításai"
+
+#~ msgid "Full (all available colors)"
+#~ msgstr "Teljes (az összes elérhető szín)"
+
+#~ msgid "Medium (256 colors)"
+#~ msgstr "Közepes (256 szín)"
+
+#~ msgid "Low (64 colors)"
+#~ msgstr "Alacsony (64 szín)"
+
+#~ msgid "Very low (8 colors)"
+#~ msgstr "Nagyon alacsony (8 szín)"
+
+#~ msgid "level (1=fast, 6=best [4-6 are rarely useful])"
+#~ msgstr "szint (1=gyors, 6=legjobb [4-6 ritkán hasznos])"
+
+#~ msgid "Screen"
+#~ msgstr "Képernyő"
+
+#~ msgid "Resize remote session on connect"
+#~ msgstr "Távoli munkamenet átméretezése kapcsolódáskor"
+
+#~ msgid "Resize remote session to the local window"
+#~ msgstr "Távoli munkamenet átméretezése a helyi ablakhoz"
+
+#~ msgid "Full-screen mode"
+#~ msgstr "Teljes képernyős mód"
+
+#~ msgid "Enable full-screen mode over all monitors"
+#~ msgstr "Teljes képernyős mód engedélyezése az összes kijelzőn"
+
+#~ msgid "Misc."
+#~ msgstr "Egyéb"
+
+#~ msgid "Show dot when no cursor"
+#~ msgstr "Pont megjelenítése, ha nincs kurzor"
+
+#~ msgid "VNC Viewer: Connection Details"
+#~ msgstr "VNC megjelenítő: kapcsolat részletei"
+
+#~ msgid "Save As..."
+#~ msgstr "Mentés másként…"
+
+#~ msgid "Authentication cancelled"
+#~ msgstr "Hitelesítés megszakítva"
+
+#, c-format
+#~ msgid "Failed to update keyboard LED state: %d"
+#~ msgstr "Nem sikerült frissíteni a billentyűzet LED állapotát: %d"
+
+#~ msgid "No key code specified on key press"
+#~ msgstr "Nincs billentyűkód megadva a billentyűzetlenyomáskor"
+
+#, c-format
+#~ msgid "No symbol for key code 0x%02x (in the current state)"
+#~ msgstr "Nincs szimbólum a billentyűkódhoz: 0x%02x (a jelenlegi állapotban)"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "E&xit viewer"
+#~ msgstr "&Kilépés a megjelenítőből"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "A &TigerVNC megjelenítő névjegye…"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "Dismiss &menu"
+#~ msgstr "&Menü eltüntetése"
+
+#, c-format
+#~ msgid "The name of the parameter %s was too large to write to the registry"
+#~ msgstr ""
+#~ "A(z) %s paraméter neve túl nagy volt a regisztrációs adatbázisba történő "
+#~ "íráshoz"
+
+#, c-format
+#~ msgid "The parameter %s was too large to write to the registry"
+#~ msgstr ""
+#~ "A(z) %s paraméter túl nagy volt a regisztrációs adatbázisba történő "
+#~ "íráshoz"
+
+#, c-format
+#~ msgid "Failed to write parameter %s of type %s to the registry: %ld"
+#~ msgstr ""
+#~ "Nem sikerült a(z) %2$s típusú %1$s paraméter írása a regisztrációs "
+#~ "adatbázisba: %3$ld"
+
+#, c-format
+#~ msgid "The name of the parameter %s was too large to read from the registry"
+#~ msgstr ""
+#~ "A(z) %s paraméter neve túl nagy volt a regisztrációs adatbázisból történő "
+#~ "olvasáshoz"
+
+#, c-format
+#~ msgid "Failed to read parameter %s from the registry: %ld"
+#~ msgstr ""
+#~ "Nem sikerült a(z) %s paraméter olvasása a regisztrációs adatbázisból: %ld"
+
+#, c-format
+#~ msgid "The parameter %s was too large to read from the registry"
+#~ msgstr ""
+#~ "A(z) %s paraméter túl nagy volt a regisztrációs adatbázisból történő "
+#~ "olvasáshoz"
+
+#, c-format
+#~ msgid "Failed to create registry key: %ld"
+#~ msgstr "Nem sikerült létrehozni a regisztrációs adatbázis kulcsot: %ld"
+
+#, c-format
+#~ msgid "Unknown parameter type for parameter %s"
+#~ msgstr "Ismeretlen paramétertípus a(z) %s paraméternél"
+
+#, c-format
+#~ msgid "Failed to close registry key: %ld"
+#~ msgstr "Nem sikerült lezárni a regisztrációs adatbázis kulcsot: %ld"
+
+#, c-format
+#~ msgid "Failed to open registry key: %ld"
+#~ msgstr "Nem sikerült megnyitni a regisztrációs adatbázis kulcsot: %ld"
+
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Nem sikerült kiírni a beállítófájlt, nem lehet megszerezni a saját "
+#~ "könyvtár útvonalát."
+
+#, c-format
+#~ msgid "Failed to write configuration file, can't open %s: %s"
+#~ msgstr "Nem sikerült kiírni a beállítófájlt, nem lehet megnyitni: %s: %s"
+
+#~ msgid "Failed to read configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Nem sikerült beolvasni a beállítófájlt, nem lehet megszerezni a saját "
+#~ "könyvtár útvonalát."
+
+#, c-format
+#~ msgid "Failed to read configuration file, can't open %s: %s"
+#~ msgstr "Nem sikerült beolvasni a beállítófájlt, nem lehet megnyitni: %s: %s"
+
+#, c-format
+#~ msgid "Failed to read line %d in file %s: %s"
+#~ msgstr "Nem sikerült a(z) %d. sort olvasni a(z) %s fájlban: %s"
+
+#, c-format
+#~ msgid "Unknown parameter %s on line %d in file %s"
+#~ msgstr "Ismeretlen %s paraméter a(z) %d. sornál a(z) %s fájlban"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC Viewer %d-bit v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "TigerVNC megjelenítő: %d bites, %s verzió\n"
+#~ "Összeállítva: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC csapat és sokan mások (lásd: README.rst)\n"
+#~ "Nézze meg a https://www.tigervnc.org oldalt a TigerVNC információiért."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "A TigerVNC megjelenítő névjegye"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Hiba az új TigerVNC megjelenítő indításakor: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC Viewer will now exit."
+#~ msgstr ""
+#~ "%d befejezési szignál érkezett. A TigerVNC megjelenítő most ki fog lépni."
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "TigerVNC megjelenítő"
+
+#~ msgid "Hide Others"
+#~ msgstr "Egyebek elrejtése"
+
+#~ msgid "Show All"
+#~ msgstr "Összes megjelenítése"
+
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
+#~ msgstr ""
+#~ "Nem sikerült létrehozni a VNC saját könyvtárát: nem lehet megszerezni a "
+#~ "saját könyvtár útvonalát."
+
+#, c-format
+#~ msgid "Could not create VNC home directory: %s."
+#~ msgstr "Nem sikerült létrehozni a VNC saját könyvtárát: %s"
+
+#~ msgid "Remote Desktop Viewer"
+#~ msgstr "Távoli asztal megjelenítő"
+
+#~ msgid "tigervnc"
+#~ msgstr "tigervnc"
 
 #~ msgid "Enabling continuous updates"
 #~ msgstr "Folyamatos frissítések engedélyezése"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.14.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2025-01-14 16:15+0100\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2025-01-22 10:47+0700\n"
 "Last-Translator: Andika Triwidada <andika@gmail.com>\n"
 "Language-Team: Indonesian <translation-team-id@lists.sourceforge.net>\n"
@@ -19,17 +19,17 @@ msgstr ""
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: Poedit 3.5\n"
 
-#: vncviewer/CConn.cxx:102
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "Terhubung ke soket %s"
 
-#: vncviewer/CConn.cxx:109
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "Terhubung ke host %s port %d"
 
-#: vncviewer/CConn.cxx:114
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -40,66 +40,63 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:151
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Nama desktop: %.80s"
 
-#: vncviewer/CConn.cxx:154
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Host: %.80s port: %d"
 
-#: vncviewer/CConn.cxx:158
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Ukuran: %d × %d"
 
-#: vncviewer/CConn.cxx:165
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Format piksel: %s"
 
-#: vncviewer/CConn.cxx:170
-#, c-format
-msgid "(server default %s)"
-msgstr "(server baku %s)"
-
-#: vncviewer/CConn.cxx:173
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Pengkodean yang diminta: %s"
 
-#: vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Pengkodean yang terakhir dipakai: %s"
 
-#: vncviewer/CConn.cxx:181
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Estimasi kecepatan saluran: %d kbit/s"
 
-#: vncviewer/CConn.cxx:185
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Versi protokol: %d.%d"
 
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Metode keamanan: %s"
 
-#: vncviewer/CConn.cxx:250 vncviewer/CConn.cxx:252
-msgid "The connection was dropped by the server before the session could be established."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
 msgstr "Koneksi diputus oleh server sebelum sesi dapat dijalin."
 
-#: vncviewer/CConn.cxx:262
+#: vncviewer/CConn.cxx:258
 #, c-format
 msgid "Authentication failed: %s"
 msgstr "Autentikasi gagal: %s"
 
-#: vncviewer/CConn.cxx:263
+#: vncviewer/CConn.cxx:259
 #, c-format
 msgid ""
 "Failed to authenticate with the server. Reason given by the server:\n"
@@ -110,31 +107,22 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:335
-#, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "SetDesktopSize gagal: %d"
-
-#: vncviewer/CConn.cxx:408
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "SetColourMapEntries yang tidak valid dari server!"
-
-#: vncviewer/CConn.cxx:516
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Throughput %d kbit/s - mengubah ke kualitas %d"
 
-#: vncviewer/CConn.cxx:538
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "Throughput %d kbit/s - warna penuh sekarang difungsikan"
 
-#: vncviewer/CConn.cxx:541
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "Throughput %d kbit/s - warna penuh sekarang dinonaktifkan"
 
-#: vncviewer/CConn.cxx:567
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Memakai format piksel %s"
@@ -147,136 +135,128 @@ msgstr "Geometri yang dinyatakan tidak valid!"
 msgid "Reducing window size to fit on current monitor"
 msgstr "Mengurangi ukuran jendela agar pas di monitor saat ini"
 
-#: vncviewer/DesktopWindow.cxx:646
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
-msgstr "Menyesuaikan ukuran jendela untuk menghindari permintaan layar penuh yang tidak disengaja"
+msgstr ""
+"Menyesuaikan ukuran jendela untuk menghindari permintaan layar penuh yang "
+"tidak disengaja"
 
-#: vncviewer/DesktopWindow.cxx:694
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Tekan %s untuk membuka menu konteks"
 
-#: vncviewer/DesktopWindow.cxx:1094 vncviewer/DesktopWindow.cxx:1102
-#: vncviewer/DesktopWindow.cxx:1122
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Kegagalan dalam mengambil alih papan ketik"
 
-#: vncviewer/DesktopWindow.cxx:1411
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
-msgstr "Tata letak layar yang tidak valid dihitung untuk permintaan ubah ukuran!"
+msgstr ""
+"Tata letak layar yang tidak valid dihitung untuk permintaan ubah ukuran!"
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "Keadaan yang tidak valid untuk emulasi 3 tombol"
 
-#: vncviewer/KeyboardWin32.cxx:242
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "Tidak ada kode pindai untuk tombol virtual yang diperluas 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:244
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "Tidak ada kode pindai untuk tombol virtual 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:250
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "Kode pindai tidak valid 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:262
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "Tidak ada simbol untuk tombol virtual yang diperluas 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:264
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "Tidak ada simbol untuk tombol virtual 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:423
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
 msgid "Failed to update keyboard LED state: %lu"
 msgstr "Gagal memperbarui keadaan LED papan tik: %lu"
 
-#: vncviewer/KeyboardX11.cxx:104
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "Tidak ada simbol untuk kode tombol %d (dalam keadaan saat ini)"
 
-#: vncviewer/KeyboardX11.cxx:129
+#: vncviewer/KeyboardX11.cxx:148
 #, c-format
 msgid "Failed to get keyboard LED state: %d"
 msgstr "Gagal mendapatkan keadaan LED papan tik: %d"
 
-#: vncviewer/KeyboardX11.cxx:174
+#: vncviewer/KeyboardX11.cxx:193
 msgid "Failed to update keyboard LED state"
 msgstr "Gagal memperbarui keadaan LED papan tik"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:100
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "Gagal mendapatkan konfigurasi monitor sistem"
 
-#: vncviewer/MonitorIndicesParameter.cxx:79
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "Konfigurasi yang tidak valid dinyatakan untuk %s"
-
-#: vncviewer/MonitorIndicesParameter.cxx:86
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "Indeks monitor %d tidak ada"
 
-#: vncviewer/MonitorIndicesParameter.cxx:162
-#: vncviewer/MonitorIndicesParameter.cxx:182
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "Indeks monitor tidak valid '%s'"
-
-#: vncviewer/MonitorIndicesParameter.cxx:170
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "Karakter tak terduga '%c'"
-
-#: vncviewer/OptionsDialog.cxx:64
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
 msgid "TigerVNC options"
 msgstr "Opsi TigerVNC"
 
-#: vncviewer/OptionsDialog.cxx:97 vncviewer/ServerDialog.cxx:107
-#: vncviewer/vncviewer.cxx:397
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "Batal"
 
-#: vncviewer/OptionsDialog.cxx:102 vncviewer/vncviewer.cxx:396
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "OK"
 
-#: vncviewer/OptionsDialog.cxx:514
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "Kompresi"
 
-#: vncviewer/OptionsDialog.cxx:530
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "Pilih otomatis"
 
-#: vncviewer/OptionsDialog.cxx:541
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "Pengkodean yang disukai"
 
-#: vncviewer/OptionsDialog.cxx:602
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "Tingkat warna"
 
-#: vncviewer/OptionsDialog.cxx:614
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "Penuh"
 
-#: vncviewer/OptionsDialog.cxx:621
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "Sedang"
 
-#: vncviewer/OptionsDialog.cxx:628
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "Rendah"
 
@@ -284,166 +264,177 @@ msgstr "Rendah"
 msgid "Very low"
 msgstr "Sangat rendah"
 
-#: vncviewer/OptionsDialog.cxx:657
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "Tingkat kompresi ubahan:"
 
-#: vncviewer/OptionsDialog.cxx:664
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "tingkat (0=buruk, 9=terbaik)"
 
-#: vncviewer/OptionsDialog.cxx:671
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "Izinkan kompresi JPEG:"
 
-#: vncviewer/OptionsDialog.cxx:678
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "kualitas (0=buruk, 9=terbaik)"
 
-#: vncviewer/OptionsDialog.cxx:689
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "Keamanan"
 
-#: vncviewer/OptionsDialog.cxx:703
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "Enkripsi"
 
-#: vncviewer/OptionsDialog.cxx:715 vncviewer/OptionsDialog.cxx:782
-#: vncviewer/OptionsDialog.cxx:905
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "Nihil"
 
-#: vncviewer/OptionsDialog.cxx:722
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "TLS dengan sertifikat anonim"
 
-#: vncviewer/OptionsDialog.cxx:728
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "TLS dengan sertifikat X509"
 
-#: vncviewer/OptionsDialog.cxx:735
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "Path ke sertifikat CA X509"
 
-#: vncviewer/OptionsDialog.cxx:742
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "Path ke berkas CRL X509"
 
-#: vncviewer/OptionsDialog.cxx:770
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "Otentikasi"
 
-#: vncviewer/OptionsDialog.cxx:788
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "VNC standar (tidak aman tanpa enkripsi)"
 
-#: vncviewer/OptionsDialog.cxx:794
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "Nama pengguna dan kata sandi (tidak aman tanpa enkripsi)"
 
-#: vncviewer/OptionsDialog.cxx:822
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "Masukan"
 
-#: vncviewer/OptionsDialog.cxx:835
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "Hanya melihat (mengabaikan tetikus dan papan ketik)"
 
-#: vncviewer/OptionsDialog.cxx:842
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "Tetikus"
 
-#: vncviewer/OptionsDialog.cxx:854
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "Emulasikan tombol tengah tetikus"
 
-#: vncviewer/OptionsDialog.cxx:860
+#: vncviewer/OptionsDialog.cxx:880
 msgid "Show local cursor when not provided by server"
 msgstr "Tampilkan kursor lokal ketika tidak disediakan oleh server"
 
-#: vncviewer/OptionsDialog.cxx:865
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
 msgid "Cursor type"
 msgstr "Tipe kursor"
 
-#: vncviewer/OptionsDialog.cxx:867
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
 msgid "Dot"
 msgstr "Titik"
 
-#: vncviewer/OptionsDialog.cxx:868
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
 msgid "System"
 msgstr "Sistem"
 
-#: vncviewer/OptionsDialog.cxx:888
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "Papan Tik"
 
-#: vncviewer/OptionsDialog.cxx:900
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
 msgstr "Lewatkan tombol-tombol sistem secara langsung ke server (layar penuh)"
 
-#: vncviewer/OptionsDialog.cxx:903
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "Tombol menu"
 
-#: vncviewer/OptionsDialog.cxx:926
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "Papan Klip"
 
-#: vncviewer/OptionsDialog.cxx:938
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "Terima papan klip dari server"
 
-#: vncviewer/OptionsDialog.cxx:946
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "Juga atur pemilihan primer"
 
-#: vncviewer/OptionsDialog.cxx:953
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "Kirim papan klip ke server"
 
-#: vncviewer/OptionsDialog.cxx:961
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "Kirim pilihan primer sebagai papan klip"
 
-#: vncviewer/OptionsDialog.cxx:982
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "Tampilan"
 
-#: vncviewer/OptionsDialog.cxx:996
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "Mode tampilan"
 
-#: vncviewer/OptionsDialog.cxx:1009
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "Berjendela"
 
-#: vncviewer/OptionsDialog.cxx:1017
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "Layar penuh pada monitor saat ini"
 
-#: vncviewer/OptionsDialog.cxx:1025
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "Layar penuh di semua monitor"
 
-#: vncviewer/OptionsDialog.cxx:1033
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "Layar penuh pada monitor yang dipilih"
 
-#: vncviewer/OptionsDialog.cxx:1062
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
 msgid "Miscellaneous"
 msgstr "Rupa-rupa"
 
-#: vncviewer/OptionsDialog.cxx:1070
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "Bersama (jangan putuskan pemirsa lain)"
 
-#: vncviewer/OptionsDialog.cxx:1076
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "Minta untuk menyambungkan kembali saat kesalahan koneksi"
-
-#: vncviewer/ServerDialog.cxx:63
-msgid "VNC viewer: Connection details"
-msgstr "Penampil VNC: Rincian sambungan"
 
 #: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
@@ -488,7 +479,7 @@ msgstr "Konfigurasi TigerVNC (*.tigervnc)"
 msgid "Select a TigerVNC configuration file"
 msgstr "Pilih berkas konfigurasi TigerVNC"
 
-#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:517
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -508,7 +499,7 @@ msgstr "Simpan konfigurasi TigerVNC ke berkas"
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "%s sudah ada. Apakah Anda ingin menimpa?"
 
-#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:394
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "Tidak"
 
@@ -549,169 +540,172 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:351 vncviewer/ServerDialog.cxx:429
-#: vncviewer/vncviewer.cxx:580
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
 msgid "Could not determine VNC state directory path"
 msgstr "Tidak bisa menentukan path direktori keadaan VNC"
 
-#: vncviewer/ServerDialog.cxx:363 vncviewer/ServerDialog.cxx:437
-#: vncviewer/parameters.cxx:671 vncviewer/parameters.cxx:752
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
 msgid "Could not open \"%s\""
 msgstr "Tak bisa membuka \"%s\""
 
-#: vncviewer/ServerDialog.cxx:378 vncviewer/ServerDialog.cxx:387
-#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:773
-#: vncviewer/parameters.cxx:807 vncviewer/parameters.cxx:837
-#: vncviewer/parameters.cxx:844
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
 msgid "Failed to read line %d in file \"%s\""
 msgstr "Gagal membaca baris %d dalam berkas \"%s\""
 
-#: vncviewer/ServerDialog.cxx:390 vncviewer/parameters.cxx:776
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "Baris terlalu panjang"
 
-#: vncviewer/UserDialog.cxx:123
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "Membuka berkas kata sandi gagal"
 
-#: vncviewer/UserDialog.cxx:143
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "Otentikasi VNC"
 
-#: vncviewer/UserDialog.cxx:150
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "Sambungan ini aman"
 
-#: vncviewer/UserDialog.cxx:154
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "Sambungan ini tidak aman"
 
-#: vncviewer/UserDialog.cxx:176
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "Nama Pengguna:"
 
-#: vncviewer/UserDialog.cxx:189
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "Kata Sandi:"
 
-#: vncviewer/UserDialog.cxx:197
+#: vncviewer/UserDialog.cxx:204
 msgid "Keep password for reconnect"
 msgstr "Simpan sandi untuk penyambungan ulang"
 
-#: vncviewer/Viewport.cxx:695
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
 msgid "Disconn&ect"
 msgstr "Putuskan &Sambungan"
 
-#: vncviewer/Viewport.cxx:698
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "Layar &Penuh"
 
-#: vncviewer/Viewport.cxx:701
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "Mi&nimalkan"
 
-#: vncviewer/Viewport.cxx:703
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "Ubah ukuran &jendela ke sesi"
 
-#: vncviewer/Viewport.cxx:708
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:711
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:717
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "Kirim %s"
 
-#: vncviewer/Viewport.cxx:724
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Kirim Ctrl-Alt-&Del"
 
-#: vncviewer/Viewport.cxx:727
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "Sega&rkan layar"
 
-#: vncviewer/Viewport.cxx:730
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&Opsi..."
 
-#: vncviewer/Viewport.cxx:732
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "&Info koneksi..."
 
-#: vncviewer/Viewport.cxx:734
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "Tentang penampil &TigerVNC..."
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:830
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "Informasi sambungan VNC"
 
-#: vncviewer/Win32TouchHandler.cxx:48
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "Jendela terdaftar untuk sentuhan, bukan gestur"
 
-#: vncviewer/Win32TouchHandler.cxx:83
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "Gagal mengatur konfigurasi gestur (galat 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:95
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "Gagal mendapatkan informasi gestur (error 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:360
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr "Tombol tetikus yang tidak valid %d, harus angka antara 1 dan 7."
 
-#: vncviewer/Win32TouchHandler.cxx:425
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
-msgstr "Tombol 0x%x yang tidak ditangani - tidak dapat menghasilkan kejadian papan ketik."
+msgstr ""
+"Tombol 0x%x yang tidak ditangani - tidak dapat menghasilkan kejadian papan "
+"ketik."
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:107
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
 msgstr "Tidak bisa mendapatkan mask kejadian X Input 2 untuk jendela 0x%08lx"
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr "Jendela 0x%08lx tidak memiliki mask kejadian X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:114
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr "Window 0x%08lx memiliki lebih dari satu mask kejadian X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "Kegagalan saat meng-grab perangkat %i"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-msgid "TigerVNC Viewer"
-msgstr "Penampil TigerVNC"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -719,100 +713,127 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr "Sambungkan ke server VNC dan tampilkan desktop jarak jauh"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
-msgstr "Virtual Network Computing (VNC) adalah sistem tampilan jarak jauh yang memungkinkan Anda untuk melihat dan berinteraksi dengan lingkungan desktop virtual yang berjalan di komputer lain di jaringan. Menggunakan VNC, Anda dapat menjalankan aplikasi grafis pada mesin jarak jauh dan hanya mengirim tampilan dari aplikasi ini ke perangkat lokal Anda. Paket ini berisi klien yang akan memungkinkan Anda untuk terhubung ke desktop lain yang menjalankan server VNC. VNC adalah platform-independen dan mendukung berbagai sistem operasi dan arsitektur sebagai server dan klien."
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+"Virtual Network Computing (VNC) adalah sistem tampilan jarak jauh yang "
+"memungkinkan Anda untuk melihat dan berinteraksi dengan lingkungan desktop "
+"virtual yang berjalan di komputer lain di jaringan. Menggunakan VNC, Anda "
+"dapat menjalankan aplikasi grafis pada mesin jarak jauh dan hanya mengirim "
+"tampilan dari aplikasi ini ke perangkat lokal Anda. Paket ini berisi klien "
+"yang akan memungkinkan Anda untuk terhubung ke desktop lain yang menjalankan "
+"server VNC. VNC adalah platform-independen dan mendukung berbagai sistem "
+"operasi dan arsitektur sebagai server dan klien."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
-msgstr "TigerVNC adalah versi VNC berkecepatan tinggi berdasarkan basis kode RealVNC 4 dan X.org. TigerVNC dimulai sebagai upaya pengembangan generasi berikutnya untuk TightVNC pada platform Unix dan Linux, tetapi terpisah dari proyek induknya pada awal 2009 sehingga TightVNC dapat fokus pada platform Windows. TigerVNC mendukung varian Pengodean ketat yang sangat dipercepat dengan penggunaan kodek JPEG libjpeg-turbo."
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+"TigerVNC adalah versi VNC berkecepatan tinggi berdasarkan basis kode RealVNC "
+"4 dan X.org. TigerVNC dimulai sebagai upaya pengembangan generasi berikutnya "
+"untuk TightVNC pada platform Unix dan Linux, tetapi terpisah dari proyek "
+"induknya pada awal 2009 sehingga TightVNC dapat fokus pada platform Windows. "
+"TigerVNC mendukung varian Pengodean ketat yang sangat dipercepat dengan "
+"penggunaan kodek JPEG libjpeg-turbo."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC viewer connection to a CentOS machine"
-msgstr "Koneksi penampil TigerVNC ke mesin CentOS"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC viewer connection to a macOS machine"
-msgstr "Koneksi penampil TigerVNC ke mesin macOS"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC viewer connection to a Windows machine"
-msgstr "Koneksi penampil TigerVNC ke mesin Windows"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
 #. developer_name tag deprecated with Appstream 1.0
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
-#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:48
 msgid "The TigerVNC team"
 msgstr "Tim TigerVNC"
 
-#: vncviewer/parameters.cxx:319 vncviewer/parameters.cxx:344
-#: vncviewer/parameters.cxx:361 vncviewer/parameters.cxx:401
-#: vncviewer/parameters.cxx:421
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "Nama parameter terlalu besar"
 
-#: vncviewer/parameters.cxx:323 vncviewer/parameters.cxx:328
-#: vncviewer/parameters.cxx:379
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "Parameter terlalu besar"
 
-#: vncviewer/parameters.cxx:386 vncviewer/parameters.cxx:712
-#: vncviewer/parameters.cxx:822
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "Format tidak valid atau nilai terlalu besar"
 
-#: vncviewer/parameters.cxx:440 vncviewer/parameters.cxx:473
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "Gagal membuat kunci registry"
 
-#: vncviewer/parameters.cxx:461 vncviewer/parameters.cxx:528
-#: vncviewer/parameters.cxx:571 vncviewer/parameters.cxx:638
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "Gagal menutup kunci registry"
 
-#: vncviewer/parameters.cxx:479 vncviewer/parameters.cxx:506
-#: vncviewer/parameters.cxx:680 vncviewer/parameters.cxx:692
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "Gagal menyimpan \"%s\": %s"
 
-#: vncviewer/parameters.cxx:489 vncviewer/parameters.cxx:520
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "Gagal menghapus \"%s\": %s"
 
-#: vncviewer/parameters.cxx:544 vncviewer/parameters.cxx:616
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "Gagal membuka kunci registry"
 
-#: vncviewer/parameters.cxx:561
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "Gagal membaca entri riwayat server %d: %s"
 
-#: vncviewer/parameters.cxx:597 vncviewer/parameters.cxx:627
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "Gagal membaca parameter \"%s\": %s"
 
-#: vncviewer/parameters.cxx:661 vncviewer/parameters.cxx:740
-#: vncviewer/vncviewer.cxx:546
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
 msgid "Could not determine VNC config directory path"
 msgstr "Tidak bisa menentukan path direktori konfig VNC"
 
-#: vncviewer/parameters.cxx:682 vncviewer/parameters.cxx:694
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "Tak bisa meng-enkode parameter"
 
-#: vncviewer/parameters.cxx:785
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "Berkas konfigurasi %s berada dalam format yang tidak valid"
 
-#: vncviewer/parameters.cxx:809
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "Format tidak valid"
 
-#: vncviewer/parameters.cxx:846
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "Parameter tidak dikenal"
 
@@ -853,23 +874,23 @@ msgid "X Input 2 (or newer) is not available."
 msgstr "X Input 2 (atau yang lebih baru) tidak tersedia."
 
 #: vncviewer/touch.cxx:266
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
-msgstr "X Input 2.2 (atau yang lebih baru) tidak tersedia. Gestur sentuh tidak akan didukung."
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+"X Input 2.2 (atau yang lebih baru) tidak tersedia. Gestur sentuh tidak akan "
+"didukung."
 
-#: vncviewer/vncviewer.cxx:104
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
 "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"Penampil TigerVNC v%s\n"
-"Dibangun pada: %s\n"
-"Hak Cipta (C) 1999-%d Tim TigerVNC dan banyak lainnya (lihat README.rst)\n"
-"Lihat https://www.tigervnc.org untuk informasi tentang TigerVNC."
 
-#: vncviewer/vncviewer.cxx:158
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -880,15 +901,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:174
-msgid "About TigerVNC Viewer"
-msgstr "Tentang Penampil &TigerVNC"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:195
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "Kesalahan FLTK internal. Keluar."
 
-#: vncviewer/vncviewer.cxx:214
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -899,63 +920,59 @@ msgstr ""
 "\n"
 "Mencoba untuk menyambung kembali?"
 
-#: vncviewer/vncviewer.cxx:245 vncviewer/vncviewer.cxx:257
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Kesalahan saat memulai Penampil TigerVNC baru: %s"
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:266
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC viewer will now exit."
-msgstr "Sinyal pengakhiran %d telah diterima. Penampil TigerVNC sekarang akan keluar."
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:391 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC viewer"
-msgstr "Penampil TigerVNC"
-
-#: vncviewer/vncviewer.cxx:395
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "Ya"
 
-#: vncviewer/vncviewer.cxx:398
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "Tutup"
 
-#: vncviewer/vncviewer.cxx:403
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "Tentang"
 
-#: vncviewer/vncviewer.cxx:406
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "Sembunyikan"
 
-#: vncviewer/vncviewer.cxx:409
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "Keluar"
 
-#: vncviewer/vncviewer.cxx:413
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "Layanan"
 
-#: vncviewer/vncviewer.cxx:414
+#: vncviewer/vncviewer.cxx:413
 msgid "Hide others"
 msgstr "Sembunyikan lainnya"
 
-#: vncviewer/vncviewer.cxx:415
+#: vncviewer/vncviewer.cxx:414
 msgid "Show all"
 msgstr "Tampilkan semua"
 
-#: vncviewer/vncviewer.cxx:424
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "&Berkas"
 
-#: vncviewer/vncviewer.cxx:427
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "Ko&neksi Baru"
 
-#: vncviewer/vncviewer.cxx:450
+#: vncviewer/vncviewer.cxx:449
 #, c-format
 msgid ""
 "\n"
@@ -972,24 +989,19 @@ msgstr ""
 "            %s [parameter] -listen [port]\n"
 "            %s [parameter] [.tigervnc file]\n"
 
-#: vncviewer/vncviewer.cxx:465
+#: vncviewer/vncviewer.cxx:464
 #, c-format
 msgid ""
 "\n"
 "Options:\n"
 "\n"
 "  -display Xdisplay  - Specifies the X display for the viewer window\n"
-"  -geometry geometry - Initial position of the main VNC viewer window. See the\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
 "                       man page for details.\n"
 msgstr ""
-"\n"
-"Opsi:\n"
-"\n"
-"  -display Xdisplay  - Menyatakan display X bagi jendela penampil\n"
-"  -geometry geometri - Posisi awal dari jendela penampil VNC utama. Lihat\n"
-"                       halaman man untuk rincian.\n"
 
-#: vncviewer/vncviewer.cxx:472
+#: vncviewer/vncviewer.cxx:471
 #, c-format
 msgid ""
 "\n"
@@ -1006,73 +1018,83 @@ msgstr ""
 "Nama parameter tidak peka huruf besar kecil.  Parameternya adalah:\n"
 "\n"
 
-#: vncviewer/vncviewer.cxx:527
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
-msgstr "FullScreenAllMonitors sudah usang, atur FullScreenMode ke 'all' sebagai gantinya"
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+"FullScreenAllMonitors sudah usang, atur FullScreenMode ke 'all' sebagai "
+"gantinya"
 
-#: vncviewer/vncviewer.cxx:532
-msgid "DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' instead"
-msgstr "DotWhenNoCursor usang, tata AlwaysCursor ke 1 dan CursorType ke 'Dot' sebagai pengganti"
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+"DotWhenNoCursor usang, tata AlwaysCursor ke 1 dan CursorType ke 'Dot' "
+"sebagai pengganti"
 
-#: vncviewer/vncviewer.cxx:553
-msgid "~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
 msgstr "~/.vnc usang, harap baca 'man vncviewer' untuk migrasi ke path mana."
 
-#: vncviewer/vncviewer.cxx:557
+#: vncviewer/vncviewer.cxx:556
 #, c-format
-msgid "%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC location."
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
 msgstr "%%APPDATA%%\\vnc usang, harap beralih ke lokasi %%APPDATA%%\\TigerVNC."
 
-#: vncviewer/vncviewer.cxx:562
+#: vncviewer/vncviewer.cxx:561
 #, c-format
 msgid "Could not create VNC config directory \"%s\": %s"
 msgstr "Tidak bisa membuat direktori konfig VNC \"%s\": %s"
 
-#: vncviewer/vncviewer.cxx:568
+#: vncviewer/vncviewer.cxx:567
 msgid "Could not determine VNC data directory path"
 msgstr "Tidak bisa menentukan path direktori data VNC"
 
-#: vncviewer/vncviewer.cxx:574
+#: vncviewer/vncviewer.cxx:573
 #, c-format
 msgid "Could not create VNC data directory \"%s\": %s"
 msgstr "Tidak bisa membuat direktori data VNC \"%s\": %s"
 
-#: vncviewer/vncviewer.cxx:586
+#: vncviewer/vncviewer.cxx:585
 #, c-format
 msgid "Could not create VNC state directory \"%s\": %s"
 msgstr "Tidak bisa membuat direktori keadaan VNC \"%s\": %s"
 
-#: vncviewer/vncviewer.cxx:703
+#: vncviewer/vncviewer.cxx:704
 #, c-format
 msgid "%s: Unrecognized option '%s'\n"
 msgstr "%s: Opsi tidak dikenal '%s'\n"
 
-#: vncviewer/vncviewer.cxx:705 vncviewer/vncviewer.cxx:713
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
 #, c-format
 msgid "See '%s --help' for more information.\n"
 msgstr "Lihat '%s --help' untuk informasi lebih lanjut.\n"
 
-#: vncviewer/vncviewer.cxx:712
+#: vncviewer/vncviewer.cxx:713
 #, c-format
 msgid "%s: Extra argument '%s'\n"
 msgstr "%s: Argumen ekstra '%s'\n"
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:748 vncviewer/vncviewer.cxx:749
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "Parameter -listen dan -via tidak kompatibel"
 
-#: vncviewer/vncviewer.cxx:763
+#: vncviewer/vncviewer.cxx:764
 msgid "Unable to listen for incoming connections"
 msgstr "Tidak bisa mendengarkan koneksi masuk"
 
-#: vncviewer/vncviewer.cxx:765
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "Mendengarkan pada port %d"
 
-#: vncviewer/vncviewer.cxx:794
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -1083,7 +1105,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:815
+#: vncviewer/vncviewer.cxx:816
 #, c-format
 msgid ""
 "Failure setting up encrypted tunnel:\n"
@@ -1097,3 +1119,92 @@ msgstr ""
 #: vncviewer/vncviewer.desktop.in.in:4
 msgid "Remote desktop viewer"
 msgstr "Penampil desktop jarak jauh"
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(server baku %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "SetDesktopSize gagal: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "SetColourMapEntries yang tidak valid dari server!"
+
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "Konfigurasi yang tidak valid dinyatakan untuk %s"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "Indeks monitor tidak valid '%s'"
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "Karakter tak terduga '%c'"
+
+#~ msgid "VNC viewer: Connection details"
+#~ msgstr "Penampil VNC: Rincian sambungan"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "Tentang penampil &TigerVNC..."
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "Penampil TigerVNC"
+
+#~ msgid "TigerVNC viewer connection to a CentOS machine"
+#~ msgstr "Koneksi penampil TigerVNC ke mesin CentOS"
+
+#~ msgid "TigerVNC viewer connection to a macOS machine"
+#~ msgstr "Koneksi penampil TigerVNC ke mesin macOS"
+
+#~ msgid "TigerVNC viewer connection to a Windows machine"
+#~ msgstr "Koneksi penampil TigerVNC ke mesin Windows"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "Penampil TigerVNC v%s\n"
+#~ "Dibangun pada: %s\n"
+#~ "Hak Cipta (C) 1999-%d Tim TigerVNC dan banyak lainnya (lihat README.rst)\n"
+#~ "Lihat https://www.tigervnc.org untuk informasi tentang TigerVNC."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "Tentang Penampil &TigerVNC"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Kesalahan saat memulai Penampil TigerVNC baru: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC viewer will now exit."
+#~ msgstr ""
+#~ "Sinyal pengakhiran %d telah diterima. Penampil TigerVNC sekarang akan "
+#~ "keluar."
+
+#~ msgid "TigerVNC viewer"
+#~ msgstr "Penampil TigerVNC"
+
+#, c-format
+#~ msgid ""
+#~ "\n"
+#~ "Options:\n"
+#~ "\n"
+#~ "  -display Xdisplay  - Specifies the X display for the viewer window\n"
+#~ "  -geometry geometry - Initial position of the main VNC viewer window. "
+#~ "See the\n"
+#~ "                       man page for details.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Opsi:\n"
+#~ "\n"
+#~ "  -display Xdisplay  - Menyatakan display X bagi jendela penampil\n"
+#~ "  -geometry geometri - Posisi awal dari jendela penampil VNC utama. "
+#~ "Lihat\n"
+#~ "                       halaman man untuk rincian.\n"

--- a/po/it.po
+++ b/po/it.po
@@ -3,750 +3,1190 @@ msgid ""
 msgstr ""
 "Project-Id-Version: TigerVNC 1.3.80\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2014-09-22 11:15+0000\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:194
+#: vncviewer/CConn.cxx:103
 #, c-format
-msgid "(server default %s)"
+msgid "Connected to socket %s"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:227
-msgid "About"
-msgstr "Informazioni"
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:103
-msgid "About TigerVNC Viewer"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1086
-msgid "About TigerVNC viewer..."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/ServerDialog.cxx:86
-msgid "About..."
-msgstr "Informazioni..."
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:704
-msgid "Accept clipboard from server"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/DesktopWindow.cxx:327
-msgid "Adjusting window size to avoid accidental full screen request"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:563
-msgid "Allow JPEG compression:"
-msgstr "Consenti la compressione JPEG:"
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1070
-msgid "Alt"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:648
-msgid "Authentication"
-msgstr "Autenticazione"
-
-#: /home/ossman/devel/tigervnc/vncviewer/UserDialog.cxx:89
-msgid "Authentication cancelled"
-msgstr "Autenticazione annullata"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:437
-msgid "Auto select"
-msgstr "Selezione auto"
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:651
+#: vncviewer/CConn.cxx:110
 #, c-format
-msgid "Bad Name/Value pair on line: %d in file: %s"
+msgid "Connected to host %s port %d"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/Win32PixelBuffer.cxx:92
-msgid "BitBlt failed"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/ServerDialog.cxx:91
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:221
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:83
-msgid "Cancel"
-msgstr "Annulla"
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:116
-msgid "CleanupSignalHandler called"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:222
-msgid "Close"
-msgstr "Chiudi"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:499
-msgid "Color level"
-msgstr "Livello del colore"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:421
-#, fuzzy
-msgid "Compression"
-msgstr "Compressione SSH"
-
-#: /home/ossman/devel/tigervnc/vncviewer/ServerDialog.cxx:96
-msgid "Connect"
-msgstr "Connettiti"
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1085
-msgid "Connection info..."
-msgstr "Info connessione..."
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:362
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:404
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
-"Could not convert the parameter-name %s to wchar_t* when reading from the "
-"Registry, the buffersize is to small."
+"Failed to connect to \"%s\":\n"
+"\n"
+"%s"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:302
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:340
-#, c-format
-msgid ""
-"Could not convert the parameter-name %s to wchar_t* when writing to the "
-"Registry, the buffersize is to small."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:318
-#, c-format
-msgid ""
-"Could not convert the parameter-value %s to wchar_t* when writing to the "
-"Registry, the buffersize is to small."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:381
-#, c-format
-msgid ""
-"Could not convert the parameter-value for %s to utf8 char* when reading from "
-"the Registry, the buffer dest is to small."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:256
-#, c-format
-msgid "Could not create VNC home directory: %s."
-msgstr "Impossibile creare la home directory VNC: %s."
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:251
-msgid "Could not create VNC home directory: can't obtain home directory path."
-msgstr ""
-"Impossibile creare la home directory VNC: impossibile ottenere il percorso "
-"della home directory."
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:310
-#, c-format
-msgid "Could not encode the parameter-value %s when writing to the Registry."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:613
-#, c-format
-msgid ""
-"Could not read the line(%d) in the configuration file,the buffersize is to "
-"small."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Win32PixelBuffer.cxx:80
-msgid "CreateCompatibleDC failed"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1068
-msgid "Ctrl"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:550
-msgid "Custom compression level:"
-msgstr "Livello di compressione:"
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:283
-msgid ""
-"Decoding: The size of the buffer dest is to small, it needs to be 1 byte "
-"bigger."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:172
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1088
-msgid "Dismiss menu"
-msgstr "Ignora menu"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:778
-#, fuzzy
-msgid "Enable full-screen mode over all monitors"
-msgstr "Abilita modalità schermo intero su tutti i monitor"
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:469
-msgid "Enabling continuous updates"
-msgstr "Abilitazione aggiornamenti continui"
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:200
-#, c-format
-msgid ""
-"Encoding backslash: The size of the buffer dest is to small, it needs to be "
-"more than %d bytes bigger."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:214
-#, c-format
-msgid ""
-"Encoding escape sequence: The size of the buffer dest is to small, it needs "
-"to be more than %d bytes bigger."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:234
-#, c-format
-msgid ""
-"Encoding normal character: The size of the buffer dest is to small, it needs "
-"to be more than %d bytes bigger."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:595
-msgid "Encryption"
-msgstr "Crittografia"
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:503
-#, c-format
-msgid "Error(%d) closing key:  Software\\TigerVNC\\vncviewer"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:455
-#, c-format
-msgid "Error(%d) closing key: Software\\TigerVNC\\vncviewer"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:434
-#, c-format
-msgid "Error(%d) creating key: Software\\TigerVNC\\vncviewer"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:471
-#, c-format
-msgid "Error(%d) opening key: Software\\TigerVNC\\vncviewer"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:373
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:415
-#, c-format
-msgid "Error(%d) reading %s from Registry."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:348
-#, c-format
-msgid "Error(%d) writing %d(REG_DWORD) to Registry."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:326
-#, c-format
-msgid "Error(%d) writing %s(REG_SZ) to Registry."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OSXPixelBuffer.cxx:50
-#: /home/ossman/devel/tigervnc/vncviewer/FLTKPixelBuffer.cxx:33
-msgid "Error: Not enough memory for framebuffer"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/X11PixelBuffer.cxx:69
-msgid "Error: couldn't find suitable pixmap format"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/X11PixelBuffer.cxx:60
-msgid "Error: display lacks pixmap format for default depth"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/X11PixelBuffer.cxx:78
-msgid "Error: only true colour displays supported"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1056
-msgid "Exit viewer"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:588
-#, fuzzy
-msgid "Failed to read configuration file, can't obtain home directory path."
-msgstr ""
-"Impossibile creare la home directory VNC: impossibile ottenere il percorso "
-"della home directory."
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:602
-#, c-format
-msgid "Failed to read configuration file, can't open %s"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:621
-#, c-format
-msgid "Failed to read line %d in file %s"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:528
-#, fuzzy
-msgid "Failed to write configuration file, can't obtain home directory path."
-msgstr ""
-"Impossibile creare la home directory VNC: impossibile ottenere il percorso "
-"della home directory."
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:542
-#, c-format
-msgid "Failed to write configuration file, can't open %s"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/DesktopWindow.cxx:526
-#: /home/ossman/devel/tigervnc/vncviewer/DesktopWindow.cxx:538
-#: /home/ossman/devel/tigervnc/vncviewer/DesktopWindow.cxx:551
-msgid "Failure grabbing keyboard"
-msgstr "Errore di raccolta della tastiera"
-
-#: /home/ossman/devel/tigervnc/vncviewer/DesktopWindow.cxx:563
-msgid "Failure grabbing mouse"
-msgstr "Errore di raccolta del mouse"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:512
-msgid "Full (all available colors)"
-msgstr "Pieno (tutti i colori disponibili)"
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1059
-msgid "Full screen"
-msgstr "Schermo intero"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:770
-#, fuzzy
-msgid "Full-screen mode"
-msgstr "Modalità schermo intero"
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:230
-msgid "Hide"
-msgstr "Nascondi"
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:238
-msgid "Hide Others"
-msgstr "Nascondi altri"
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:690
-msgid "Input"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:510
-msgid "Internal FLTK error. Exiting."
-msgstr "Errore FLTK interno. Uscita in corso."
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:384
-msgid "Invalid SetColourMapEntries from server!"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/DesktopWindow.cxx:106
-msgid "Invalid geometry specified!"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:708
-#, c-format
-msgid "Invalid parameter name on line: %d in file: %s"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/DesktopWindow.cxx:797
-msgid "Invalid screen layout computed for resize request!"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:204
-#, fuzzy, c-format
-msgid "Last used encoding: %s"
-msgstr "Utilizzo codifica %s"
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:631
-#, c-format
-msgid ""
-"Line 1 in file %s\n"
-"must contain the TigerVNC configuration file identifier string:\n"
-"\"%s\""
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:209
-#, c-format
-msgid "Line speed estimate: %d kbit/s"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:478
-#, c-format
-msgid "Listening on port %d\n"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/ServerDialog.cxx:69
-msgid "Load..."
-msgstr "Carica..."
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:526
-msgid "Low (64 colors)"
-msgstr "Basso (64 colori)"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:519
-msgid "Medium (256 colors)"
-msgstr "Medio (256 colori)"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:725
-#, fuzzy
-msgid "Menu key"
-msgstr "Tasto di menu a comparsa"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:791
-msgid "Misc."
-msgstr "Varie"
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1026
-#, c-format
-msgid "Multiple characters given for key code %d (0x%04x): '%s'"
-msgstr "Caratteri multipli forniti per il codice chiave %d (0x%04x): '%s'"
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:218
-msgid "No"
-msgstr "No"
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:688
-#, c-format
-msgid "No scan code for extended virtual key 0x%02x"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:690
-#, c-format
-msgid "No scan code for virtual key 0x%02x"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:701
-#, c-format
-msgid "No symbol for extended virtual key 0x%02x"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:765
-#, c-format
-msgid "No symbol for key code %d (in the current state)"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:739
-#, c-format
-msgid "No symbol for key code 0x%02x (in the current state)"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:703
-#, c-format
-msgid "No symbol for virtual key 0x%02x"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:606
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:659
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:727
-msgid "None"
-msgstr "Nessuno"
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:220
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:88
-msgid "OK"
-msgstr "OK"
-
-#: /home/ossman/devel/tigervnc/vncviewer/UserDialog.cxx:74
-msgid "Opening password file failed"
-msgstr "Apertura del file di password non riuscita"
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1084
-#: /home/ossman/devel/tigervnc/vncviewer/ServerDialog.cxx:64
-msgid "Options..."
-msgstr "Opzioni..."
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:463
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:464
-msgid "Parameters -listen and -via are incompatible"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:722
-msgid "Pass system keys directly to server (full screen)"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/UserDialog.cxx:87
-#: /home/ossman/devel/tigervnc/vncviewer/UserDialog.cxx:102
-msgid "Password:"
-msgstr "Password:"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:625
-msgid "Path to X509 CA certificate"
-msgstr "Percorso del certificato X509 CA"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:632
-msgid "Path to X509 CRL file"
-msgstr "Percorso del file X509 CRL"
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:188
-#, fuzzy, c-format
-msgid "Pixel format: %s"
-msgstr "Utilizzo del formato pixel %s"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:449
-msgid "Preferred encoding"
-msgstr "Codifica preferita"
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:214
-#, c-format
-msgid "Protocol version: %d.%d"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:233
-msgid "Quit"
-msgstr "Esci"
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1082
-msgid "Refresh screen"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:199
-#, fuzzy, c-format
-msgid "Requested encoding: %s"
-msgstr "Codifica preferita"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:749
-#, fuzzy
-msgid "Resize remote session on connect"
-msgstr "Ridimensiona la sessione remota alla finestra locale"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:762
-msgid "Resize remote session to the local window"
-msgstr "Ridimensiona la sessione remota alla finestra locale"
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1062
-msgid "Resize window to session"
-msgstr "Ridimensiona la finestra alla sessione"
-
-#: /home/ossman/devel/tigervnc/vncviewer/ServerDialog.cxx:74
-msgid "Save As..."
-msgstr "Salva con nome..."
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:741
-msgid "Screen"
-msgstr "Schermo"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:580
-msgid "Security"
-msgstr "Sicurezza"
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:219
-#, c-format
-msgid "Security method: %s"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Win32PixelBuffer.cxx:83
-msgid "SelectObject failed"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1075
-#, c-format
-msgid "Send %s"
-msgstr "Invia %s"
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1080
-msgid "Send Ctrl-Alt-Del"
-msgstr "Invia Ctrl-Alt-Del"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:710
-msgid "Send clipboard to server"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:716
-msgid "Send primary selection and cut buffer as clipboard"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:237
-msgid "Services"
-msgstr "Servizi"
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:319
-#, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "Impostazioni dimensioni desktop non riuscita: %d"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:799
-msgid "Shared (don't disconnect other viewers)"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:239
-msgid "Show All"
-msgstr "Mostra tutto"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:805
-msgid "Show dot when no cursor"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:182
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:665
-msgid "Standard VNC (insecure without encryption)"
-msgstr "VNC standard (non protetto senza crittografia)"
+#: vncviewer/CConn.cxx:166
+#, fuzzy, c-format
+msgid "Pixel format: %s"
+msgstr "Utilizzo del formato pixel %s"
 
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:618
-msgid "TLS with X509 certificates"
-msgstr "TLS con certificati X509"
+#: vncviewer/CConn.cxx:169
+#, fuzzy, c-format
+msgid "Requested encoding: %s"
+msgstr "Codifica preferita"
 
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:612
-msgid "TLS with anonymous certificates"
-msgstr "TLS con certificati anonimi"
+#: vncviewer/CConn.cxx:173
+#, fuzzy, c-format
+msgid "Last used encoding: %s"
+msgstr "Utilizzo codifica %s"
 
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:448
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:497
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:561
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:701
+#: vncviewer/CConn.cxx:177
 #, c-format
-msgid "The parameterArray contains a object of a invalid type at line %d."
+msgid "Line speed estimate: %d kbit/s"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:664
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:680
+#: vncviewer/CConn.cxx:181
 #, c-format
-msgid "The value of the parameter %s on line %d in file %s is invalid."
+msgid "Protocol version: %d.%d"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:539
+#: vncviewer/CConn.cxx:185
+#, c-format
+msgid "Security method: %s"
+msgstr ""
+
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
+msgstr ""
+
+#: vncviewer/CConn.cxx:258
+#, c-format
+msgid "Authentication failed: %s"
+msgstr ""
+
+#: vncviewer/CConn.cxx:259
+#, c-format
+msgid ""
+"Failed to authenticate with the server. Reason given by the server:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Velocità effettiva %d kbit/s - passaggio alla qualità %d"
 
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:561
+#: vncviewer/CConn.cxx:521
 #, c-format
-msgid "Throughput %d kbit/s - full color is now %s"
-msgstr "Velocità effettiva %d kbit/s - tutti i colori sono ora %s"
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:210
-msgid "TigerVNC Viewer"
+msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:80
+#: vncviewer/CConn.cxx:524
 #, c-format
-msgid ""
-"TigerVNC Viewer %d-bit v%s\n"
-"Built on: %s\n"
-"Copyright (C) 1999-%d TigerVNC Team and many others (see README.txt)\n"
-"See http://www.tigervnc.org for information on TigerVNC."
+msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1004
-#, c-format
-msgid "Unknown FLTK key code %d (0x%04x)"
-msgstr "Codice chiave FLTK sconosciuto %d (0x%04x)"
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:878
-#, c-format
-msgid "Unknown decimal separator: '%s'"
-msgstr "Separatore decimale sconosciuto: '%s'"
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:271
-#, fuzzy, c-format
-msgid "Unknown escape sequence at character %d"
-msgstr "Separatore decimale sconosciuto: '%s'"
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:430
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:437
-#, fuzzy
-msgid "Unknown rect encoding"
-msgstr "Utilizzo codifica %s"
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:429
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:436
-#, c-format
-msgid "Unknown rect encoding %d"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:671
-msgid "Username and password (insecure without encryption)"
-msgstr "Nome utente e password (non protetti senza crittografia)"
-
-#: /home/ossman/devel/tigervnc/vncviewer/UserDialog.cxx:99
-msgid "Username:"
-msgstr "Nome utente:"
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:573
-#, c-format
-msgid "Using %s encoding"
-msgstr "Utilizzo codifica %s"
-
-#: /home/ossman/devel/tigervnc/vncviewer/X11PixelBuffer.cxx:80
-#, c-format
-msgid "Using default colormap and visual, %sdepth %d."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:620
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Utilizzo del formato pixel %s"
 
-#: /home/ossman/devel/tigervnc/vncviewer/ServerDialog.cxx:42
-msgid "VNC Viewer: Connection Details"
-msgstr "VNC Viewer: dettagli di connessione"
+#: vncviewer/DesktopWindow.cxx:146
+msgid "Invalid geometry specified!"
+msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:57
+#: vncviewer/DesktopWindow.cxx:167
+msgid "Reducing window size to fit on current monitor"
+msgstr ""
+
+#: vncviewer/DesktopWindow.cxx:681
+msgid "Adjusting window size to avoid accidental full-screen request"
+msgstr ""
+
+#: vncviewer/DesktopWindow.cxx:712
+#, c-format
+msgid "Press %s to open the context menu"
+msgstr ""
+
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
+msgid "Failure grabbing keyboard"
+msgstr "Errore di raccolta della tastiera"
+
+#: vncviewer/DesktopWindow.cxx:1427
+msgid "Invalid screen layout computed for resize request!"
+msgstr ""
+
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
+msgid "Invalid state for 3 button emulation"
+msgstr ""
+
+#: vncviewer/KeyboardWin32.cxx:243
+#, c-format
+msgid "No scan code for extended virtual key 0x%02x"
+msgstr ""
+
+#: vncviewer/KeyboardWin32.cxx:245
+#, c-format
+msgid "No scan code for virtual key 0x%02x"
+msgstr ""
+
+#: vncviewer/KeyboardWin32.cxx:251
+#, c-format
+msgid "Invalid scan code 0x%02x"
+msgstr ""
+
+#: vncviewer/KeyboardWin32.cxx:263
+#, c-format
+msgid "No symbol for extended virtual key 0x%02x"
+msgstr ""
+
+#: vncviewer/KeyboardWin32.cxx:265
+#, c-format
+msgid "No symbol for virtual key 0x%02x"
+msgstr ""
+
+#: vncviewer/KeyboardWin32.cxx:424
+#, c-format
+msgid "Failed to update keyboard LED state: %lu"
+msgstr ""
+
+#: vncviewer/KeyboardX11.cxx:123
+#, c-format
+msgid "No symbol for key code %d (in the current state)"
+msgstr ""
+
+#: vncviewer/KeyboardX11.cxx:148
+#, c-format
+msgid "Failed to get keyboard LED state: %d"
+msgstr ""
+
+#: vncviewer/KeyboardX11.cxx:193
+msgid "Failed to update keyboard LED state"
+msgstr ""
+
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
+msgid "Failed to get system monitor configuration"
+msgstr ""
+
+#: vncviewer/MonitorIndicesParameter.cxx:73
+#, c-format
+msgid "Monitor index %d does not exist"
+msgstr ""
+
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
+msgid "TigerVNC options"
+msgstr ""
+
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
+msgid "Cancel"
+msgstr "Annulla"
+
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
+msgid "OK"
+msgstr "OK"
+
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 #, fuzzy
-msgid "VNC Viewer: Connection Options"
-msgstr "VNC Viewer: dettagli di connessione"
+msgid "Compression"
+msgstr "Compressione SSH"
 
-#: /home/ossman/devel/tigervnc/vncviewer/UserDialog.cxx:86
-#: /home/ossman/devel/tigervnc/vncviewer/UserDialog.cxx:96
+#: vncviewer/OptionsDialog.cxx:524
+msgid "Auto select"
+msgstr "Selezione auto"
+
+#: vncviewer/OptionsDialog.cxx:536
+msgid "Preferred encoding"
+msgstr "Codifica preferita"
+
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
+msgid "Color level"
+msgstr "Livello del colore"
+
+#: vncviewer/OptionsDialog.cxx:611
+msgid "Full"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:619
+msgid "Medium"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:627
+msgid "Low"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:635
+msgid "Very low"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:658
+msgid "Custom compression level:"
+msgstr "Livello di compressione:"
+
+#: vncviewer/OptionsDialog.cxx:666
+msgid "level (0=fast, 9=best)"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:674
+msgid "Allow JPEG compression:"
+msgstr "Consenti la compressione JPEG:"
+
+#: vncviewer/OptionsDialog.cxx:682
+msgid "quality (0=poor, 9=best)"
+msgstr "qualità (0=scadente, 9=ottimale)"
+
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
+msgid "Security"
+msgstr "Sicurezza"
+
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
+msgid "Encryption"
+msgstr "Crittografia"
+
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
+msgid "None"
+msgstr "Nessuno"
+
+#: vncviewer/OptionsDialog.cxx:730
+msgid "TLS with anonymous certificates"
+msgstr "TLS con certificati anonimi"
+
+#: vncviewer/OptionsDialog.cxx:737
+msgid "TLS with X509 certificates"
+msgstr "TLS con certificati X509"
+
+#: vncviewer/OptionsDialog.cxx:745
+msgid "Path to X509 CA certificate"
+msgstr "Percorso del certificato X509 CA"
+
+#: vncviewer/OptionsDialog.cxx:753
+msgid "Path to X509 CRL file"
+msgstr "Percorso del file X509 CRL"
+
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
+msgid "Authentication"
+msgstr "Autenticazione"
+
+#: vncviewer/OptionsDialog.cxx:802
+msgid "Standard VNC (insecure without encryption)"
+msgstr "VNC standard (non protetto senza crittografia)"
+
+#: vncviewer/OptionsDialog.cxx:809
+msgid "Username and password (insecure without encryption)"
+msgstr "Nome utente e password (non protetti senza crittografia)"
+
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
+msgid "Input"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:852
+msgid "View only (ignore mouse and keyboard)"
+msgstr ""
+
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
+msgid "Mouse"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:873
+msgid "Emulate middle mouse button"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:880
+msgid "Show local cursor when not provided by server"
+msgstr ""
+
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
+msgid "Cursor type"
+msgstr ""
+
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
+msgid "Dot"
+msgstr ""
+
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
+msgid "System"
+msgstr ""
+
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
+msgid "Keyboard"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:925
+msgid "Pass system keys directly to server (full screen)"
+msgstr ""
+
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
+#, fuzzy
+msgid "Menu key"
+msgstr "Tasto di menu a comparsa"
+
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
+msgid "Clipboard"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:968
+msgid "Accept clipboard from server"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:977
+msgid "Also set primary selection"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:985
+msgid "Send clipboard to server"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:994
+msgid "Send primary selection as clipboard"
+msgstr ""
+
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
+msgid "Display"
+msgstr ""
+
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
+msgid "Display mode"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1045
+msgid "Windowed"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1054
+msgid "Full screen on current monitor"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1063
+msgid "Full screen on all monitors"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1072
+msgid "Full screen on selected monitor(s)"
+msgstr ""
+
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
+msgid "Miscellaneous"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1111
+msgid "Shared (don't disconnect other viewers)"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1118
+msgid "Ask to reconnect on connection errors"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:73
+msgid "VNC server:"
+msgstr "Server VNC:"
+
+#: vncviewer/ServerDialog.cxx:80
+msgid "Options..."
+msgstr "Opzioni..."
+
+#: vncviewer/ServerDialog.cxx:84
+msgid "Load..."
+msgstr "Carica..."
+
+#: vncviewer/ServerDialog.cxx:88
+msgid "Save as..."
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:102
+msgid "About..."
+msgstr "Informazioni..."
+
+#: vncviewer/ServerDialog.cxx:111
+msgid "Connect"
+msgstr "Connettiti"
+
+#: vncviewer/ServerDialog.cxx:147
+#, c-format
+msgid ""
+"Unable to load the server history:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:176 vncviewer/ServerDialog.cxx:216
+msgid "TigerVNC configuration (*.tigervnc)"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:177
+msgid "Select a TigerVNC configuration file"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
+#, c-format
+msgid ""
+"Unable to load the specified configuration file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:217
+msgid "Save the TigerVNC configuration to file"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:243
+#, c-format
+msgid "%s already exists. Do you want to overwrite?"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
+msgid "No"
+msgstr "No"
+
+#: vncviewer/ServerDialog.cxx:244
+msgid "Overwrite"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:260
+#, c-format
+msgid ""
+"Unable to save the specified configuration file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:294
+#, c-format
+msgid ""
+"Unable to save the default configuration:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:306
+#, c-format
+msgid ""
+"Unable to save the server history:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
+msgid "Could not determine VNC state directory path"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
+#, c-format
+msgid "Could not open \"%s\""
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
+#, c-format
+msgid "Failed to read line %d in file \"%s\""
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
+msgid "Line too long"
+msgstr ""
+
+#: vncviewer/UserDialog.cxx:130
+msgid "Opening password file failed"
+msgstr "Apertura del file di password non riuscita"
+
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "Autenticazione VNC"
 
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1176
+#: vncviewer/UserDialog.cxx:157
+msgid "This connection is secure"
+msgstr ""
+
+#: vncviewer/UserDialog.cxx:161
+msgid "This connection is not secure"
+msgstr ""
+
+#: vncviewer/UserDialog.cxx:183
+msgid "Username:"
+msgstr "Nome utente:"
+
+#: vncviewer/UserDialog.cxx:196
+msgid "Password:"
+msgstr "Password:"
+
+#: vncviewer/UserDialog.cxx:204
+msgid "Keep password for reconnect"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:749
+msgctxt "ContextMenu|"
+msgid "Disconn&ect"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:752
+msgctxt "ContextMenu|"
+msgid "&Full screen"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:755
+msgctxt "ContextMenu|"
+msgid "Minimi&ze"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:757
+msgctxt "ContextMenu|"
+msgid "Resize &window to session"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:762
+msgctxt "ContextMenu|"
+msgid "&Ctrl"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:765
+msgctxt "ContextMenu|"
+msgid "&Alt"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:771
+#, c-format
+msgctxt "ContextMenu|"
+msgid "Send %s"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:779
+msgctxt "ContextMenu|"
+msgid "Send Ctrl-Alt-&Del"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:782
+msgctxt "ContextMenu|"
+msgid "&Refresh screen"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:785
+msgctxt "ContextMenu|"
+msgid "&Options..."
+msgstr ""
+
+#: vncviewer/Viewport.cxx:787
+msgctxt "ContextMenu|"
+msgid "Connection &info..."
+msgstr ""
+
+#: vncviewer/Viewport.cxx:789
+msgctxt "ContextMenu|"
+msgid "About &TigerVNC..."
+msgstr ""
+
+#: vncviewer/Viewport.cxx:885
 #, fuzzy
 msgid "VNC connection info"
 msgstr "Info connessione..."
 
-#: /home/ossman/devel/tigervnc/vncviewer/ServerDialog.cxx:49
-#: /home/ossman/devel/tigervnc/vncviewer/ServerDialog.cxx:54
-msgid "VNC server:"
-msgstr "Server VNC:"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:533
-msgid "Very low (8 colors)"
-msgstr "Molto bassa (8 colori)"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:698
-msgid "View only (ignore mouse and keyboard)"
+#: vncviewer/Win32TouchHandler.cxx:49
+msgid "Window is registered for touch instead of gestures"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:219
+#: vncviewer/Win32TouchHandler.cxx:84
+#, c-format
+msgid "Failed to set gesture configuration (error 0x%x)"
+msgstr ""
+
+#: vncviewer/Win32TouchHandler.cxx:96
+#, c-format
+msgid "Failed to get gesture information (error 0x%x)"
+msgstr ""
+
+#: vncviewer/Win32TouchHandler.cxx:364
+#, c-format
+msgid "Invalid mouse button %d, must be a number between 1 and 7."
+msgstr ""
+
+#: vncviewer/Win32TouchHandler.cxx:429
+#, c-format
+msgid "Unhandled key 0x%x - can't generate keyboard event."
+msgstr ""
+
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
+#, c-format
+msgid "Unable to get X Input 2 event mask for window 0x%08lx"
+msgstr ""
+
+#: vncviewer/XInputTouchHandler.cxx:105
+#, c-format
+msgid "Window 0x%08lx has no X Input 2 event mask"
+msgstr ""
+
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
+#, c-format
+msgid "Window 0x%08lx has more than one X Input 2 event mask"
+msgstr ""
+
+#: vncviewer/XInputTouchHandler.cxx:144
+#, c-format
+msgid "Failure grabbing device %i"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
+#: vncviewer/vncviewer.desktop.in.in:5
+msgid "Connect to VNC server and display remote desktop"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
+
+#. developer_name tag deprecated with Appstream 1.0
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
+msgid "The TigerVNC team"
+msgstr ""
+
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
+msgid "The name of the parameter is too large"
+msgstr ""
+
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
+msgid "The parameter is too large"
+msgstr ""
+
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
+msgid "Invalid format or too large value"
+msgstr ""
+
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
+msgid "Failed to create registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
+msgid "Failed to close registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
+#, c-format
+msgid "Failed to save \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
+#, c-format
+msgid "Failed to remove \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
+msgid "Failed to open registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:635
+#, c-format
+msgid "Failed to read server history entry %d: %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
+#, c-format
+msgid "Failed to read parameter \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
+msgid "Could not determine VNC config directory path"
+msgstr ""
+
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
+msgid "Could not encode parameter"
+msgstr ""
+
+#: vncviewer/parameters.cxx:872
+#, c-format
+msgid "Configuration file %s is in an invalid format"
+msgstr ""
+
+#: vncviewer/parameters.cxx:895
+msgid "Invalid format"
+msgstr ""
+
+#: vncviewer/parameters.cxx:939
+msgid "Unknown parameter"
+msgstr ""
+
+#: vncviewer/touch.cxx:75
+#, c-format
+msgid "Got message (0x%x) for an unhandled window"
+msgstr ""
+
+#: vncviewer/touch.cxx:138 vncviewer/touch.cxx:160
+#, c-format
+msgid "Invalid window 0x%08lx specified for pointer grab"
+msgstr ""
+
+#: vncviewer/touch.cxx:183 vncviewer/touch.cxx:184
+#, c-format
+msgid "Failed to create touch handler: %s"
+msgstr ""
+
+#: vncviewer/touch.cxx:188
+#, c-format
+msgid "Couldn't attach event handler to window (error 0x%x)"
+msgstr ""
+
+#: vncviewer/touch.cxx:215
+msgid "Failed to get event data for X Input event"
+msgstr ""
+
+#: vncviewer/touch.cxx:228
+msgid "X Input event for unknown window"
+msgstr ""
+
+#: vncviewer/touch.cxx:254
+msgid "X Input extension not available."
+msgstr ""
+
+#: vncviewer/touch.cxx:261
+msgid "X Input 2 (or newer) is not available."
+msgstr ""
+
+#: vncviewer/touch.cxx:266
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:103
+#, c-format
+msgid ""
+"TigerVNC v%s\n"
+"Built on: %s\n"
+"Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+"See https://www.tigervnc.org for information on TigerVNC."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:157
+#, c-format
+msgid ""
+"An unexpected error occurred when communicating with the server:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:194
+msgid "Internal FLTK error. Exiting."
+msgstr "Errore FLTK interno. Uscita in corso."
+
+#: vncviewer/vncviewer.cxx:213
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"Attempt to reconnect?"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
+#, c-format
+msgid "Error starting new connection: %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:265
+#, c-format
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "Sì"
 
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:111
-#, c-format
-msgid "connected to host %s port %d"
-msgstr "connesso all'host %s porta %d"
+#: vncviewer/vncviewer.cxx:397
+msgid "Close"
+msgstr "Chiudi"
 
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:563
-msgid "disabled"
-msgstr "disabilitato"
+#: vncviewer/vncviewer.cxx:402
+msgid "About"
+msgstr "Informazioni"
 
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:563
-msgid "enabled"
-msgstr "abilitato"
+#: vncviewer/vncviewer.cxx:405
+msgid "Hide"
+msgstr "Nascondi"
 
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:556
-msgid "level (1=fast, 6=best [4-6 are rarely useful])"
-msgstr "livello (1=veloce, 6=ottimale [4-6 sono raramente utili])"
+#: vncviewer/vncviewer.cxx:408
+msgid "Quit"
+msgstr "Esci"
 
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:569
-msgid "quality (0=poor, 9=best)"
-msgstr "qualità (0=scadente, 9=ottimale)"
+#: vncviewer/vncviewer.cxx:412
+msgid "Services"
+msgstr "Servizi"
 
-#: /home/ossman/devel/tigervnc/vncviewer/Win32PixelBuffer.cxx:63
-msgid "unable to create DIB section"
+#: vncviewer/vncviewer.cxx:413
+msgid "Hide others"
 msgstr ""
+
+#: vncviewer/vncviewer.cxx:414
+msgid "Show all"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:423
+msgctxt "SysMenu|"
+msgid "&File"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:426
+msgctxt "SysMenu|File|"
+msgid "&New Connection"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:449
+#, c-format
+msgid ""
+"\n"
+"Usage: %s [parameters] [host][:displayNum]\n"
+"       %s [parameters] [host][::port]\n"
+"       %s [parameters] [unix socket]\n"
+"       %s [parameters] -listen [port]\n"
+"       %s [parameters] [.tigervnc file]\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:464
+#, c-format
+msgid ""
+"\n"
+"Options:\n"
+"\n"
+"  -display Xdisplay  - Specifies the X display for the viewer window\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
+"                       man page for details.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:471
+#, c-format
+msgid ""
+"\n"
+"Parameters can be turned on with -<param> or off with -<param>=0\n"
+"Parameters which take a value can be specified as -<param> <value>\n"
+"Other valid forms are <param>=<value> -<param>=<value> --<param>=<value>\n"
+"Parameter names are case-insensitive.  The parameters are:\n"
+"\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:556
+#, c-format
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:561
+#, c-format
+msgid "Could not create VNC config directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:567
+msgid "Could not determine VNC data directory path"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:573
+#, c-format
+msgid "Could not create VNC data directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:585
+#, c-format
+msgid "Could not create VNC state directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:704
+#, c-format
+msgid "%s: Unrecognized option '%s'\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
+#, c-format
+msgid "See '%s --help' for more information.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:713
+#, c-format
+msgid "%s: Extra argument '%s'\n"
+msgstr ""
+
+#. TRANSLATORS: "Parameters" are command line arguments, or settings
+#. from a file or the Windows registry.
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
+msgid "Parameters -listen and -via are incompatible"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:764
+msgid "Unable to listen for incoming connections"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:766
+#, c-format
+msgid "Listening on port %d"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:795
+#, c-format
+msgid ""
+"Failure waiting for incoming VNC connection:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:816
+#, c-format
+msgid ""
+"Failure setting up encrypted tunnel:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.desktop.in.in:4
+msgid "Remote desktop viewer"
+msgstr ""
+
+#~ msgid "Authentication cancelled"
+#~ msgstr "Autenticazione annullata"
+
+#~ msgid "Connection info..."
+#~ msgstr "Info connessione..."
+
+#, c-format
+#~ msgid "Could not create VNC home directory: %s."
+#~ msgstr "Impossibile creare la home directory VNC: %s."
+
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
+#~ msgstr ""
+#~ "Impossibile creare la home directory VNC: impossibile ottenere il "
+#~ "percorso della home directory."
+
+#~ msgid "Dismiss menu"
+#~ msgstr "Ignora menu"
+
+#, fuzzy
+#~ msgid "Enable full-screen mode over all monitors"
+#~ msgstr "Abilita modalità schermo intero su tutti i monitor"
+
+#~ msgid "Enabling continuous updates"
+#~ msgstr "Abilitazione aggiornamenti continui"
+
+#, fuzzy
+#~ msgid "Failed to read configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Impossibile creare la home directory VNC: impossibile ottenere il "
+#~ "percorso della home directory."
+
+#, fuzzy
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Impossibile creare la home directory VNC: impossibile ottenere il "
+#~ "percorso della home directory."
+
+#~ msgid "Failure grabbing mouse"
+#~ msgstr "Errore di raccolta del mouse"
+
+#~ msgid "Full (all available colors)"
+#~ msgstr "Pieno (tutti i colori disponibili)"
+
+#~ msgid "Full screen"
+#~ msgstr "Schermo intero"
+
+#, fuzzy
+#~ msgid "Full-screen mode"
+#~ msgstr "Modalità schermo intero"
+
+#~ msgid "Hide Others"
+#~ msgstr "Nascondi altri"
+
+#~ msgid "Low (64 colors)"
+#~ msgstr "Basso (64 colori)"
+
+#~ msgid "Medium (256 colors)"
+#~ msgstr "Medio (256 colori)"
+
+#~ msgid "Misc."
+#~ msgstr "Varie"
+
+#, c-format
+#~ msgid "Multiple characters given for key code %d (0x%04x): '%s'"
+#~ msgstr "Caratteri multipli forniti per il codice chiave %d (0x%04x): '%s'"
+
+#, fuzzy
+#~ msgid "Resize remote session on connect"
+#~ msgstr "Ridimensiona la sessione remota alla finestra locale"
+
+#~ msgid "Resize remote session to the local window"
+#~ msgstr "Ridimensiona la sessione remota alla finestra locale"
+
+#~ msgid "Resize window to session"
+#~ msgstr "Ridimensiona la finestra alla sessione"
+
+#~ msgid "Save As..."
+#~ msgstr "Salva con nome..."
+
+#~ msgid "Screen"
+#~ msgstr "Schermo"
+
+#, c-format
+#~ msgid "Send %s"
+#~ msgstr "Invia %s"
+
+#~ msgid "Send Ctrl-Alt-Del"
+#~ msgstr "Invia Ctrl-Alt-Del"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "Impostazioni dimensioni desktop non riuscita: %d"
+
+#~ msgid "Show All"
+#~ msgstr "Mostra tutto"
+
+#, c-format
+#~ msgid "Throughput %d kbit/s - full color is now %s"
+#~ msgstr "Velocità effettiva %d kbit/s - tutti i colori sono ora %s"
+
+#, c-format
+#~ msgid "Unknown FLTK key code %d (0x%04x)"
+#~ msgstr "Codice chiave FLTK sconosciuto %d (0x%04x)"
+
+#, c-format
+#~ msgid "Unknown decimal separator: '%s'"
+#~ msgstr "Separatore decimale sconosciuto: '%s'"
+
+#, fuzzy, c-format
+#~ msgid "Unknown escape sequence at character %d"
+#~ msgstr "Separatore decimale sconosciuto: '%s'"
+
+#, fuzzy
+#~ msgid "Unknown rect encoding"
+#~ msgstr "Utilizzo codifica %s"
+
+#, c-format
+#~ msgid "Using %s encoding"
+#~ msgstr "Utilizzo codifica %s"
+
+#~ msgid "VNC Viewer: Connection Details"
+#~ msgstr "VNC Viewer: dettagli di connessione"
+
+#, fuzzy
+#~ msgid "VNC Viewer: Connection Options"
+#~ msgstr "VNC Viewer: dettagli di connessione"
+
+#~ msgid "Very low (8 colors)"
+#~ msgstr "Molto bassa (8 colori)"
+
+#, c-format
+#~ msgid "connected to host %s port %d"
+#~ msgstr "connesso all'host %s porta %d"
+
+#~ msgid "disabled"
+#~ msgstr "disabilitato"
+
+#~ msgid "enabled"
+#~ msgstr "abilitato"
+
+#~ msgid "level (1=fast, 6=best [4-6 are rarely useful])"
+#~ msgstr "livello (1=veloce, 6=ottimale [4-6 sono raramente utili])"
 
 #, fuzzy
 #~ msgid ""

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.14.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2025-01-14 16:15+0100\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2025-01-22 05:48+0100\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>\n"
 "Language-Team: Georgian <(nothing)>\n"
@@ -19,17 +19,17 @@ msgstr ""
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: Poedit 3.5\n"
 
-#: vncviewer/CConn.cxx:102
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "მიერთება სოკეტთან %s"
 
-#: vncviewer/CConn.cxx:109
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "მიერთებულია ჰოსტთან %s პორტი %d"
 
-#: vncviewer/CConn.cxx:114
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -40,66 +40,63 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:151
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "სამუშაო მაგიდის სახელი: %.80s"
 
-#: vncviewer/CConn.cxx:154
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "პოსტი: %.80s პორტი: %d"
 
-#: vncviewer/CConn.cxx:158
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "ზომა: %d x %d"
 
-#: vncviewer/CConn.cxx:165
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "პიქსელის ფორმატი: %s"
 
-#: vncviewer/CConn.cxx:170
-#, c-format
-msgid "(server default %s)"
-msgstr "(სერვერის ნაგულისხმები %s)"
-
-#: vncviewer/CConn.cxx:173
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "მოთხოვნილი კოდირება: %s"
 
-#: vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "ბოლოს გამოყენებული კოდირება: %s"
 
-#: vncviewer/CConn.cxx:181
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "კავშირის დაახლოებითი სიჩქარე: %d kbit/s"
 
-#: vncviewer/CConn.cxx:185
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "პროტოკოლის ვერსია: %d.%d"
 
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "უსაფრთხოების მეთოდი: %s"
 
-#: vncviewer/CConn.cxx:250 vncviewer/CConn.cxx:252
-msgid "The connection was dropped by the server before the session could be established."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
 msgstr "კავშირი გაითიშა სერვერის მიერ სანამ სესია დადგებოდა."
 
-#: vncviewer/CConn.cxx:262
+#: vncviewer/CConn.cxx:258
 #, c-format
 msgid "Authentication failed: %s"
 msgstr "ავთენტიკაციის შეცდომა: %s"
 
-#: vncviewer/CConn.cxx:263
+#: vncviewer/CConn.cxx:259
 #, c-format
 msgid ""
 "Failed to authenticate with the server. Reason given by the server:\n"
@@ -110,31 +107,22 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:335
-#, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "SetDesktopSize-ის შეცდომა: %d"
-
-#: vncviewer/CConn.cxx:408
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "არასწორი SetColourMapEntries სერვერიდან!"
-
-#: vncviewer/CConn.cxx:516
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "გამტარობა %d კბიტ/წმ - ხარისხი შეიცვლება: %d"
 
-#: vncviewer/CConn.cxx:538
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "გამტარობა %d კბიტ/წმ - ფერთა სრული გამა ჩართულია"
 
-#: vncviewer/CConn.cxx:541
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "გამტარობა %d კბიტ/წმ - ფერთა სრული გამა გამორთულია"
 
-#: vncviewer/CConn.cxx:567
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "პიქსელის ფორმატი: %s"
@@ -147,136 +135,127 @@ msgstr "მითითებული გეომეტრია არას�
 msgid "Reducing window size to fit on current monitor"
 msgstr "ფანჯრის ზომის შეცვლა მიმდინარე ეკრანზე დასატევად"
 
-#: vncviewer/DesktopWindow.cxx:646
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
-msgstr "ეკრანის ზომის მორგება შემთხვევით სრულ ეკრანზე გაშლის თავიდან ასარიდებლად"
+msgstr ""
+"ეკრანის ზომის მორგება შემთხვევით სრულ ეკრანზე გაშლის თავიდან ასარიდებლად"
 
-#: vncviewer/DesktopWindow.cxx:694
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "კონტექსტური მენიუს გასახსნელად დააწექით: %s"
 
-#: vncviewer/DesktopWindow.cxx:1094 vncviewer/DesktopWindow.cxx:1102
-#: vncviewer/DesktopWindow.cxx:1122
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "კლავიატურის ჩაჭერის შეცდომა"
 
-#: vncviewer/DesktopWindow.cxx:1411
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
 msgstr "ზომის შესაცვლელად გამოთვლილი ფანჯრების განლაგება არასწორია!"
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "არასწორი მდგომარეობა 3 ღილაკის ემულაციისთვის"
 
-#: vncviewer/KeyboardWin32.cxx:242
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
-msgstr "გაფართოებული ვირტუალური ღილაკისთვის სკანირების კოდი არ არსებობს: 0x%02x"
+msgstr ""
+"გაფართოებული ვირტუალური ღილაკისთვის სკანირების კოდი არ არსებობს: 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:244
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "სკანირების კოდი ვირტუალური ღილაკისთვის არსებობს: 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:250
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "სკანირების არასწორი კოდი: 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:262
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "გაფართოებული ვირტუალური ღილაკის სიმბოლო ნაპოვნი არაა:0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:264
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "ვირტუალური ღილაკის სიმბოლო ნაპოვნი არაა: 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:423
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
 msgid "Failed to update keyboard LED state: %lu"
 msgstr "კლავიატურის LED-ის მდგომარეობის განახლების შეცდომა: %lu"
 
-#: vncviewer/KeyboardX11.cxx:104
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "ღილაკის კოდისთვის %d (მიმდინარე მდგომარეობაში) სიმბოლო აღმოჩენილი არაა"
 
-#: vncviewer/KeyboardX11.cxx:129
+#: vncviewer/KeyboardX11.cxx:148
 #, c-format
 msgid "Failed to get keyboard LED state: %d"
 msgstr "კლავიატურის LED-ის მდგომარეობის მიღების შეცდომა: %d"
 
-#: vncviewer/KeyboardX11.cxx:174
+#: vncviewer/KeyboardX11.cxx:193
 msgid "Failed to update keyboard LED state"
 msgstr "კლავიატურის LED-ის მდგომარეობის განახლების შეცდომა"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:100
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "სისტემური მონიტორის ინფორმაციის მიღება შეუძლებელია"
 
-#: vncviewer/MonitorIndicesParameter.cxx:79
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "%s-ის მითითებული კონფიგურაცია არასწორია"
-
-#: vncviewer/MonitorIndicesParameter.cxx:86
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "ეკრანის ინდექსი %d არ არსებობს"
 
-#: vncviewer/MonitorIndicesParameter.cxx:162
-#: vncviewer/MonitorIndicesParameter.cxx:182
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "ეკრანის არასწორი ინდექსი: '%s'"
-
-#: vncviewer/MonitorIndicesParameter.cxx:170
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "მოულოდნელი სიმბოლო '%c'"
-
-#: vncviewer/OptionsDialog.cxx:64
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
 msgid "TigerVNC options"
 msgstr "TigerVNC-ის მორგება"
 
-#: vncviewer/OptionsDialog.cxx:97 vncviewer/ServerDialog.cxx:107
-#: vncviewer/vncviewer.cxx:397
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "გაუქმება"
 
-#: vncviewer/OptionsDialog.cxx:102 vncviewer/vncviewer.cxx:396
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "დიახ"
 
-#: vncviewer/OptionsDialog.cxx:514
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "შეკუმშვა"
 
-#: vncviewer/OptionsDialog.cxx:530
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "ავტომატური არჩევა"
 
-#: vncviewer/OptionsDialog.cxx:541
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "სასურველი კოდირებ"
 
-#: vncviewer/OptionsDialog.cxx:602
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "ფერის დონე"
 
-#: vncviewer/OptionsDialog.cxx:614
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "მთლიანი"
 
-#: vncviewer/OptionsDialog.cxx:621
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "საშუალო"
 
-#: vncviewer/OptionsDialog.cxx:628
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "დაბალი"
 
@@ -284,166 +263,177 @@ msgstr "დაბალი"
 msgid "Very low"
 msgstr "ძალიან დაბალი"
 
-#: vncviewer/OptionsDialog.cxx:657
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "შეკუმშვის დონის ხელით მითითება:"
 
-#: vncviewer/OptionsDialog.cxx:664
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "დონე (0=სწრაფი, 9=საუკეთესო)"
 
-#: vncviewer/OptionsDialog.cxx:671
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "JPEG შეკუმშვის ჩართვა:"
 
-#: vncviewer/OptionsDialog.cxx:678
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "ხარისხი (0=ცუდი, 9=საუკეთესო)"
 
-#: vncviewer/OptionsDialog.cxx:689
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "უსაფრთხოება"
 
-#: vncviewer/OptionsDialog.cxx:703
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "დაშიფრვა"
 
-#: vncviewer/OptionsDialog.cxx:715 vncviewer/OptionsDialog.cxx:782
-#: vncviewer/OptionsDialog.cxx:905
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "არაფერი"
 
-#: vncviewer/OptionsDialog.cxx:722
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "TLS ანონიმური სერტიფიკატებით"
 
-#: vncviewer/OptionsDialog.cxx:728
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "TLS X509 სერტიფიკატებით"
 
-#: vncviewer/OptionsDialog.cxx:735
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "X509 CA სერტიფიკატის ბილიკი"
 
-#: vncviewer/OptionsDialog.cxx:742
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "X509 CRL ფაილის ბილიკი"
 
-#: vncviewer/OptionsDialog.cxx:770
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "ავთენტიფიკაცია"
 
-#: vncviewer/OptionsDialog.cxx:788
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "VNC-ის სტანდარტი (დაუცველი, დაშიფვრის გარეშე)"
 
-#: vncviewer/OptionsDialog.cxx:794
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "მომხმარებელი და პაროლი (დაუცველი, დაშიფვრის გარეშე)"
 
-#: vncviewer/OptionsDialog.cxx:822
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "შეყვანა"
 
-#: vncviewer/OptionsDialog.cxx:835
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "მხოლოდ ნახვა (თაგუნას და კლავიატურის იგნორირება)"
 
-#: vncviewer/OptionsDialog.cxx:842
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "თაგუნა"
 
-#: vncviewer/OptionsDialog.cxx:854
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "თაგუნას შუა ღილიკის ემულაცია"
 
-#: vncviewer/OptionsDialog.cxx:860
+#: vncviewer/OptionsDialog.cxx:880
 msgid "Show local cursor when not provided by server"
 msgstr "ლოკალური კურსორის ჩვენება, როცა ის მოწოდებული არაა სერვერის მიერ"
 
-#: vncviewer/OptionsDialog.cxx:865
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
 msgid "Cursor type"
 msgstr "კურსორის ტიპი"
 
-#: vncviewer/OptionsDialog.cxx:867
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
 msgid "Dot"
 msgstr "წერტილი"
 
-#: vncviewer/OptionsDialog.cxx:868
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
 msgid "System"
 msgstr "სისტემა"
 
-#: vncviewer/OptionsDialog.cxx:888
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "კლავიატურა"
 
-#: vncviewer/OptionsDialog.cxx:900
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
 msgstr "სისტემური ღილაკების პირდაპირ სერვერზე გაგზავნა (სრულ ეკრანზე)"
 
-#: vncviewer/OptionsDialog.cxx:903
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "მენიუს ღილაკი"
 
-#: vncviewer/OptionsDialog.cxx:926
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "გაცვლის ბუფერი"
 
-#: vncviewer/OptionsDialog.cxx:938
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "სერვერიდან გაცვლის ბუფერის მიღება"
 
-#: vncviewer/OptionsDialog.cxx:946
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "ძირითადი არჩევანის დაყენება"
 
-#: vncviewer/OptionsDialog.cxx:953
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "გაცვლის ბაფერის სერვერზე გაგზავნა"
 
-#: vncviewer/OptionsDialog.cxx:961
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "ძირითადი არჩევანის გაცვლის ბუფერით გაგზავნა"
 
-#: vncviewer/OptionsDialog.cxx:982
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "ჩვენება"
 
-#: vncviewer/OptionsDialog.cxx:996
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "ჩვენების რეჟიმი"
 
-#: vncviewer/OptionsDialog.cxx:1009
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "ფანჯარაში"
 
-#: vncviewer/OptionsDialog.cxx:1017
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "სრულ ეკრანზე მიმდინარე მონიტორზე"
 
-#: vncviewer/OptionsDialog.cxx:1025
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "სრულ ეკრანზე ყველა მონიტორზე"
 
-#: vncviewer/OptionsDialog.cxx:1033
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "სრულ ეკრანზე მონიშნულ მონიტორ(ებ)-ზე"
 
-#: vncviewer/OptionsDialog.cxx:1062
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
 msgid "Miscellaneous"
 msgstr "სხვადასხვა"
 
-#: vncviewer/OptionsDialog.cxx:1070
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "გაზიარებული (სხვა მაყურებლები არ გამოიყრებიან)"
 
-#: vncviewer/OptionsDialog.cxx:1076
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "კავშირის დაკარგვისას თავიდან შეერთების შესახებ კითხვა"
-
-#: vncviewer/ServerDialog.cxx:63
-msgid "VNC viewer: Connection details"
-msgstr "VNC-ის დათვალიერება: კავშირის დეტალები"
 
 #: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
@@ -488,7 +478,7 @@ msgstr "TigerVNC-ის კონფიგურაცია (*.tigervnc)"
 msgid "Select a TigerVNC configuration file"
 msgstr "აირჩიეთ TigerVNC-ის კონფიგურაციის ფაილი"
 
-#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:517
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -508,7 +498,7 @@ msgstr "TigerVNC-ის კონფიგურაციის ფაილი�
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "'%s' უკვე არსებობს. გნებავთ გადააწეროთ?"
 
-#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:394
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "არა"
 
@@ -549,169 +539,170 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:351 vncviewer/ServerDialog.cxx:429
-#: vncviewer/vncviewer.cxx:580
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
 msgid "Could not determine VNC state directory path"
 msgstr "VNC-ის მდგომარეობის საქაღალდის ბილიკის დადგენა შეუძლებელია"
 
-#: vncviewer/ServerDialog.cxx:363 vncviewer/ServerDialog.cxx:437
-#: vncviewer/parameters.cxx:671 vncviewer/parameters.cxx:752
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
 msgid "Could not open \"%s\""
 msgstr "\"%s\"-ის გახსნის შეცდომა"
 
-#: vncviewer/ServerDialog.cxx:378 vncviewer/ServerDialog.cxx:387
-#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:773
-#: vncviewer/parameters.cxx:807 vncviewer/parameters.cxx:837
-#: vncviewer/parameters.cxx:844
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
 msgid "Failed to read line %d in file \"%s\""
 msgstr "შეუძლებელია %d-ე ხაზის წაკითხვა ფაილში \"%s\""
 
-#: vncviewer/ServerDialog.cxx:390 vncviewer/parameters.cxx:776
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "ხაზი ძალიან გრძელია"
 
-#: vncviewer/UserDialog.cxx:123
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "ფაილის გახსნის შეცდომა"
 
-#: vncviewer/UserDialog.cxx:143
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "VNC ავთენტიფიკაცია"
 
-#: vncviewer/UserDialog.cxx:150
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "შეერთება დაცულია"
 
-#: vncviewer/UserDialog.cxx:154
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "შეერთება დაუცველია"
 
-#: vncviewer/UserDialog.cxx:176
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "მომხმარებელი:"
 
-#: vncviewer/UserDialog.cxx:189
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "პაროლი:"
 
-#: vncviewer/UserDialog.cxx:197
+#: vncviewer/UserDialog.cxx:204
 msgid "Keep password for reconnect"
 msgstr "პაროლის შენახვა თავიდან დასაკავშირებლად"
 
-#: vncviewer/Viewport.cxx:695
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
 msgid "Disconn&ect"
 msgstr "&გათიშვა"
 
-#: vncviewer/Viewport.cxx:698
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "&მთელს ეკრანზე"
 
-#: vncviewer/Viewport.cxx:701
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "&მინიმიზაცია"
 
-#: vncviewer/Viewport.cxx:703
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "&ფანჯრის ზომის სესიის ზომამდე შეცვლა"
 
-#: vncviewer/Viewport.cxx:708
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:711
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:717
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "%s-ის გაგზავნა"
 
-#: vncviewer/Viewport.cxx:724
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Ctrl-Alt-&Del-ის გაგზავნა"
 
-#: vncviewer/Viewport.cxx:727
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "&ეკრანის განახლება"
 
-#: vncviewer/Viewport.cxx:730
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&მორგება..."
 
-#: vncviewer/Viewport.cxx:732
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "&შეერთების ინფორმაცია..."
 
-#: vncviewer/Viewport.cxx:734
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "&TigerVNC-ის კლიენტის შესახებ..."
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:830
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "VNC-ის შეერთების ინფორმაცია"
 
-#: vncviewer/Win32TouchHandler.cxx:48
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "ფანჯარა რეგისტრირებულია შესახებად, ჟესტების მაგიერ"
 
-#: vncviewer/Win32TouchHandler.cxx:83
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "ჟესტის კონფიგურაციის მიღება ჩავარდა (შეცდომა 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:95
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "ჟესტის ინფორმაციის მიღება ჩავარდა (შეცდომა 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:360
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr "არასწორი თაგუნას ღილაკი %d. უნდა იყოს რიცხვი შუალედიდან 1-7."
 
-#: vncviewer/Win32TouchHandler.cxx:425
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
 msgstr "უცნობი ღილაკი 0x%x - კლავიატურის მოვლენის გენერაცია შეუძლებელია."
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:107
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
 msgstr ""
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr ""
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:114
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr ""
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "მოწყობილობის ჩაჭერის შეცდომა: %i"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-msgid "TigerVNC Viewer"
-msgstr "TigerVNC-ის კლიენტი"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -719,100 +710,113 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
 msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
 msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC viewer connection to a CentOS machine"
-msgstr "TigerVNC-ის დამთვალიერებლის კავშირი CentOS-ის მანქანასთან"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC viewer connection to a macOS machine"
-msgstr "TigerVNC-ის დამთვალიერებლის კავშირი macOS-ის მანქანასთან"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC viewer connection to a Windows machine"
-msgstr "TigerVNC-ის დამთვალიერებლის კავშირი Windows-ის მანქანასთან"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
 #. developer_name tag deprecated with Appstream 1.0
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
-#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:48
 msgid "The TigerVNC team"
 msgstr "TigerVNC-ის გუნდი"
 
-#: vncviewer/parameters.cxx:319 vncviewer/parameters.cxx:344
-#: vncviewer/parameters.cxx:361 vncviewer/parameters.cxx:401
-#: vncviewer/parameters.cxx:421
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "პარამეტრის სახელი ძალიან დიდია"
 
-#: vncviewer/parameters.cxx:323 vncviewer/parameters.cxx:328
-#: vncviewer/parameters.cxx:379
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "პარამეტრი ძალიან დიდია"
 
-#: vncviewer/parameters.cxx:386 vncviewer/parameters.cxx:712
-#: vncviewer/parameters.cxx:822
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "არასწორი ფორმატი ან ძალიან დიდი მნიშვნელობა"
 
-#: vncviewer/parameters.cxx:440 vncviewer/parameters.cxx:473
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "რეესრის გასაღების შექმნის შეცდომა"
 
-#: vncviewer/parameters.cxx:461 vncviewer/parameters.cxx:528
-#: vncviewer/parameters.cxx:571 vncviewer/parameters.cxx:638
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "რეესტრის გასაღების დახურვის შეცდომა"
 
-#: vncviewer/parameters.cxx:479 vncviewer/parameters.cxx:506
-#: vncviewer/parameters.cxx:680 vncviewer/parameters.cxx:692
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "\"%s'-ის შენახვის შეცდომა: %s"
 
-#: vncviewer/parameters.cxx:489 vncviewer/parameters.cxx:520
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "\"%s\"-ის წაშლის შეცდომა: %s"
 
-#: vncviewer/parameters.cxx:544 vncviewer/parameters.cxx:616
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "რეესტრის გასაღების გახსნის შეცდომა"
 
-#: vncviewer/parameters.cxx:561
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "სერვერის ისტორიის ჩანაწერის (%d) წაკითხვა შეუძლებელია: %s"
 
-#: vncviewer/parameters.cxx:597 vncviewer/parameters.cxx:627
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "\"%s\"-ის წაკითხვის შეცდომა: %s"
 
-#: vncviewer/parameters.cxx:661 vncviewer/parameters.cxx:740
-#: vncviewer/vncviewer.cxx:546
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
 msgid "Could not determine VNC config directory path"
 msgstr "VNC-ის კონფიგურაციის საქაღალდის ბილიკის დადგენა შეუძლებელია"
 
-#: vncviewer/parameters.cxx:682 vncviewer/parameters.cxx:694
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "პარამეტრის კოდირების შეცდომა"
 
-#: vncviewer/parameters.cxx:785
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "კონფიგურაციის არასწორი ფორმატი ფაილისთვის : %s"
 
-#: vncviewer/parameters.cxx:809
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "არასწორი ფორმატი"
 
-#: vncviewer/parameters.cxx:846
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "უცნობი პარამეტრი"
 
@@ -853,19 +857,22 @@ msgid "X Input 2 (or newer) is not available."
 msgstr "X Input 2 (ან უფრო ახალი) მიუწვდომელია."
 
 #: vncviewer/touch.cxx:266
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
-msgstr "X Input 2.2 (ან უფრო ახალი) მიუწვდომელია. შეხების ჟესტები მხარდაუჭერელია."
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+"X Input 2.2 (ან უფრო ახალი) მიუწვდომელია. შეხების ჟესტები მხარდაუჭერელია."
 
-#: vncviewer/vncviewer.cxx:104
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
 "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:158
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -876,15 +883,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:174
-msgid "About TigerVNC Viewer"
-msgstr "TigerVNC-ის კლიენტის შესახებ"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:195
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "FLTK-ის შიდა შეცდომა. პროგრამა ასრულებს მუშაობას."
 
-#: vncviewer/vncviewer.cxx:214
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -895,63 +902,59 @@ msgstr ""
 "\n"
 "ვცადო თავიდან დაკავშირება?"
 
-#: vncviewer/vncviewer.cxx:245 vncviewer/vncviewer.cxx:257
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "TigerVNC-ის ახალი დამთვალიერებლის გაშვების შეცდომა: %s"
-
-#: vncviewer/vncviewer.cxx:266
-#, c-format
-msgid "Termination signal %d has been received. TigerVNC viewer will now exit."
+msgid "Error starting new connection: %s"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:391 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC viewer"
-msgstr "TigerVNC-ის დამთვალიერებელი"
+#: vncviewer/vncviewer.cxx:265
+#, c-format
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:395
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "დიახ"
 
-#: vncviewer/vncviewer.cxx:398
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "დახურვა"
 
-#: vncviewer/vncviewer.cxx:403
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "შესახებ"
 
-#: vncviewer/vncviewer.cxx:406
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "დამალვა"
 
-#: vncviewer/vncviewer.cxx:409
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "გასვლა"
 
-#: vncviewer/vncviewer.cxx:413
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "სერვისები"
 
-#: vncviewer/vncviewer.cxx:414
+#: vncviewer/vncviewer.cxx:413
 msgid "Hide others"
 msgstr "სხვების დამალვა"
 
-#: vncviewer/vncviewer.cxx:415
+#: vncviewer/vncviewer.cxx:414
 msgid "Show all"
 msgstr "ყველას ჩვენება"
 
-#: vncviewer/vncviewer.cxx:424
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "&ფაილი"
 
-#: vncviewer/vncviewer.cxx:427
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "&ახალი შეერთება"
 
-#: vncviewer/vncviewer.cxx:450
+#: vncviewer/vncviewer.cxx:449
 #, c-format
 msgid ""
 "\n"
@@ -962,18 +965,19 @@ msgid ""
 "       %s [parameters] [.tigervnc file]\n"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:465
+#: vncviewer/vncviewer.cxx:464
 #, c-format
 msgid ""
 "\n"
 "Options:\n"
 "\n"
 "  -display Xdisplay  - Specifies the X display for the viewer window\n"
-"  -geometry geometry - Initial position of the main VNC viewer window. See the\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
 "                       man page for details.\n"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:472
+#: vncviewer/vncviewer.cxx:471
 #, c-format
 msgid ""
 "\n"
@@ -984,73 +988,80 @@ msgid ""
 "\n"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:527
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:532
-msgid "DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' instead"
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:553
-msgid "~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:557
+#: vncviewer/vncviewer.cxx:556
 #, c-format
-msgid "%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC location."
-msgstr "%%APPDATA%%\\vnc მოძველებულია. გადაერთეთ მდებარეობაზე %%APPDATA%%\\TigerVNC."
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+"%%APPDATA%%\\vnc მოძველებულია. გადაერთეთ მდებარეობაზე %%APPDATA%%\\TigerVNC."
 
-#: vncviewer/vncviewer.cxx:562
+#: vncviewer/vncviewer.cxx:561
 #, c-format
 msgid "Could not create VNC config directory \"%s\": %s"
 msgstr "ვერ შევქმენი VNC-ის კონფიგურაციის საქაღალდე \"%s\": %s"
 
-#: vncviewer/vncviewer.cxx:568
+#: vncviewer/vncviewer.cxx:567
 msgid "Could not determine VNC data directory path"
 msgstr "VNC-ის მონაცემების საქაღალდის ბილიკის დადგენა შეუძლებელია"
 
-#: vncviewer/vncviewer.cxx:574
+#: vncviewer/vncviewer.cxx:573
 #, c-format
 msgid "Could not create VNC data directory \"%s\": %s"
 msgstr "ვერ შევქმენი VNC-ის მონაცემების საქაღალდე \"%s\": %s"
 
-#: vncviewer/vncviewer.cxx:586
+#: vncviewer/vncviewer.cxx:585
 #, c-format
 msgid "Could not create VNC state directory \"%s\": %s"
 msgstr "VNC-ის მდგომარეობის საქაღალდის \"%s\" შექმნა შეუძლებელია: %s"
 
-#: vncviewer/vncviewer.cxx:703
+#: vncviewer/vncviewer.cxx:704
 #, c-format
 msgid "%s: Unrecognized option '%s'\n"
 msgstr "%s: უცნობი პარამეტრი '%s'\n"
 
-#: vncviewer/vncviewer.cxx:705 vncviewer/vncviewer.cxx:713
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
 #, c-format
 msgid "See '%s --help' for more information.\n"
 msgstr "მეტი ინფორმაციისთვის იხილეთ '%s --help'.\n"
 
-#: vncviewer/vncviewer.cxx:712
+#: vncviewer/vncviewer.cxx:713
 #, c-format
 msgid "%s: Extra argument '%s'\n"
 msgstr "%s: დამატებითი არგუმენტი '%s'\n"
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:748 vncviewer/vncviewer.cxx:749
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "პარამეტრები -listen და -via თავსებადი არაა"
 
-#: vncviewer/vncviewer.cxx:763
+#: vncviewer/vncviewer.cxx:764
 msgid "Unable to listen for incoming connections"
 msgstr "შემომავალი კავშირებისთვის მოსმენა შეუძლებელია"
 
-#: vncviewer/vncviewer.cxx:765
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "ვუსმენ პორტზე %d"
 
-#: vncviewer/vncviewer.cxx:794
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -1061,7 +1072,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:815
+#: vncviewer/vncviewer.cxx:816
 #, c-format
 msgid ""
 "Failure setting up encrypted tunnel:\n"
@@ -1075,6 +1086,58 @@ msgstr ""
 #: vncviewer/vncviewer.desktop.in.in:4
 msgid "Remote desktop viewer"
 msgstr "დაშორებული სამუშაო მაგიდის კლიენტი"
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(სერვერის ნაგულისხმები %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "SetDesktopSize-ის შეცდომა: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "არასწორი SetColourMapEntries სერვერიდან!"
+
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "%s-ის მითითებული კონფიგურაცია არასწორია"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "ეკრანის არასწორი ინდექსი: '%s'"
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "მოულოდნელი სიმბოლო '%c'"
+
+#~ msgid "VNC viewer: Connection details"
+#~ msgstr "VNC-ის დათვალიერება: კავშირის დეტალები"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "&TigerVNC-ის კლიენტის შესახებ..."
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "TigerVNC-ის კლიენტი"
+
+#~ msgid "TigerVNC viewer connection to a CentOS machine"
+#~ msgstr "TigerVNC-ის დამთვალიერებლის კავშირი CentOS-ის მანქანასთან"
+
+#~ msgid "TigerVNC viewer connection to a macOS machine"
+#~ msgstr "TigerVNC-ის დამთვალიერებლის კავშირი macOS-ის მანქანასთან"
+
+#~ msgid "TigerVNC viewer connection to a Windows machine"
+#~ msgstr "TigerVNC-ის დამთვალიერებლის კავშირი Windows-ის მანქანასთან"
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "TigerVNC-ის კლიენტის შესახებ"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "TigerVNC-ის ახალი დამთვალიერებლის გაშვების შეცდომა: %s"
+
+#~ msgid "TigerVNC viewer"
+#~ msgstr "TigerVNC-ის დამთვალიერებელი"
 
 #~ msgid "Failed to get monitor name because X11 RandR could not be found"
 #~ msgstr "მონიტორის სახელის მიღება შეუძლებელია X11 Randr-ის არარსებობის გამო"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.12.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2022-12-15 16:35+0100\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2023-08-15 23:51+0900\n"
 "Last-Translator: JiYoon Kwon <bbkjo0123@gmail.com>\n"
 "Language-Team: Korean <translation-team-ko@googlegroups.com>\n"
@@ -29,7 +29,7 @@ msgstr "소켓 %s에 연결됨"
 msgid "Connected to host %s port %d"
 msgstr "호스트 %s의 포트 %d와 연결됨"
 
-#: vncviewer/CConn.cxx:114
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -40,372 +40,428 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:159
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "데스크톱 이름: %.80s"
 
-#: vncviewer/CConn.cxx:164
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "호스트: %.80s 포트: %d"
 
-#: vncviewer/CConn.cxx:169
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "크기: %d x %d"
 
-#: vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "픽셀 형식: %s"
 
-#: vncviewer/CConn.cxx:184
-#, c-format
-msgid "(server default %s)"
-msgstr "(서버 기본값 %s)"
-
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "요청된 인코딩: %s"
 
-#: vncviewer/CConn.cxx:194
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "최근 사용된 인코딩: %s"
 
-#: vncviewer/CConn.cxx:199
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "회선 속도 측정: %d kbit/s"
 
-#: vncviewer/CConn.cxx:204
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "프로토콜 버전: %d.%d"
 
-#: vncviewer/CConn.cxx:209
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "보안 방식: %s"
 
-#: vncviewer/CConn.cxx:270 vncviewer/CConn.cxx:272
-msgid "The connection was dropped by the server before the session could be established."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
 msgstr "세션이 생성되기 전 서버에서 연결을 끊었습니다."
 
-#: vncviewer/CConn.cxx:332
+#: vncviewer/CConn.cxx:258
 #, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "데스크톱 사이즈 설정 실패: %d"
+msgid "Authentication failed: %s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:404
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "서버에서 잘못된 SetColourMapEntries를 설정했습니다!"
+#: vncviewer/CConn.cxx:259
+#, c-format
+msgid ""
+"Failed to authenticate with the server. Reason given by the server:\n"
+"\n"
+"%s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:512
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "처리량 %d kbit/s - 품질을 %d로 변경 중"
 
-#: vncviewer/CConn.cxx:534
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "처리량 %d kbit/s - 높은 색상 수준으로 변경 가능"
 
-#: vncviewer/CConn.cxx:537
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "처리량 %d kbit/s - 높은 색상 수준으로 변경 불가"
 
 # 사용 중..? 사용?
-#: vncviewer/CConn.cxx:563
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "%s 픽셀 형식을 사용"
 
 # geometry를 해상도라고 번역
-#: vncviewer/DesktopWindow.cxx:145
+#: vncviewer/DesktopWindow.cxx:146
 msgid "Invalid geometry specified!"
 msgstr "잘못된 해상도가 지정되었습니다!"
 
-#: vncviewer/DesktopWindow.cxx:166
+#: vncviewer/DesktopWindow.cxx:167
 msgid "Reducing window size to fit on current monitor"
 msgstr "현재 모니터에 맞게 창 크기 축소"
 
-#: vncviewer/DesktopWindow.cxx:648
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
 msgstr "실수로 최대화 요청을 하지 않도로 창 크기를 조정"
 
-#: vncviewer/DesktopWindow.cxx:696
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "콘텍스트 메뉴를 열려면 %s를 누르십시오"
 
-#: vncviewer/DesktopWindow.cxx:1083 vncviewer/DesktopWindow.cxx:1091
-#: vncviewer/DesktopWindow.cxx:1111
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "키보드 점유 실패"
 
-#: vncviewer/DesktopWindow.cxx:1401
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
 msgstr "크기 재조정 요청에 대해 잘못된 화면 레이아웃이 계산되었습니다!"
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "유효하지 않은 3 버튼 에뮬레이션 상태"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:105
+#: vncviewer/KeyboardWin32.cxx:243
+#, c-format
+msgid "No scan code for extended virtual key 0x%02x"
+msgstr "확장된 가상 키 0x%02x의 스캔 코드가 없음"
+
+#: vncviewer/KeyboardWin32.cxx:245
+#, c-format
+msgid "No scan code for virtual key 0x%02x"
+msgstr "가상 키 0x%02x의 스캔 코드가 없음"
+
+#: vncviewer/KeyboardWin32.cxx:251
+#, c-format
+msgid "Invalid scan code 0x%02x"
+msgstr "잘못된 스캔 코드 0x%02x"
+
+#: vncviewer/KeyboardWin32.cxx:263
+#, c-format
+msgid "No symbol for extended virtual key 0x%02x"
+msgstr "확장된 가상 키 0x%02x의 심볼이 없음"
+
+#: vncviewer/KeyboardWin32.cxx:265
+#, c-format
+msgid "No symbol for virtual key 0x%02x"
+msgstr "가상 키 0x%02x의 심볼이 없음"
+
+#: vncviewer/KeyboardWin32.cxx:424
+#, c-format
+msgid "Failed to update keyboard LED state: %lu"
+msgstr "키보드 LED 상태 업데이트 실패: %lu"
+
+#: vncviewer/KeyboardX11.cxx:123
+#, c-format
+msgid "No symbol for key code %d (in the current state)"
+msgstr "키 %d의 심볼이 없음 (현재 상태)"
+
+#: vncviewer/KeyboardX11.cxx:148
+#, c-format
+msgid "Failed to get keyboard LED state: %d"
+msgstr "키보드 LED 상태 불러오기 실패: %d"
+
+#: vncviewer/KeyboardX11.cxx:193
+msgid "Failed to update keyboard LED state"
+msgstr "키보드 LED 상태 업데이트 실패"
+
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "시스템 모니터 환경 설정을 가져오는 데 실패함"
 
-# geometry를 해상도라고 번역
-#: vncviewer/MonitorIndicesParameter.cxx:83
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "%s에 대해 유효하지 않은 환경 설정"
-
-#: vncviewer/MonitorIndicesParameter.cxx:91
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "모니터 인덱스 %d가 존재하지 않음"
 
-#: vncviewer/MonitorIndicesParameter.cxx:169
-#: vncviewer/MonitorIndicesParameter.cxx:189
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "유효하지 않은 모니터 인덱스 '%s'"
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
+msgid "TigerVNC options"
+msgstr ""
 
-#: vncviewer/MonitorIndicesParameter.cxx:177
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "예상치 못한 문자 '%c'"
-
-#: vncviewer/OptionsDialog.cxx:63
-msgid "VNC Viewer: Connection Options"
-msgstr "VNC 뷰어: 연결 설정"
-
-#: vncviewer/OptionsDialog.cxx:89 vncviewer/ServerDialog.cxx:108
-#: vncviewer/vncviewer.cxx:417
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "취소"
 
-#: vncviewer/OptionsDialog.cxx:94 vncviewer/vncviewer.cxx:416
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "확인"
 
-#: vncviewer/OptionsDialog.cxx:484
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "압축"
 
-#: vncviewer/OptionsDialog.cxx:501
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "자동 선택"
 
-#: vncviewer/OptionsDialog.cxx:516
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "선호되는 인코딩"
 
-#: vncviewer/OptionsDialog.cxx:574
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "색상 수준"
 
-#: vncviewer/OptionsDialog.cxx:585
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "높음"
 
-#: vncviewer/OptionsDialog.cxx:592
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "중간"
 
-#: vncviewer/OptionsDialog.cxx:599
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "낮음"
 
-#: vncviewer/OptionsDialog.cxx:606
+#: vncviewer/OptionsDialog.cxx:635
 msgid "Very low"
 msgstr "매우 낮음"
 
-#: vncviewer/OptionsDialog.cxx:624
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "사용자 정의 압축 수준:"
 
-#: vncviewer/OptionsDialog.cxx:630
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "품질(0=나쁨, 9=좋음)"
 
-#: vncviewer/OptionsDialog.cxx:637
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "JPEG 압축 허용:"
 
-#: vncviewer/OptionsDialog.cxx:643
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "품질(0=나쁨, 9=좋음)"
 
-#: vncviewer/OptionsDialog.cxx:654
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "보안"
 
-#: vncviewer/OptionsDialog.cxx:676
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "암호화"
 
-#: vncviewer/OptionsDialog.cxx:687 vncviewer/OptionsDialog.cxx:750
-#: vncviewer/OptionsDialog.cxx:854
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "없음"
 
-#: vncviewer/OptionsDialog.cxx:694
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "익명 인증서가 있는 TLS"
 
-#: vncviewer/OptionsDialog.cxx:700
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "X509 인증서가 있는 TLS"
 
-#: vncviewer/OptionsDialog.cxx:707
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "X509 CA 인증서의 경로"
 
-#: vncviewer/OptionsDialog.cxx:714
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "X509 CRL 파일의 경로"
 
-#: vncviewer/OptionsDialog.cxx:739
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "인증"
 
-#: vncviewer/OptionsDialog.cxx:756
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "표준 VNC (암호화하지 않아 취약함)"
 
 # 사용자라고 표시하기 괜찮은가?
 # 사용자 명?
 # 사용자 이름
-#: vncviewer/OptionsDialog.cxx:762
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "사용자와 암호(암호화하지 않아 취약함)"
 
-#: vncviewer/OptionsDialog.cxx:781
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "입력"
 
-#: vncviewer/OptionsDialog.cxx:794
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "보기 전용(마우스와 키보드 무시)"
 
-#: vncviewer/OptionsDialog.cxx:801
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "마우스"
 
-#: vncviewer/OptionsDialog.cxx:815
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "마우스 가운데 버튼 에뮬레이트"
 
-#: vncviewer/OptionsDialog.cxx:821
-msgid "Show dot when no cursor"
-msgstr "커서가 없을 때 점 표시"
+#: vncviewer/OptionsDialog.cxx:880
+msgid "Show local cursor when not provided by server"
+msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:835
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
+msgid "Cursor type"
+msgstr ""
+
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
+msgid "Dot"
+msgstr ""
+
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
+msgid "System"
+msgstr ""
+
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "키보드"
 
-#: vncviewer/OptionsDialog.cxx:849
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
 msgstr "시스템 키를 서버에 직접 전달 (전체 화면)"
 
-#: vncviewer/OptionsDialog.cxx:852
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "메뉴 키"
 
-#: vncviewer/OptionsDialog.cxx:871
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "클립보드"
 
 # 승인 vs 허용
-#: vncviewer/OptionsDialog.cxx:885
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "서버에서 받은 클립보드를 허용"
 
 # 왜 also가 붙을까?
-#: vncviewer/OptionsDialog.cxx:893
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "주 선택으로도 설정"
 
-#: vncviewer/OptionsDialog.cxx:900
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "클립보드를 서버에 전송"
 
-#: vncviewer/OptionsDialog.cxx:908
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "기본 선택을 클립보드로 전송"
 
-#: vncviewer/OptionsDialog.cxx:927
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "화면"
 
-#: vncviewer/OptionsDialog.cxx:941
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "화면 모드"
 
-#: vncviewer/OptionsDialog.cxx:956
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "창 모드"
 
-#: vncviewer/OptionsDialog.cxx:964
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "현재 모니터에 전체화면"
 
-#: vncviewer/OptionsDialog.cxx:972
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "모든 모니터에 전체 화면"
 
-#: vncviewer/OptionsDialog.cxx:980
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "선택한 모니터에 전체 화면"
 
-#: vncviewer/OptionsDialog.cxx:1007
-msgid "Misc."
-msgstr "기타."
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
+msgid "Miscellaneous"
+msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:1015
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "공유 (다른 뷰어와의 연결을 끊지 않음)"
 
-#: vncviewer/OptionsDialog.cxx:1021
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "연결 오류 시 다시 연결을 요청"
 
-#: vncviewer/ServerDialog.cxx:58
-msgid "VNC Viewer: Connection Details"
-msgstr "VNC 뷰어: 연결 세부 사항"
-
-#: vncviewer/ServerDialog.cxx:65 vncviewer/ServerDialog.cxx:70
+#: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
 msgstr "VNC 서버:"
 
-#: vncviewer/ServerDialog.cxx:81
+#: vncviewer/ServerDialog.cxx:80
 msgid "Options..."
 msgstr "설정..."
 
-#: vncviewer/ServerDialog.cxx:86
+#: vncviewer/ServerDialog.cxx:84
 msgid "Load..."
 msgstr "불러오기..."
 
-#: vncviewer/ServerDialog.cxx:91
-msgid "Save As..."
-msgstr "다른 이름으로 저장..."
+#: vncviewer/ServerDialog.cxx:88
+msgid "Save as..."
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:103
+#: vncviewer/ServerDialog.cxx:102
 msgid "About..."
 msgstr "정보..."
 
-#: vncviewer/ServerDialog.cxx:113
+#: vncviewer/ServerDialog.cxx:111
 msgid "Connect"
 msgstr "연결"
 
-#: vncviewer/ServerDialog.cxx:145
+#: vncviewer/ServerDialog.cxx:147
 #, c-format
 msgid ""
 "Unable to load the server history:\n"
@@ -416,16 +472,16 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:173 vncviewer/ServerDialog.cxx:212
+#: vncviewer/ServerDialog.cxx:176 vncviewer/ServerDialog.cxx:216
 msgid "TigerVNC configuration (*.tigervnc)"
 msgstr "TigerVNC 환경 설정(*.tigervnc)"
 
 # 구성 vs 환경설정
-#: vncviewer/ServerDialog.cxx:174
+#: vncviewer/ServerDialog.cxx:177
 msgid "Select a TigerVNC configuration file"
 msgstr "TigerVNC 환경 설정 파일 선택"
 
-#: vncviewer/ServerDialog.cxx:196 vncviewer/vncviewer.cxx:552
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -436,24 +492,24 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:213
+#: vncviewer/ServerDialog.cxx:217
 msgid "Save the TigerVNC configuration to file"
 msgstr "TigerVNC 환경 설정을 파일로 저장"
 
-#: vncviewer/ServerDialog.cxx:239
+#: vncviewer/ServerDialog.cxx:243
 #, c-format
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "%s이(가) 이미 존재합니다. 덮어쓰시겠습니까?"
 
-#: vncviewer/ServerDialog.cxx:240 vncviewer/vncviewer.cxx:414
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "아니오"
 
-#: vncviewer/ServerDialog.cxx:240
+#: vncviewer/ServerDialog.cxx:244
 msgid "Overwrite"
 msgstr "덮어쓰기"
 
-#: vncviewer/ServerDialog.cxx:256
+#: vncviewer/ServerDialog.cxx:260
 #, c-format
 msgid ""
 "Unable to save the specified configuration file:\n"
@@ -464,7 +520,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:290
+#: vncviewer/ServerDialog.cxx:294
 #, c-format
 msgid ""
 "Unable to save the default configuration:\n"
@@ -475,7 +531,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:303
+#: vncviewer/ServerDialog.cxx:306
 #, c-format
 msgid ""
 "Unable to save the server history:\n"
@@ -486,230 +542,170 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:320 vncviewer/ServerDialog.cxx:387
-#: vncviewer/parameters.cxx:635 vncviewer/parameters.cxx:740
-#: vncviewer/vncviewer.cxx:459
-msgid "Could not obtain the home directory path"
-msgstr "VNC 홈 디렉토리 생성 불가: %s"
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
+msgid "Could not determine VNC state directory path"
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:333 vncviewer/ServerDialog.cxx:396
-#: vncviewer/parameters.cxx:646 vncviewer/parameters.cxx:753
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
-msgid "Could not open \"%s\": %s"
-msgstr "\"%s\"를 열 수 없습니다: %s"
+msgid "Could not open \"%s\""
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:348 vncviewer/ServerDialog.cxx:356
-#: vncviewer/parameters.cxx:767 vncviewer/parameters.cxx:773
-#: vncviewer/parameters.cxx:804 vncviewer/parameters.cxx:833
-#: vncviewer/parameters.cxx:839
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
-msgid "Failed to read line %d in file %s: %s"
-msgstr "파일의 %d줄을 읽지 못함 %s: %s"
+msgid "Failed to read line %d in file \"%s\""
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:357 vncviewer/parameters.cxx:774
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "행 길이 초과"
 
-#: vncviewer/UserDialog.cxx:98
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "암호 파일을 열기 실패"
 
-#: vncviewer/UserDialog.cxx:118
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "VNC 인증"
 
-#: vncviewer/UserDialog.cxx:125
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "이 연결은 안전합니다"
 
-#: vncviewer/UserDialog.cxx:129
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "이 연결은 취약합니다"
 
-#: vncviewer/UserDialog.cxx:146
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "사용자:"
 
-#: vncviewer/UserDialog.cxx:159
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "비밀번호:"
 
-#: vncviewer/UserDialog.cxx:198
-msgid "Authentication cancelled"
-msgstr "인증이 취소됨"
+#: vncviewer/UserDialog.cxx:204
+msgid "Keep password for reconnect"
+msgstr ""
 
-#: vncviewer/Viewport.cxx:391
-#, c-format
-msgid "Failed to update keyboard LED state: %lu"
-msgstr "키보드 LED 상태 업데이트 실패: %lu"
-
-#: vncviewer/Viewport.cxx:397 vncviewer/Viewport.cxx:403
-#, c-format
-msgid "Failed to update keyboard LED state: %d"
-msgstr "키보드 LED 상태 업데이트 실패: %d"
-
-#: vncviewer/Viewport.cxx:433
-msgid "Failed to update keyboard LED state"
-msgstr "키보드 LED 상태 업데이트 실패"
-
-#: vncviewer/Viewport.cxx:460 vncviewer/Viewport.cxx:468
-#: vncviewer/Viewport.cxx:485
-#, c-format
-msgid "Failed to get keyboard LED state: %d"
-msgstr "키보드 LED 상태 불러오기 실패: %d"
-
-#: vncviewer/Viewport.cxx:849
-msgid "No key code specified on key press"
-msgstr "입력된 키 코드가 지정되지 않음"
-
-#: vncviewer/Viewport.cxx:1008
-#, c-format
-msgid "No scan code for extended virtual key 0x%02x"
-msgstr "확장된 가상 키 0x%02x의 스캔 코드가 없음"
-
-#: vncviewer/Viewport.cxx:1010
-#, c-format
-msgid "No scan code for virtual key 0x%02x"
-msgstr "가상 키 0x%02x의 스캔 코드가 없음"
-
-#: vncviewer/Viewport.cxx:1016
-#, c-format
-msgid "Invalid scan code 0x%02x"
-msgstr "잘못된 스캔 코드 0x%02x"
-
-#: vncviewer/Viewport.cxx:1046
-#, c-format
-msgid "No symbol for extended virtual key 0x%02x"
-msgstr "확장된 가상 키 0x%02x의 심볼이 없음"
-
-#: vncviewer/Viewport.cxx:1048
-#, c-format
-msgid "No symbol for virtual key 0x%02x"
-msgstr "가상 키 0x%02x의 심볼이 없음"
-
-#: vncviewer/Viewport.cxx:1154
-#, c-format
-msgid "No symbol for key code 0x%02x (in the current state)"
-msgstr "키 0x%02x의 심볼이 없음 (현재 상태)"
-
-#: vncviewer/Viewport.cxx:1187
-#, c-format
-msgid "No symbol for key code %d (in the current state)"
-msgstr "키 %d의 심볼이 없음 (현재 상태)"
-
-#: vncviewer/Viewport.cxx:1247
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
-msgid "Dis&connect"
-msgstr "연결끊기(&C)"
+msgid "Disconn&ect"
+msgstr ""
 
-#: vncviewer/Viewport.cxx:1250
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "최대화(&F)"
 
-#: vncviewer/Viewport.cxx:1253
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "최소화(&Z)"
 
-#: vncviewer/Viewport.cxx:1255
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "세션에 맞춰 화면 크기를 재설정(&W)"
 
-#: vncviewer/Viewport.cxx:1260
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:1263
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:1269
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "%s 전송"
 
-#: vncviewer/Viewport.cxx:1275
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Ctrl-Alt-Del 전송(&D)"
 
-#: vncviewer/Viewport.cxx:1278
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "화면을 다시 불러오기(&R)"
 
-#: vncviewer/Viewport.cxx:1281
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "설정(&O)"
 
-#: vncviewer/Viewport.cxx:1283
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "연결 정보(&I)"
 
-#: vncviewer/Viewport.cxx:1285
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "TigerVNC 뷰어 정보(&T)"
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:1374
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "VNC 연결 정보"
 
-#: vncviewer/Win32TouchHandler.cxx:47
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "제스처 대신 터치로 창이 등록됨"
 
-#: vncviewer/Win32TouchHandler.cxx:81
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "제스처 구성 설정 실패 (오류: 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:93
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "제스처 정보를 불러오기 실패 (오류 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:358
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr "잘못된 마우스 버튼 %d, 1에서 7 사이의 값을 가져야 합니다."
 
-#: vncviewer/Win32TouchHandler.cxx:423
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
 msgstr "처리되지 않은 키 0x%x - 키보드 이벤트를 생성할 수 없음."
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:107
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
 msgstr "창 0x%08lx에 대한 X Input 2 이벤트 마스크를 가져올 수 없음"
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr "0x%08lx 창에 X Input 2 이벤트 마스트가 없음"
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:114
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr "창 0x%08lx에 X Input 2 이벤트 마스크가 두 개 이상 존재함"
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "장치 %i을(를) 가져오지 못함"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-#: vncviewer/vncviewer.cxx:406 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC Viewer"
-msgstr "TigerVNC 뷰어"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -717,96 +713,126 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr "VNC 서버와 연결하고 원격 데스크톱을 보입니다"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
-msgstr "가상 네트워크 컴퓨팅(Virtual Network Computing, VNC)이란 네트워크를 통해 다른 컴퓨터에서 실행 중인 가상 데스크톱 환경을 보고 상호작용할 수 있는 원격 디스플레이 시스템입니다. VNC을 사용하면 원격 컴퓨터에서 실행한 그래픽 애플리케이션의 화면만 로컬 장치로 전송할 수 있습니다. 이 패키지에는 VNC 서버를 실행하는 다른 데스크톱에 연결할 수 있는 클라이언트가 포함되어 있습니다. VNC는 플랫폼 독립적이며 서버와 클라이언트로서 다양한 운영 체제 및 아키텍처를 지원합니다."
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+"가상 네트워크 컴퓨팅(Virtual Network Computing, VNC)이란 네트워크를 통해 다"
+"른 컴퓨터에서 실행 중인 가상 데스크톱 환경을 보고 상호작용할 수 있는 원격 디"
+"스플레이 시스템입니다. VNC을 사용하면 원격 컴퓨터에서 실행한 그래픽 애플리케"
+"이션의 화면만 로컬 장치로 전송할 수 있습니다. 이 패키지에는 VNC 서버를 실행하"
+"는 다른 데스크톱에 연결할 수 있는 클라이언트가 포함되어 있습니다. VNC는 플랫"
+"폼 독립적이며 서버와 클라이언트로서 다양한 운영 체제 및 아키텍처를 지원합니"
+"다."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
-msgstr "TigerVNC는 RealVNC 4와 X.org 코드를 기반으로 한 고속 버전의 VNC입니다. TigerVNC는 Unix 및 Linux 플랫폼에서의 차세대 TightVNC를 개발하기 위해 시작되었지만 2009년 초에 프로젝트에서 분리었고 TightVNC는 Windows 플랫폼에 집중할 수 있게 되었습니다. TigerVNC는 libjpeg-turbo JPEG 코덱을 사용하여 가속화되는 Tight 인코딩의 변형을 지원합니다."
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+"TigerVNC는 RealVNC 4와 X.org 코드를 기반으로 한 고속 버전의 VNC입니다. "
+"TigerVNC는 Unix 및 Linux 플랫폼에서의 차세대 TightVNC를 개발하기 위해 시작되"
+"었지만 2009년 초에 프로젝트에서 분리었고 TightVNC는 Windows 플랫폼에 집중할 "
+"수 있게 되었습니다. TigerVNC는 libjpeg-turbo JPEG 코덱을 사용하여 가속화되는 "
+"Tight 인코딩의 변형을 지원합니다."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC Viewer connection to a CentOS machine"
-msgstr "CentOS 기기에 대한 TigerVNC 뷰어 연결"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC Viewer connection to a macOS machine"
-msgstr "macOS 기기에 대한 TigerVNC 뷰어 연결"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC Viewer connection to a Windows machine"
-msgstr "Windows 기기에 대한 TigerVNC 뷰어 연결"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
-#: vncviewer/parameters.cxx:308 vncviewer/parameters.cxx:333
-#: vncviewer/parameters.cxx:350 vncviewer/parameters.cxx:390
-#: vncviewer/parameters.cxx:410
+#. developer_name tag deprecated with Appstream 1.0
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
+msgid "The TigerVNC team"
+msgstr ""
+
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "변수명 길이 초과"
 
-#: vncviewer/parameters.cxx:312 vncviewer/parameters.cxx:317
-#: vncviewer/parameters.cxx:368
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "변수 크기 초과"
 
-#: vncviewer/parameters.cxx:375 vncviewer/parameters.cxx:696
-#: vncviewer/parameters.cxx:818
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "잘못된 형식 또는 변수 크기 초과"
 
-#: vncviewer/parameters.cxx:429 vncviewer/parameters.cxx:460
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "레지스트리 키 생성 실패"
 
-#: vncviewer/parameters.cxx:448 vncviewer/parameters.cxx:503
-#: vncviewer/parameters.cxx:545 vncviewer/parameters.cxx:612
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "레지스트리 키를 닫지 못함"
 
-#: vncviewer/parameters.cxx:466 vncviewer/parameters.cxx:483
-#: vncviewer/parameters.cxx:654 vncviewer/parameters.cxx:664
-#: vncviewer/parameters.cxx:675
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "\"%s\" 저장 실패: %s"
 
-#: vncviewer/parameters.cxx:479 vncviewer/parameters.cxx:567
-#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:714
-msgid "Unknown parameter type"
-msgstr "알 수 없는 타입의 변수"
-
-#: vncviewer/parameters.cxx:496
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "\"%s\" 삭제 실패: %s"
 
 # 레지스터 vs 등록
-#: vncviewer/parameters.cxx:518 vncviewer/parameters.cxx:590
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "레지스트리 키를 열지 못함"
 
-#: vncviewer/parameters.cxx:535
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "서버 히스토리 항목 %d를 읽지 못함: %s"
 
-#: vncviewer/parameters.cxx:571 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "변수 %s 읽기 실패: %s"
 
-#: vncviewer/parameters.cxx:655 vncviewer/parameters.cxx:666
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
+msgid "Could not determine VNC config directory path"
+msgstr ""
+
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "파라미터를 인코딩할 수 없음"
 
-#: vncviewer/parameters.cxx:783
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "환경 설정 파일 %s의 형식이 잘못됨"
 
-#: vncviewer/parameters.cxx:805
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "잘못된 형식"
 
-#: vncviewer/parameters.cxx:840
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "알 수 없는 타입의 파라미터"
 
@@ -830,40 +856,40 @@ msgstr "터치 핸들러 생성 실패: %s"
 msgid "Couldn't attach event handler to window (error 0x%x)"
 msgstr "이벤트 핸들러를 창에 연결할 수 없음 (오류 0x%x)"
 
-#: vncviewer/touch.cxx:212
+#: vncviewer/touch.cxx:215
 msgid "Failed to get event data for X Input event"
 msgstr "X Input 이벤트에 대한 이벤트 데이터를 가져오지 못함"
 
-#: vncviewer/touch.cxx:225
+#: vncviewer/touch.cxx:228
 msgid "X Input event for unknown window"
 msgstr "알 수 없는 창에 대한 X Input 이벤트"
 
-#: vncviewer/touch.cxx:251
+#: vncviewer/touch.cxx:254
 msgid "X Input extension not available."
 msgstr "X Input 확장자를 사용할 수 없습니다."
 
-#: vncviewer/touch.cxx:258
+#: vncviewer/touch.cxx:261
 msgid "X Input 2 (or newer) is not available."
 msgstr "X Input 2(또는 그 이상)을 사용할 수 없습니다."
 
-#: vncviewer/touch.cxx:263
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
-msgstr "X Input 2.2(또는 그 이상)을 사용할 수 없습니다. 터치 제스처는 지원하지 않습니다."
+#: vncviewer/touch.cxx:266
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+"X Input 2.2(또는 그 이상)을 사용할 수 없습니다. 터치 제스처는 지원하지 않습니"
+"다."
 
-#: vncviewer/vncviewer.cxx:107
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC Viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
-"Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+"Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"TigerVNC Viewer v%s\n"
-"Built on: %s\n"
-"Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
-"TigerVNC에 대한 자세한 정보는 https://www.tigervnc.org를 참조하십시오."
 
-#: vncviewer/vncviewer.cxx:161
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -871,15 +897,15 @@ msgid ""
 "%s"
 msgstr "서버 통신 중 예상치 못한 오류 발생: %s"
 
-#: vncviewer/vncviewer.cxx:177
-msgid "About TigerVNC Viewer"
-msgstr "TigerVNC 뷰어 정보"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:198
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "내부 FLTK 오류. 종료합니다."
 
-#: vncviewer/vncviewer.cxx:217
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -890,79 +916,167 @@ msgstr ""
 "\n"
 "다시 연결을 시도하시겠습니까?"
 
-#: vncviewer/vncviewer.cxx:248 vncviewer/vncviewer.cxx:260
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "새 TigerVNC 뷰어를 시작하는 중 오류 발생: %s"
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:269
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC Viewer will now exit."
-msgstr "종료 신호 %d가 수신되었습니다. TigerVNC 뷰어를 종료합니다."
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:415
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "예"
 
-#: vncviewer/vncviewer.cxx:418
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "닫기"
 
-#: vncviewer/vncviewer.cxx:423
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "정보"
 
-#: vncviewer/vncviewer.cxx:426
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "숨기기"
 
-#: vncviewer/vncviewer.cxx:429
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "나가기"
 
-#: vncviewer/vncviewer.cxx:433
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "서비스"
 
-#: vncviewer/vncviewer.cxx:434
-msgid "Hide Others"
-msgstr "다른 것 숨기기"
+#: vncviewer/vncviewer.cxx:413
+msgid "Hide others"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:435
-msgid "Show All"
-msgstr "모두 보이기"
+#: vncviewer/vncviewer.cxx:414
+msgid "Show all"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:444
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "파일(&F)"
 
-#: vncviewer/vncviewer.cxx:447
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "새 연결(&N)"
 
-#: vncviewer/vncviewer.cxx:463
+#: vncviewer/vncviewer.cxx:449
 #, c-format
-msgid "Could not create VNC home directory: %s"
-msgstr "VNC 홈 디렉토리 생성 불가: %s"
+msgid ""
+"\n"
+"Usage: %s [parameters] [host][:displayNum]\n"
+"       %s [parameters] [host][::port]\n"
+"       %s [parameters] [unix socket]\n"
+"       %s [parameters] -listen [port]\n"
+"       %s [parameters] [.tigervnc file]\n"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:562
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
-msgstr "FullScreenAllMonitors는 더 이상 사용되지 않으며 대신 FullScreenMode를 'all'로 설정합니다"
+#: vncviewer/vncviewer.cxx:464
+#, c-format
+msgid ""
+"\n"
+"Options:\n"
+"\n"
+"  -display Xdisplay  - Specifies the X display for the viewer window\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
+"                       man page for details.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:471
+#, c-format
+msgid ""
+"\n"
+"Parameters can be turned on with -<param> or off with -<param>=0\n"
+"Parameters which take a value can be specified as -<param> <value>\n"
+"Other valid forms are <param>=<value> -<param>=<value> --<param>=<value>\n"
+"Parameter names are case-insensitive.  The parameters are:\n"
+"\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+"FullScreenAllMonitors는 더 이상 사용되지 않으며 대신 FullScreenMode를 "
+"'all'로 설정합니다"
+
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:556
+#, c-format
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:561
+#, c-format
+msgid "Could not create VNC config directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:567
+msgid "Could not determine VNC data directory path"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:573
+#, c-format
+msgid "Could not create VNC data directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:585
+#, c-format
+msgid "Could not create VNC state directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:704
+#, c-format
+msgid "%s: Unrecognized option '%s'\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
+#, c-format
+msgid "See '%s --help' for more information.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:713
+#, c-format
+msgid "%s: Extra argument '%s'\n"
+msgstr ""
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:768 vncviewer/vncviewer.cxx:769
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "-listen과 -via를 통한 인자들은 호환되지 않음"
 
-#: vncviewer/vncviewer.cxx:783
+#: vncviewer/vncviewer.cxx:764
+msgid "Unable to listen for incoming connections"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "포트 %d에 접속 대기중"
 
-#: vncviewer/vncviewer.cxx:816
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -973,9 +1087,141 @@ msgstr ""
 "\n"
 "%s"
 
+#: vncviewer/vncviewer.cxx:816
+#, c-format
+msgid ""
+"Failure setting up encrypted tunnel:\n"
+"\n"
+"%s"
+msgstr ""
+
 #: vncviewer/vncviewer.desktop.in.in:4
-msgid "Remote Desktop Viewer"
-msgstr "원격 데스크톱 뷰어"
+msgid "Remote desktop viewer"
+msgstr ""
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(서버 기본값 %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "데스크톱 사이즈 설정 실패: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "서버에서 잘못된 SetColourMapEntries를 설정했습니다!"
+
+# geometry를 해상도라고 번역
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "%s에 대해 유효하지 않은 환경 설정"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "유효하지 않은 모니터 인덱스 '%s'"
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "예상치 못한 문자 '%c'"
+
+#~ msgid "VNC Viewer: Connection Options"
+#~ msgstr "VNC 뷰어: 연결 설정"
+
+#~ msgid "Show dot when no cursor"
+#~ msgstr "커서가 없을 때 점 표시"
+
+#~ msgid "Misc."
+#~ msgstr "기타."
+
+#~ msgid "VNC Viewer: Connection Details"
+#~ msgstr "VNC 뷰어: 연결 세부 사항"
+
+#~ msgid "Save As..."
+#~ msgstr "다른 이름으로 저장..."
+
+#~ msgid "Could not obtain the home directory path"
+#~ msgstr "VNC 홈 디렉토리 생성 불가: %s"
+
+#, c-format
+#~ msgid "Could not open \"%s\": %s"
+#~ msgstr "\"%s\"를 열 수 없습니다: %s"
+
+#, c-format
+#~ msgid "Failed to read line %d in file %s: %s"
+#~ msgstr "파일의 %d줄을 읽지 못함 %s: %s"
+
+#~ msgid "Authentication cancelled"
+#~ msgstr "인증이 취소됨"
+
+#, c-format
+#~ msgid "Failed to update keyboard LED state: %d"
+#~ msgstr "키보드 LED 상태 업데이트 실패: %d"
+
+#~ msgid "No key code specified on key press"
+#~ msgstr "입력된 키 코드가 지정되지 않음"
+
+#, c-format
+#~ msgid "No symbol for key code 0x%02x (in the current state)"
+#~ msgstr "키 0x%02x의 심볼이 없음 (현재 상태)"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "Dis&connect"
+#~ msgstr "연결끊기(&C)"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "TigerVNC 뷰어 정보(&T)"
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "TigerVNC 뷰어"
+
+#~ msgid "TigerVNC Viewer connection to a CentOS machine"
+#~ msgstr "CentOS 기기에 대한 TigerVNC 뷰어 연결"
+
+#~ msgid "TigerVNC Viewer connection to a macOS machine"
+#~ msgstr "macOS 기기에 대한 TigerVNC 뷰어 연결"
+
+#~ msgid "TigerVNC Viewer connection to a Windows machine"
+#~ msgstr "Windows 기기에 대한 TigerVNC 뷰어 연결"
+
+#~ msgid "Unknown parameter type"
+#~ msgstr "알 수 없는 타입의 변수"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC Viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "TigerVNC Viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+#~ "TigerVNC에 대한 자세한 정보는 https://www.tigervnc.org를 참조하십시오."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "TigerVNC 뷰어 정보"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "새 TigerVNC 뷰어를 시작하는 중 오류 발생: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC Viewer will now exit."
+#~ msgstr "종료 신호 %d가 수신되었습니다. TigerVNC 뷰어를 종료합니다."
+
+#~ msgid "Hide Others"
+#~ msgstr "다른 것 숨기기"
+
+#~ msgid "Show All"
+#~ msgstr "모두 보이기"
+
+#, c-format
+#~ msgid "Could not create VNC home directory: %s"
+#~ msgstr "VNC 홈 디렉토리 생성 불가: %s"
+
+#~ msgid "Remote Desktop Viewer"
+#~ msgstr "원격 데스크톱 뷰어"
 
 #~ msgid "Failed to get monitor name because X11 RandR could not be found"
 #~ msgstr "X11 RandR을 찾을 수 없어 모니터 이름을 가져오지 못함"
@@ -1033,7 +1279,8 @@ msgstr "원격 데스크톱 뷰어"
 #~ msgid "The parameter %s was too large to read from the registry"
 #~ msgstr "변수 %s가 너무 커 레지스트리에서 읽을 수 없습니다"
 
-#~ msgid "Failed to write configuration file, can't obtain home directory path."
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
 #~ msgstr "환경설정 파일 저장 실패, 홈 디렉토리 경로를 얻지 못하였습니다."
 
 #~ msgid "Failed to write configuration file, can't open %s: %s"
@@ -1045,7 +1292,8 @@ msgstr "원격 데스크톱 뷰어"
 #~ msgid "Unknown parameter %s on line %d in file %s"
 #~ msgstr "알 수 없는 매개변수 %1$s가 파일 %3$s의 %2$d줄에 존재"
 
-#~ msgid "Could not create VNC home directory: can't obtain home directory path."
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
 #~ msgstr "VNC 홈 디렉토리 생성 불가: 홈 디렉토리 경로를 찾을 수 없습니다."
 
 #~ msgid "tigervnc"

--- a/po/nl.po
+++ b/po/nl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.7.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2017-04-19 13:05+0000\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2017-05-03 20:34+0200\n"
 "Last-Translator: Benno Schulenberg <benno@vertaalt.nl>\n"
 "Language-Team: Dutch <vertaling@vrijschrift.org>\n"
@@ -21,644 +21,1256 @@ msgstr ""
 "X-Generator: Lokalize 1.0\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: vncviewer/CConn.cxx:103
+#, c-format
+msgid "Connected to socket %s"
+msgstr ""
+
 #: vncviewer/CConn.cxx:110
 #, c-format
-msgid "connected to host %s port %d"
-msgstr "verbonden met host %s poort %d"
+msgid "Connected to host %s port %d"
+msgstr ""
 
-#: vncviewer/CConn.cxx:169
+#: vncviewer/CConn.cxx:115
+#, c-format
+msgid ""
+"Failed to connect to \"%s\":\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Bureaubladnaam: %.80s"
 
-#: vncviewer/CConn.cxx:174
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Host: %.80s poort: %d"
 
-#: vncviewer/CConn.cxx:179
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Grootte: %d x %d"
 
-#: vncviewer/CConn.cxx:187
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Pixel-indeling: %s"
 
-#: vncviewer/CConn.cxx:194
-#, c-format
-msgid "(server default %s)"
-msgstr "(serverstandaard is %s)"
-
-#: vncviewer/CConn.cxx:199
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Gevraagde codering: %s"
 
-#: vncviewer/CConn.cxx:204
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Laatst gebruikte codering: %s"
 
-#: vncviewer/CConn.cxx:209
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Geschatte lijnsnelheid: %d kbit/s"
 
-#: vncviewer/CConn.cxx:214
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Protocolversie: %d.%d"
 
-#: vncviewer/CConn.cxx:219
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Beveiligingsmethode: %s"
 
-#: vncviewer/CConn.cxx:343
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
+msgstr ""
+
+#: vncviewer/CConn.cxx:258
 #, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "### SetDesktopSize is mislukt: %d"
+msgid "Authentication failed: %s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:413
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "Ongeldige 'SetColourMapEntries' van de server!"
+#: vncviewer/CConn.cxx:259
+#, c-format
+msgid ""
+"Failed to authenticate with the server. Reason given by the server:\n"
+"\n"
+"%s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:489
-msgid "Enabling continuous updates"
-msgstr "Continue updates inschakelen"
-
-#: vncviewer/CConn.cxx:559
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Throughput is %d kbit/s -- overgaand naar kwaliteit %d"
 
-#: vncviewer/CConn.cxx:581
+#: vncviewer/CConn.cxx:521
 #, c-format
-msgid "Throughput %d kbit/s - full color is now %s"
-msgstr "Throughput is %d kbit/s -- volledige kleuren is nu %s"
+msgid "Throughput %d kbit/s - full color is now enabled"
+msgstr ""
 
-#: vncviewer/CConn.cxx:583
-msgid "disabled"
-msgstr "uitgeschakeld"
-
-#: vncviewer/CConn.cxx:583
-msgid "enabled"
-msgstr "ingeschakeld"
-
-#: vncviewer/CConn.cxx:593
+#: vncviewer/CConn.cxx:524
 #, c-format
-msgid "Using %s encoding"
-msgstr "Codering %s wordt gebruikt"
+msgid "Throughput %d kbit/s - full color is now disabled"
+msgstr ""
 
-#: vncviewer/CConn.cxx:640
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Pixel-indeling %s wordt gebruikt"
 
-#: vncviewer/DesktopWindow.cxx:121
+#: vncviewer/DesktopWindow.cxx:146
 msgid "Invalid geometry specified!"
 msgstr "Ongeldige afmetingen opgegeven!"
 
-#: vncviewer/DesktopWindow.cxx:434
-msgid "Adjusting window size to avoid accidental full screen request"
-msgstr "Venstergrootte wordt aangepast om onbedoeld volledigschermverzoek te vermijden"
+#: vncviewer/DesktopWindow.cxx:167
+msgid "Reducing window size to fit on current monitor"
+msgstr ""
 
-#: vncviewer/DesktopWindow.cxx:478
+#: vncviewer/DesktopWindow.cxx:681
+msgid "Adjusting window size to avoid accidental full-screen request"
+msgstr ""
+
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Druk op %s om het contextmenu te openen"
 
-#: vncviewer/DesktopWindow.cxx:741 vncviewer/DesktopWindow.cxx:747
-#: vncviewer/DesktopWindow.cxx:760
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Het \"grijpen\" van het toetsenbord is mislukt"
 
-#: vncviewer/DesktopWindow.cxx:772
-msgid "Failure grabbing mouse"
-msgstr "Het \"grijpen\" van de muis is mislukt"
-
-#: vncviewer/DesktopWindow.cxx:1002
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
 msgstr "Ongeldige schermopmaak berekend voor wijzigingsverzoek."
 
-#: vncviewer/FLTKPixelBuffer.cxx:33
-msgid "Not enough memory for framebuffer"
-msgstr "Onvoldoende geheugen beschikbaar voor framebuffer"
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
+msgid "Invalid state for 3 button emulation"
+msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:57
-msgid "VNC Viewer: Connection Options"
-msgstr "VNC-viewer: Verbindingsopties"
-
-#: vncviewer/OptionsDialog.cxx:83 vncviewer/ServerDialog.cxx:91
-#: vncviewer/vncviewer.cxx:282
-msgid "Cancel"
-msgstr "Annuleren"
-
-#: vncviewer/OptionsDialog.cxx:88 vncviewer/vncviewer.cxx:281
-msgid "OK"
-msgstr "OK"
-
-#: vncviewer/OptionsDialog.cxx:423
-msgid "Compression"
-msgstr "Compressie"
-
-#: vncviewer/OptionsDialog.cxx:439
-msgid "Auto select"
-msgstr "Automatisch selecteren"
-
-#: vncviewer/OptionsDialog.cxx:451
-msgid "Preferred encoding"
-msgstr "Voorkeurscodering"
-
-#: vncviewer/OptionsDialog.cxx:499
-msgid "Color level"
-msgstr "Kleurdiepte"
-
-#: vncviewer/OptionsDialog.cxx:510
-msgid "Full (all available colors)"
-msgstr "volledig (alle beschikbare kleuren)"
-
-#: vncviewer/OptionsDialog.cxx:517
-msgid "Medium (256 colors)"
-msgstr "medium (256 kleuren)"
-
-#: vncviewer/OptionsDialog.cxx:524
-msgid "Low (64 colors)"
-msgstr "laag (64 kleuren)"
-
-#: vncviewer/OptionsDialog.cxx:531
-msgid "Very low (8 colors)"
-msgstr "zeer laag (8 kleuren)"
-
-#: vncviewer/OptionsDialog.cxx:548
-msgid "Custom compression level:"
-msgstr "Aangepast compressieniveau:"
-
-#: vncviewer/OptionsDialog.cxx:554
-msgid "level (1=fast, 6=best [4-6 are rarely useful])"
-msgstr "niveau (1=snel, 6=best [4-6 zijn zelden nuttig])"
-
-#: vncviewer/OptionsDialog.cxx:561
-msgid "Allow JPEG compression:"
-msgstr "JPEG-compressie toestaan:"
-
-#: vncviewer/OptionsDialog.cxx:567
-msgid "quality (0=poor, 9=best)"
-msgstr "kwaliteit (0=slecht, 9=best)"
-
-#: vncviewer/OptionsDialog.cxx:578
-msgid "Security"
-msgstr "Beveiliging"
-
-#: vncviewer/OptionsDialog.cxx:593
-msgid "Encryption"
-msgstr "Versleuteling"
-
-#: vncviewer/OptionsDialog.cxx:604 vncviewer/OptionsDialog.cxx:657
-#: vncviewer/OptionsDialog.cxx:737
-msgid "None"
-msgstr "Geen"
-
-#: vncviewer/OptionsDialog.cxx:610
-msgid "TLS with anonymous certificates"
-msgstr "TLS met anonieme certificaten"
-
-#: vncviewer/OptionsDialog.cxx:616
-msgid "TLS with X509 certificates"
-msgstr "TLS met X509-certificaten"
-
-#: vncviewer/OptionsDialog.cxx:623
-msgid "Path to X509 CA certificate"
-msgstr "Pad naar X509 CA-certificaat"
-
-#: vncviewer/OptionsDialog.cxx:630
-msgid "Path to X509 CRL file"
-msgstr "Pad naar X509 CRL-bestand"
-
-#: vncviewer/OptionsDialog.cxx:646
-msgid "Authentication"
-msgstr "Authenticatie"
-
-#: vncviewer/OptionsDialog.cxx:663
-msgid "Standard VNC (insecure without encryption)"
-msgstr "Standaard VNC (onveilig zonder versleuteling)"
-
-#: vncviewer/OptionsDialog.cxx:669
-msgid "Username and password (insecure without encryption)"
-msgstr "Gebruikersnaam en wachtwoord (onveilig zonder versleuteling)"
-
-#: vncviewer/OptionsDialog.cxx:688
-msgid "Input"
-msgstr "Invoer"
-
-#: vncviewer/OptionsDialog.cxx:696
-msgid "View only (ignore mouse and keyboard)"
-msgstr "Alleen kijken (muis en toetsenbord negeren)"
-
-#: vncviewer/OptionsDialog.cxx:702
-msgid "Accept clipboard from server"
-msgstr "Klembord van server accepteren"
-
-#: vncviewer/OptionsDialog.cxx:710
-msgid "Also set primary selection"
-msgstr "Ook de hoofdselectie instellen"
-
-#: vncviewer/OptionsDialog.cxx:717
-msgid "Send clipboard to server"
-msgstr "Klembord naar server zenden"
-
-#: vncviewer/OptionsDialog.cxx:725
-msgid "Send primary selection as clipboard"
-msgstr "Hoofdselectie als klembord verzenden"
-
-#: vncviewer/OptionsDialog.cxx:732
-msgid "Pass system keys directly to server (full screen)"
-msgstr "Systeemsleutels direct aan server doorgeven (volledigscherm)"
-
-#: vncviewer/OptionsDialog.cxx:735
-msgid "Menu key"
-msgstr "Menutoets"
-
-#: vncviewer/OptionsDialog.cxx:751
-msgid "Screen"
-msgstr "Scherm"
-
-#: vncviewer/OptionsDialog.cxx:759
-msgid "Resize remote session on connect"
-msgstr "Grootte van gindse sessie aanpassen bij verbinden"
-
-#: vncviewer/OptionsDialog.cxx:772
-msgid "Resize remote session to the local window"
-msgstr "Gindse sessie aan het lokale venster aanpassen"
-
-#: vncviewer/OptionsDialog.cxx:778
-msgid "Full-screen mode"
-msgstr "Volledigscherm-modus"
-
-#: vncviewer/OptionsDialog.cxx:784
-msgid "Enable full-screen mode over all monitors"
-msgstr "Volledigscherm-modus over alle beeldschermen inschakelen"
-
-#: vncviewer/OptionsDialog.cxx:793
-msgid "Misc."
-msgstr "Overige"
-
-#: vncviewer/OptionsDialog.cxx:801
-msgid "Shared (don't disconnect other viewers)"
-msgstr "Gedeeld (verbinding van andere viewers niet verbreken)"
-
-#: vncviewer/OptionsDialog.cxx:807
-msgid "Show dot when no cursor"
-msgstr "Punt tonen als er geen cursor is"
-
-#: vncviewer/ServerDialog.cxx:42
-msgid "VNC Viewer: Connection Details"
-msgstr "VNC-viewer: Verbindingsdetails"
-
-#: vncviewer/ServerDialog.cxx:49 vncviewer/ServerDialog.cxx:54
-msgid "VNC server:"
-msgstr "VNC-server:"
-
-#: vncviewer/ServerDialog.cxx:64
-msgid "Options..."
-msgstr "Opties..."
-
-#: vncviewer/ServerDialog.cxx:69
-msgid "Load..."
-msgstr "Laden..."
-
-#: vncviewer/ServerDialog.cxx:74
-msgid "Save As..."
-msgstr "Opslaan als..."
-
-#: vncviewer/ServerDialog.cxx:86
-msgid "About..."
-msgstr "Info..."
-
-#: vncviewer/ServerDialog.cxx:96
-msgid "Connect"
-msgstr "Verbinden"
-
-#: vncviewer/UserDialog.cxx:74
-msgid "Opening password file failed"
-msgstr "Openen van wachtwoordbestand is mislukt"
-
-#: vncviewer/UserDialog.cxx:86 vncviewer/UserDialog.cxx:96
-msgid "VNC authentication"
-msgstr "VNC-authenticatie"
-
-#: vncviewer/UserDialog.cxx:87 vncviewer/UserDialog.cxx:102
-msgid "Password:"
-msgstr "Wachtwoord:"
-
-#: vncviewer/UserDialog.cxx:89
-msgid "Authentication cancelled"
-msgstr "Authenticatie is geannuleerd"
-
-#: vncviewer/UserDialog.cxx:99
-msgid "Username:"
-msgstr "Gebruikersnaam:"
-
-#: vncviewer/Viewport.cxx:586
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "Geen scancode voor uitgebreide virtuele toets 0x%02x"
 
-#: vncviewer/Viewport.cxx:588
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "Geen scancode voor virtuele toets 0x%02x"
 
-#: vncviewer/Viewport.cxx:605
+#: vncviewer/KeyboardWin32.cxx:251
+#, c-format
+msgid "Invalid scan code 0x%02x"
+msgstr ""
+
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "Geen symbool voor uitgebreide virtuele toets 0x%02x"
 
-#: vncviewer/Viewport.cxx:607
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "Geen symbool voor virtuele toets 0x%02x"
 
-#: vncviewer/Viewport.cxx:645
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
-msgid "No symbol for key code 0x%02x (in the current state)"
-msgstr "Geen symbool voor toetscode 0x%02x (in de huidige toestand)"
+msgid "Failed to update keyboard LED state: %lu"
+msgstr ""
 
-#: vncviewer/Viewport.cxx:671
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "Geen symbool voor toetscode %d (in de huidige toestand)"
 
-#: vncviewer/Viewport.cxx:708
-msgctxt "ContextMenu|"
-msgid "E&xit viewer"
-msgstr "Viewer af&sluiten"
+#: vncviewer/KeyboardX11.cxx:148
+#, c-format
+msgid "Failed to get keyboard LED state: %d"
+msgstr ""
 
-#: vncviewer/Viewport.cxx:711
+#: vncviewer/KeyboardX11.cxx:193
+msgid "Failed to update keyboard LED state"
+msgstr ""
+
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
+msgid "Failed to get system monitor configuration"
+msgstr ""
+
+#: vncviewer/MonitorIndicesParameter.cxx:73
+#, c-format
+msgid "Monitor index %d does not exist"
+msgstr ""
+
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
+msgid "TigerVNC options"
+msgstr ""
+
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
+msgid "Cancel"
+msgstr "Annuleren"
+
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
+msgid "OK"
+msgstr "OK"
+
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
+msgid "Compression"
+msgstr "Compressie"
+
+#: vncviewer/OptionsDialog.cxx:524
+msgid "Auto select"
+msgstr "Automatisch selecteren"
+
+#: vncviewer/OptionsDialog.cxx:536
+msgid "Preferred encoding"
+msgstr "Voorkeurscodering"
+
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
+msgid "Color level"
+msgstr "Kleurdiepte"
+
+#: vncviewer/OptionsDialog.cxx:611
+msgid "Full"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:619
+msgid "Medium"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:627
+msgid "Low"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:635
+msgid "Very low"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:658
+msgid "Custom compression level:"
+msgstr "Aangepast compressieniveau:"
+
+#: vncviewer/OptionsDialog.cxx:666
+msgid "level (0=fast, 9=best)"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:674
+msgid "Allow JPEG compression:"
+msgstr "JPEG-compressie toestaan:"
+
+#: vncviewer/OptionsDialog.cxx:682
+msgid "quality (0=poor, 9=best)"
+msgstr "kwaliteit (0=slecht, 9=best)"
+
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
+msgid "Security"
+msgstr "Beveiliging"
+
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
+msgid "Encryption"
+msgstr "Versleuteling"
+
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
+msgid "None"
+msgstr "Geen"
+
+#: vncviewer/OptionsDialog.cxx:730
+msgid "TLS with anonymous certificates"
+msgstr "TLS met anonieme certificaten"
+
+#: vncviewer/OptionsDialog.cxx:737
+msgid "TLS with X509 certificates"
+msgstr "TLS met X509-certificaten"
+
+#: vncviewer/OptionsDialog.cxx:745
+msgid "Path to X509 CA certificate"
+msgstr "Pad naar X509 CA-certificaat"
+
+#: vncviewer/OptionsDialog.cxx:753
+msgid "Path to X509 CRL file"
+msgstr "Pad naar X509 CRL-bestand"
+
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
+msgid "Authentication"
+msgstr "Authenticatie"
+
+#: vncviewer/OptionsDialog.cxx:802
+msgid "Standard VNC (insecure without encryption)"
+msgstr "Standaard VNC (onveilig zonder versleuteling)"
+
+#: vncviewer/OptionsDialog.cxx:809
+msgid "Username and password (insecure without encryption)"
+msgstr "Gebruikersnaam en wachtwoord (onveilig zonder versleuteling)"
+
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
+msgid "Input"
+msgstr "Invoer"
+
+#: vncviewer/OptionsDialog.cxx:852
+msgid "View only (ignore mouse and keyboard)"
+msgstr "Alleen kijken (muis en toetsenbord negeren)"
+
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
+msgid "Mouse"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:873
+msgid "Emulate middle mouse button"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:880
+msgid "Show local cursor when not provided by server"
+msgstr ""
+
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
+msgid "Cursor type"
+msgstr ""
+
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
+msgid "Dot"
+msgstr ""
+
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
+msgid "System"
+msgstr ""
+
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
+msgid "Keyboard"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:925
+msgid "Pass system keys directly to server (full screen)"
+msgstr "Systeemsleutels direct aan server doorgeven (volledigscherm)"
+
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
+msgid "Menu key"
+msgstr "Menutoets"
+
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
+msgid "Clipboard"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:968
+msgid "Accept clipboard from server"
+msgstr "Klembord van server accepteren"
+
+#: vncviewer/OptionsDialog.cxx:977
+msgid "Also set primary selection"
+msgstr "Ook de hoofdselectie instellen"
+
+#: vncviewer/OptionsDialog.cxx:985
+msgid "Send clipboard to server"
+msgstr "Klembord naar server zenden"
+
+#: vncviewer/OptionsDialog.cxx:994
+msgid "Send primary selection as clipboard"
+msgstr "Hoofdselectie als klembord verzenden"
+
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
+msgid "Display"
+msgstr ""
+
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
+msgid "Display mode"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1045
+msgid "Windowed"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1054
+msgid "Full screen on current monitor"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1063
+msgid "Full screen on all monitors"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1072
+msgid "Full screen on selected monitor(s)"
+msgstr ""
+
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
+msgid "Miscellaneous"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1111
+msgid "Shared (don't disconnect other viewers)"
+msgstr "Gedeeld (verbinding van andere viewers niet verbreken)"
+
+#: vncviewer/OptionsDialog.cxx:1118
+msgid "Ask to reconnect on connection errors"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:73
+msgid "VNC server:"
+msgstr "VNC-server:"
+
+#: vncviewer/ServerDialog.cxx:80
+msgid "Options..."
+msgstr "Opties..."
+
+#: vncviewer/ServerDialog.cxx:84
+msgid "Load..."
+msgstr "Laden..."
+
+#: vncviewer/ServerDialog.cxx:88
+msgid "Save as..."
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:102
+msgid "About..."
+msgstr "Info..."
+
+#: vncviewer/ServerDialog.cxx:111
+msgid "Connect"
+msgstr "Verbinden"
+
+#: vncviewer/ServerDialog.cxx:147
+#, c-format
+msgid ""
+"Unable to load the server history:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:176 vncviewer/ServerDialog.cxx:216
+msgid "TigerVNC configuration (*.tigervnc)"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:177
+msgid "Select a TigerVNC configuration file"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
+#, c-format
+msgid ""
+"Unable to load the specified configuration file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:217
+msgid "Save the TigerVNC configuration to file"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:243
+#, c-format
+msgid "%s already exists. Do you want to overwrite?"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
+msgid "No"
+msgstr "Nee"
+
+#: vncviewer/ServerDialog.cxx:244
+msgid "Overwrite"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:260
+#, c-format
+msgid ""
+"Unable to save the specified configuration file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:294
+#, c-format
+msgid ""
+"Unable to save the default configuration:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:306
+#, c-format
+msgid ""
+"Unable to save the server history:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
+msgid "Could not determine VNC state directory path"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
+#, c-format
+msgid "Could not open \"%s\""
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
+#, c-format
+msgid "Failed to read line %d in file \"%s\""
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
+msgid "Line too long"
+msgstr "Regel is te lang"
+
+#: vncviewer/UserDialog.cxx:130
+msgid "Opening password file failed"
+msgstr "Openen van wachtwoordbestand is mislukt"
+
+#: vncviewer/UserDialog.cxx:150
+msgid "VNC authentication"
+msgstr "VNC-authenticatie"
+
+#: vncviewer/UserDialog.cxx:157
+msgid "This connection is secure"
+msgstr ""
+
+#: vncviewer/UserDialog.cxx:161
+msgid "This connection is not secure"
+msgstr ""
+
+#: vncviewer/UserDialog.cxx:183
+msgid "Username:"
+msgstr "Gebruikersnaam:"
+
+#: vncviewer/UserDialog.cxx:196
+msgid "Password:"
+msgstr "Wachtwoord:"
+
+#: vncviewer/UserDialog.cxx:204
+msgid "Keep password for reconnect"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:749
+msgctxt "ContextMenu|"
+msgid "Disconn&ect"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "&Volledig scherm"
 
-#: vncviewer/Viewport.cxx:714
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "&Minimaliseren"
 
-#: vncviewer/Viewport.cxx:716
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "Ve&nster aan sessie aanpassen"
 
-#: vncviewer/Viewport.cxx:721
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:724
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:730
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "%s zenden"
 
-#: vncviewer/Viewport.cxx:736
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Ctrl-Alt-&Del zenden"
 
-#: vncviewer/Viewport.cxx:739
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "Sch&erm verversen"
 
-#: vncviewer/Viewport.cxx:742
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&Opties..."
 
-#: vncviewer/Viewport.cxx:744
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "Verbindings&info..."
 
-#: vncviewer/Viewport.cxx:746
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "Info over &TigerVNC-viewer..."
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:749
-msgctxt "ContextMenu|"
-msgid "Dismiss &menu"
-msgstr "Menu ver&laten"
-
-#: vncviewer/Viewport.cxx:833
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "VNC-verbindingsinfo"
 
-#: vncviewer/parameters.cxx:286 vncviewer/parameters.cxx:320
+#: vncviewer/Win32TouchHandler.cxx:49
+msgid "Window is registered for touch instead of gestures"
+msgstr ""
+
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
-msgid "The name of the parameter %s was too large to write to the registry"
-msgstr "De naam van parameter %s is te lang om naar het register te schrijven"
+msgid "Failed to set gesture configuration (error 0x%x)"
+msgstr ""
 
-#: vncviewer/parameters.cxx:292 vncviewer/parameters.cxx:299
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
-msgid "The parameter %s was too large to write to the registry"
-msgstr "Parameter %s is te lang om naar het register te schrijven"
+msgid "Failed to get gesture information (error 0x%x)"
+msgstr ""
 
-#: vncviewer/parameters.cxx:305 vncviewer/parameters.cxx:326
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
-msgid "Failed to write parameter %s of type %s to the registry: %ld"
-msgstr "Schrijven van parameter %s van type %s naar het register is mislukt: %ld"
+msgid "Invalid mouse button %d, must be a number between 1 and 7."
+msgstr ""
 
-#: vncviewer/parameters.cxx:341 vncviewer/parameters.cxx:380
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
-msgid "The name of the parameter %s was too large to read from the registry"
-msgstr "De naam van parameter %s is te lang om uit het register te lezen"
+msgid "Unhandled key 0x%x - can't generate keyboard event."
+msgstr ""
 
-#: vncviewer/parameters.cxx:350 vncviewer/parameters.cxx:389
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
-msgid "Failed to read parameter %s from the registry: %ld"
-msgstr "Lezen van parameter %s uit het register is mislukt: %ld"
+msgid "Unable to get X Input 2 event mask for window 0x%08lx"
+msgstr ""
 
-#: vncviewer/parameters.cxx:359
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
-msgid "The parameter %s was too large to read from the registry"
-msgstr "Parameter %s is te lang om uit het register te lezen"
+msgid "Window 0x%08lx has no X Input 2 event mask"
+msgstr ""
 
-#: vncviewer/parameters.cxx:409
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
-msgid "Failed to create registry key: %ld"
-msgstr "Aanmaken van registersleutel %ld is mislukt"
+msgid "Window 0x%08lx has more than one X Input 2 event mask"
+msgstr ""
 
-#: vncviewer/parameters.cxx:423 vncviewer/parameters.cxx:472
-#: vncviewer/parameters.cxx:534 vncviewer/parameters.cxx:665
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
-msgid "Unknown parameter type for parameter %s"
-msgstr "Onbekend parametertype voor parameter %s"
+msgid "Failure grabbing device %i"
+msgstr ""
 
-#: vncviewer/parameters.cxx:430 vncviewer/parameters.cxx:479
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
+#: vncviewer/vncviewer.desktop.in.in:5
+msgid "Connect to VNC server and display remote desktop"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
+
+#. developer_name tag deprecated with Appstream 1.0
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
+msgid "The TigerVNC team"
+msgstr ""
+
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
+msgid "The name of the parameter is too large"
+msgstr ""
+
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
+msgid "The parameter is too large"
+msgstr ""
+
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
+msgid "Invalid format or too large value"
+msgstr "Ongeldige opmaak of te grote waarde"
+
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
+msgid "Failed to create registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
+msgid "Failed to close registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
-msgid "Failed to close registry key: %ld"
-msgstr "Sluiten van registersleutel %ld is mislukt"
+msgid "Failed to save \"%s\": %s"
+msgstr ""
 
-#: vncviewer/parameters.cxx:446
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
-msgid "Failed to open registry key: %ld"
-msgstr "Openen van registersleutel %ld is mislukt"
+msgid "Failed to remove \"%s\": %s"
+msgstr ""
 
-#: vncviewer/parameters.cxx:503
-msgid "Failed to write configuration file, can't obtain home directory path."
-msgstr "Schrijven van configuratiebestand is mislukt; kan pad van thuismap niet verkrijgen."
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
+msgid "Failed to open registry key"
+msgstr ""
 
-#: vncviewer/parameters.cxx:516
+#: vncviewer/parameters.cxx:635
 #, c-format
-msgid "Failed to write configuration file, can't open %s: %s"
-msgstr "Schrijven van configuratiebestand is mislukt; kan %s niet openen: %s"
+msgid "Failed to read server history entry %d: %s"
+msgstr ""
 
-#: vncviewer/parameters.cxx:559
-msgid "Failed to read configuration file, can't obtain home directory path."
-msgstr "Lezen van configuratiebestand is mislukt; kan pad van thuismap niet verkrijgen."
-
-#: vncviewer/parameters.cxx:572
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
-msgid "Failed to read configuration file, can't open %s: %s"
-msgstr "Lezen van configuratiebestand is mislukt; kan %s niet openen: %s"
+msgid "Failed to read parameter \"%s\": %s"
+msgstr ""
 
-#: vncviewer/parameters.cxx:585 vncviewer/parameters.cxx:590
-#: vncviewer/parameters.cxx:615 vncviewer/parameters.cxx:628
-#: vncviewer/parameters.cxx:644
-#, c-format
-msgid "Failed to read line %d in file %s: %s"
-msgstr "Lezen van regel %d in bestand %s is mislukt: %s"
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
+msgid "Could not determine VNC config directory path"
+msgstr ""
 
-#: vncviewer/parameters.cxx:591
-msgid "Line too long"
-msgstr "Regel is te lang"
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
+msgid "Could not encode parameter"
+msgstr ""
 
-#: vncviewer/parameters.cxx:598
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "Configuratiebestand %s het een ongeldige opmaak"
 
-#: vncviewer/parameters.cxx:616
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "Ongeldige opmaak"
 
-#: vncviewer/parameters.cxx:629 vncviewer/parameters.cxx:645
-msgid "Invalid format or too large value"
-msgstr "Ongeldige opmaak of te grote waarde"
+#: vncviewer/parameters.cxx:939
+msgid "Unknown parameter"
+msgstr ""
 
-#: vncviewer/parameters.cxx:672
+#: vncviewer/touch.cxx:75
 #, c-format
-msgid "Unknown parameter %s on line %d in file %s"
-msgstr "Onbekende parameter %s op regel %d in bestand %s"
+msgid "Got message (0x%x) for an unhandled window"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:100
+#: vncviewer/touch.cxx:138 vncviewer/touch.cxx:160
+#, c-format
+msgid "Invalid window 0x%08lx specified for pointer grab"
+msgstr ""
+
+#: vncviewer/touch.cxx:183 vncviewer/touch.cxx:184
+#, c-format
+msgid "Failed to create touch handler: %s"
+msgstr ""
+
+#: vncviewer/touch.cxx:188
+#, c-format
+msgid "Couldn't attach event handler to window (error 0x%x)"
+msgstr ""
+
+#: vncviewer/touch.cxx:215
+msgid "Failed to get event data for X Input event"
+msgstr ""
+
+#: vncviewer/touch.cxx:228
+msgid "X Input event for unknown window"
+msgstr ""
+
+#: vncviewer/touch.cxx:254
+msgid "X Input extension not available."
+msgstr ""
+
+#: vncviewer/touch.cxx:261
+msgid "X Input 2 (or newer) is not available."
+msgstr ""
+
+#: vncviewer/touch.cxx:266
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC Viewer %d-bit v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
-"Copyright (C) 1999-%d TigerVNC Team and many others (see README.txt)\n"
-"See http://www.tigervnc.org for information on TigerVNC."
+"Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+"See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"TigerVNC Viewer (%d-bit) v%s\n"
-"Gecompileerd op: %s\n"
-"Copyright (C) 1999-%d het TigerVNC-team en vele anderen (zie README.txt)\n"
-"Zie http://www.tigervnc.org voor informatie over TigerVNC."
 
-#: vncviewer/vncviewer.cxx:127
-msgid "About TigerVNC Viewer"
-msgstr "Info over TigerVNC-viewer"
+#: vncviewer/vncviewer.cxx:157
+#, c-format
+msgid ""
+"An unexpected error occurred when communicating with the server:\n"
+"\n"
+"%s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:140
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "Interne FLTK-fout.  Bezig met afsluiten."
 
-#: vncviewer/vncviewer.cxx:158 vncviewer/vncviewer.cxx:170
+#: vncviewer/vncviewer.cxx:213
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Fout tijdens starten van nieuwe TigerVNC-viewer: %s"
+msgid ""
+"%s\n"
+"\n"
+"Attempt to reconnect?"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:179
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC Viewer will now exit."
-msgstr "Beëindigingssignaal %d werd ontvangen.  TigerVNC-viewer sluit nu af."
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:271
-msgid "TigerVNC Viewer"
-msgstr "TigerVNC-viewer"
+#: vncviewer/vncviewer.cxx:265
+#, c-format
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:279
-msgid "No"
-msgstr "Nee"
-
-#: vncviewer/vncviewer.cxx:280
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "Ja"
 
-#: vncviewer/vncviewer.cxx:283
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "Sluiten"
 
-#: vncviewer/vncviewer.cxx:288
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "Info"
 
-#: vncviewer/vncviewer.cxx:291
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "Verbergen"
 
-#: vncviewer/vncviewer.cxx:294
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "Afsluiten"
 
-#: vncviewer/vncviewer.cxx:298
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "Diensten"
 
-#: vncviewer/vncviewer.cxx:299
-msgid "Hide Others"
-msgstr "Andere verbergen"
+#: vncviewer/vncviewer.cxx:413
+msgid "Hide others"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:300
-msgid "Show All"
-msgstr "Alles tonen"
+#: vncviewer/vncviewer.cxx:414
+msgid "Show all"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:309
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "&Bestand"
 
-#: vncviewer/vncviewer.cxx:312
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "&Nieuwe verbinding"
 
-#: vncviewer/vncviewer.cxx:324
-msgid "Could not create VNC home directory: can't obtain home directory path."
-msgstr "Kan de VNC-thuismap niet aanmaken: kan pad van thuismap niet verkrijgen."
-
-#: vncviewer/vncviewer.cxx:329
+#: vncviewer/vncviewer.cxx:449
 #, c-format
-msgid "Could not create VNC home directory: %s."
-msgstr "Kan de VNC-thuismap niet aanmaken: %s."
+msgid ""
+"\n"
+"Usage: %s [parameters] [host][:displayNum]\n"
+"       %s [parameters] [host][::port]\n"
+"       %s [parameters] [unix socket]\n"
+"       %s [parameters] -listen [port]\n"
+"       %s [parameters] [.tigervnc file]\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:464
+#, c-format
+msgid ""
+"\n"
+"Options:\n"
+"\n"
+"  -display Xdisplay  - Specifies the X display for the viewer window\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
+"                       man page for details.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:471
+#, c-format
+msgid ""
+"\n"
+"Parameters can be turned on with -<param> or off with -<param>=0\n"
+"Parameters which take a value can be specified as -<param> <value>\n"
+"Other valid forms are <param>=<value> -<param>=<value> --<param>=<value>\n"
+"Parameter names are case-insensitive.  The parameters are:\n"
+"\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:556
+#, c-format
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:561
+#, c-format
+msgid "Could not create VNC config directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:567
+msgid "Could not determine VNC data directory path"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:573
+#, c-format
+msgid "Could not create VNC data directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:585
+#, c-format
+msgid "Could not create VNC state directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:704
+#, c-format
+msgid "%s: Unrecognized option '%s'\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
+#, c-format
+msgid "See '%s --help' for more information.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:713
+#, c-format
+msgid "%s: Extra argument '%s'\n"
+msgstr ""
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:534 vncviewer/vncviewer.cxx:535
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "de opties '-listen' en '-via' gaan niet samen"
 
-#: vncviewer/vncviewer.cxx:550
+#: vncviewer/vncviewer.cxx:764
+msgid "Unable to listen for incoming connections"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "Luisterend op poort %d"
+
+#: vncviewer/vncviewer.cxx:795
+#, c-format
+msgid ""
+"Failure waiting for incoming VNC connection:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:816
+#, c-format
+msgid ""
+"Failure setting up encrypted tunnel:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.desktop.in.in:4
+msgid "Remote desktop viewer"
+msgstr ""
+
+#, c-format
+#~ msgid "connected to host %s port %d"
+#~ msgstr "verbonden met host %s poort %d"
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(serverstandaard is %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "### SetDesktopSize is mislukt: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "Ongeldige 'SetColourMapEntries' van de server!"
+
+#~ msgid "Enabling continuous updates"
+#~ msgstr "Continue updates inschakelen"
+
+#, c-format
+#~ msgid "Throughput %d kbit/s - full color is now %s"
+#~ msgstr "Throughput is %d kbit/s -- volledige kleuren is nu %s"
+
+#~ msgid "disabled"
+#~ msgstr "uitgeschakeld"
+
+#~ msgid "enabled"
+#~ msgstr "ingeschakeld"
+
+#, c-format
+#~ msgid "Using %s encoding"
+#~ msgstr "Codering %s wordt gebruikt"
+
+#~ msgid "Adjusting window size to avoid accidental full screen request"
+#~ msgstr ""
+#~ "Venstergrootte wordt aangepast om onbedoeld volledigschermverzoek te "
+#~ "vermijden"
+
+#~ msgid "Failure grabbing mouse"
+#~ msgstr "Het \"grijpen\" van de muis is mislukt"
+
+#~ msgid "Not enough memory for framebuffer"
+#~ msgstr "Onvoldoende geheugen beschikbaar voor framebuffer"
+
+#~ msgid "VNC Viewer: Connection Options"
+#~ msgstr "VNC-viewer: Verbindingsopties"
+
+#~ msgid "Full (all available colors)"
+#~ msgstr "volledig (alle beschikbare kleuren)"
+
+#~ msgid "Medium (256 colors)"
+#~ msgstr "medium (256 kleuren)"
+
+#~ msgid "Low (64 colors)"
+#~ msgstr "laag (64 kleuren)"
+
+#~ msgid "Very low (8 colors)"
+#~ msgstr "zeer laag (8 kleuren)"
+
+#~ msgid "level (1=fast, 6=best [4-6 are rarely useful])"
+#~ msgstr "niveau (1=snel, 6=best [4-6 zijn zelden nuttig])"
+
+#~ msgid "Screen"
+#~ msgstr "Scherm"
+
+#~ msgid "Resize remote session on connect"
+#~ msgstr "Grootte van gindse sessie aanpassen bij verbinden"
+
+#~ msgid "Resize remote session to the local window"
+#~ msgstr "Gindse sessie aan het lokale venster aanpassen"
+
+#~ msgid "Full-screen mode"
+#~ msgstr "Volledigscherm-modus"
+
+#~ msgid "Enable full-screen mode over all monitors"
+#~ msgstr "Volledigscherm-modus over alle beeldschermen inschakelen"
+
+#~ msgid "Misc."
+#~ msgstr "Overige"
+
+#~ msgid "Show dot when no cursor"
+#~ msgstr "Punt tonen als er geen cursor is"
+
+#~ msgid "VNC Viewer: Connection Details"
+#~ msgstr "VNC-viewer: Verbindingsdetails"
+
+#~ msgid "Save As..."
+#~ msgstr "Opslaan als..."
+
+#~ msgid "Authentication cancelled"
+#~ msgstr "Authenticatie is geannuleerd"
+
+#, c-format
+#~ msgid "No symbol for key code 0x%02x (in the current state)"
+#~ msgstr "Geen symbool voor toetscode 0x%02x (in de huidige toestand)"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "E&xit viewer"
+#~ msgstr "Viewer af&sluiten"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "Info over &TigerVNC-viewer..."
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "Dismiss &menu"
+#~ msgstr "Menu ver&laten"
+
+#, c-format
+#~ msgid "The name of the parameter %s was too large to write to the registry"
+#~ msgstr ""
+#~ "De naam van parameter %s is te lang om naar het register te schrijven"
+
+#, c-format
+#~ msgid "The parameter %s was too large to write to the registry"
+#~ msgstr "Parameter %s is te lang om naar het register te schrijven"
+
+#, c-format
+#~ msgid "Failed to write parameter %s of type %s to the registry: %ld"
+#~ msgstr ""
+#~ "Schrijven van parameter %s van type %s naar het register is mislukt: %ld"
+
+#, c-format
+#~ msgid "The name of the parameter %s was too large to read from the registry"
+#~ msgstr "De naam van parameter %s is te lang om uit het register te lezen"
+
+#, c-format
+#~ msgid "Failed to read parameter %s from the registry: %ld"
+#~ msgstr "Lezen van parameter %s uit het register is mislukt: %ld"
+
+#, c-format
+#~ msgid "The parameter %s was too large to read from the registry"
+#~ msgstr "Parameter %s is te lang om uit het register te lezen"
+
+#, c-format
+#~ msgid "Failed to create registry key: %ld"
+#~ msgstr "Aanmaken van registersleutel %ld is mislukt"
+
+#, c-format
+#~ msgid "Unknown parameter type for parameter %s"
+#~ msgstr "Onbekend parametertype voor parameter %s"
+
+#, c-format
+#~ msgid "Failed to close registry key: %ld"
+#~ msgstr "Sluiten van registersleutel %ld is mislukt"
+
+#, c-format
+#~ msgid "Failed to open registry key: %ld"
+#~ msgstr "Openen van registersleutel %ld is mislukt"
+
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Schrijven van configuratiebestand is mislukt; kan pad van thuismap niet "
+#~ "verkrijgen."
+
+#, c-format
+#~ msgid "Failed to write configuration file, can't open %s: %s"
+#~ msgstr ""
+#~ "Schrijven van configuratiebestand is mislukt; kan %s niet openen: %s"
+
+#~ msgid "Failed to read configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Lezen van configuratiebestand is mislukt; kan pad van thuismap niet "
+#~ "verkrijgen."
+
+#, c-format
+#~ msgid "Failed to read configuration file, can't open %s: %s"
+#~ msgstr "Lezen van configuratiebestand is mislukt; kan %s niet openen: %s"
+
+#, c-format
+#~ msgid "Failed to read line %d in file %s: %s"
+#~ msgstr "Lezen van regel %d in bestand %s is mislukt: %s"
+
+#, c-format
+#~ msgid "Unknown parameter %s on line %d in file %s"
+#~ msgstr "Onbekende parameter %s op regel %d in bestand %s"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC Viewer %d-bit v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC Team and many others (see README.txt)\n"
+#~ "See http://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "TigerVNC Viewer (%d-bit) v%s\n"
+#~ "Gecompileerd op: %s\n"
+#~ "Copyright (C) 1999-%d het TigerVNC-team en vele anderen (zie README.txt)\n"
+#~ "Zie http://www.tigervnc.org voor informatie over TigerVNC."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "Info over TigerVNC-viewer"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Fout tijdens starten van nieuwe TigerVNC-viewer: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC Viewer will now exit."
+#~ msgstr ""
+#~ "Beëindigingssignaal %d werd ontvangen.  TigerVNC-viewer sluit nu af."
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "TigerVNC-viewer"
+
+#~ msgid "Hide Others"
+#~ msgstr "Andere verbergen"
+
+#~ msgid "Show All"
+#~ msgstr "Alles tonen"
+
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
+#~ msgstr ""
+#~ "Kan de VNC-thuismap niet aanmaken: kan pad van thuismap niet verkrijgen."
+
+#, c-format
+#~ msgid "Could not create VNC home directory: %s."
+#~ msgstr "Kan de VNC-thuismap niet aanmaken: %s."
 
 #~ msgid "Could not create framebuffer device"
 #~ msgstr "Kan framebuffer-apparaat niet aanmaken"
@@ -694,7 +1306,8 @@ msgstr "Luisterend op poort %d"
 #~ msgstr "Alleen true-color beeldschermen worden ondersteund"
 
 #~ msgid "Using default colormap and visual, TrueColor, depth %d."
-#~ msgstr "Standaard kleurenkaart en visual worden gebruikt, TrueColor, diepte %d."
+#~ msgstr ""
+#~ "Standaard kleurenkaart en visual worden gebruikt, TrueColor, diepte %d."
 
 #~ msgid "Could not create framebuffer image"
 #~ msgstr "Kan framebuffer-afbeelding niet aanmaken"

--- a/po/pl.po
+++ b/po/pl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pl\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2014-09-22 11:15+0000\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2009-03-25 21:26+0100\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -12,744 +12,1133 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:194
+#: vncviewer/CConn.cxx:103
 #, c-format
-msgid "(server default %s)"
+msgid "Connected to socket %s"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:227
-#, fuzzy
-msgid "About"
-msgstr "O programie..."
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:103
-msgid "About TigerVNC Viewer"
-msgstr "O Przeglądarce VNC"
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1086
-#, fuzzy
-msgid "About TigerVNC viewer..."
-msgstr "O Przeglądarce VNC"
-
-#: /home/ossman/devel/tigervnc/vncviewer/ServerDialog.cxx:86
-msgid "About..."
-msgstr "O programie..."
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:704
-msgid "Accept clipboard from server"
-msgstr "Akceptuj schowek z serwera"
-
-#: /home/ossman/devel/tigervnc/vncviewer/DesktopWindow.cxx:327
-msgid "Adjusting window size to avoid accidental full screen request"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:563
-msgid "Allow JPEG compression:"
-msgstr "Zezwolenie na kompresję JPEG:"
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1070
-msgid "Alt"
-msgstr "Alt"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:648
-#, fuzzy
-msgid "Authentication"
-msgstr "Uwierzytelnianie VNC"
-
-#: /home/ossman/devel/tigervnc/vncviewer/UserDialog.cxx:89
-#, fuzzy
-msgid "Authentication cancelled"
-msgstr "Uwierzytelnianie VNC"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:437
-msgid "Auto select"
-msgstr "Automatyczne wykrywanie"
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:651
+#: vncviewer/CConn.cxx:110
 #, c-format
-msgid "Bad Name/Value pair on line: %d in file: %s"
+msgid "Connected to host %s port %d"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/Win32PixelBuffer.cxx:92
-msgid "BitBlt failed"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/ServerDialog.cxx:91
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:221
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:83
-msgid "Cancel"
-msgstr "Anuluj"
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:116
-msgid "CleanupSignalHandler called"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:222
-msgid "Close"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:499
-msgid "Color level"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:421
-#, fuzzy
-msgid "Compression"
-msgstr "Własny poziom kompresji:"
-
-#: /home/ossman/devel/tigervnc/vncviewer/ServerDialog.cxx:96
-msgid "Connect"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1085
-msgid "Connection info..."
-msgstr "Informacje o połączeniu..."
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:362
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:404
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
-"Could not convert the parameter-name %s to wchar_t* when reading from the "
-"Registry, the buffersize is to small."
+"Failed to connect to \"%s\":\n"
+"\n"
+"%s"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:302
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:340
-#, c-format
-msgid ""
-"Could not convert the parameter-name %s to wchar_t* when writing to the "
-"Registry, the buffersize is to small."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:318
-#, c-format
-msgid ""
-"Could not convert the parameter-value %s to wchar_t* when writing to the "
-"Registry, the buffersize is to small."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:381
-#, c-format
-msgid ""
-"Could not convert the parameter-value for %s to utf8 char* when reading from "
-"the Registry, the buffer dest is to small."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:256
-#, c-format
-msgid "Could not create VNC home directory: %s."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:251
-msgid "Could not create VNC home directory: can't obtain home directory path."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:310
-#, c-format
-msgid "Could not encode the parameter-value %s when writing to the Registry."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:613
-#, c-format
-msgid ""
-"Could not read the line(%d) in the configuration file,the buffersize is to "
-"small."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Win32PixelBuffer.cxx:80
-msgid "CreateCompatibleDC failed"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1068
-msgid "Ctrl"
-msgstr "Ctrl"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:550
-msgid "Custom compression level:"
-msgstr "Własny poziom kompresji:"
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:283
-msgid ""
-"Decoding: The size of the buffer dest is to small, it needs to be 1 byte "
-"bigger."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:172
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1088
-msgid "Dismiss menu"
-msgstr "Zwolnij menu"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:778
-msgid "Enable full-screen mode over all monitors"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:469
-msgid "Enabling continuous updates"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:200
-#, c-format
-msgid ""
-"Encoding backslash: The size of the buffer dest is to small, it needs to be "
-"more than %d bytes bigger."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:214
-#, c-format
-msgid ""
-"Encoding escape sequence: The size of the buffer dest is to small, it needs "
-"to be more than %d bytes bigger."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:234
-#, c-format
-msgid ""
-"Encoding normal character: The size of the buffer dest is to small, it needs "
-"to be more than %d bytes bigger."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:595
-msgid "Encryption"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:503
-#, c-format
-msgid "Error(%d) closing key:  Software\\TigerVNC\\vncviewer"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:455
-#, c-format
-msgid "Error(%d) closing key: Software\\TigerVNC\\vncviewer"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:434
-#, c-format
-msgid "Error(%d) creating key: Software\\TigerVNC\\vncviewer"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:471
-#, c-format
-msgid "Error(%d) opening key: Software\\TigerVNC\\vncviewer"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:373
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:415
-#, c-format
-msgid "Error(%d) reading %s from Registry."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:348
-#, c-format
-msgid "Error(%d) writing %d(REG_DWORD) to Registry."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:326
-#, c-format
-msgid "Error(%d) writing %s(REG_SZ) to Registry."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OSXPixelBuffer.cxx:50
-#: /home/ossman/devel/tigervnc/vncviewer/FLTKPixelBuffer.cxx:33
-msgid "Error: Not enough memory for framebuffer"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/X11PixelBuffer.cxx:69
-msgid "Error: couldn't find suitable pixmap format"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/X11PixelBuffer.cxx:60
-msgid "Error: display lacks pixmap format for default depth"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/X11PixelBuffer.cxx:78
-msgid "Error: only true colour displays supported"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1056
-msgid "Exit viewer"
-msgstr "Zakończ przeglądarkę"
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:588
-msgid "Failed to read configuration file, can't obtain home directory path."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:602
-#, c-format
-msgid "Failed to read configuration file, can't open %s"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:621
-#, c-format
-msgid "Failed to read line %d in file %s"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:528
-msgid "Failed to write configuration file, can't obtain home directory path."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:542
-#, c-format
-msgid "Failed to write configuration file, can't open %s"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/DesktopWindow.cxx:526
-#: /home/ossman/devel/tigervnc/vncviewer/DesktopWindow.cxx:538
-#: /home/ossman/devel/tigervnc/vncviewer/DesktopWindow.cxx:551
-msgid "Failure grabbing keyboard"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/DesktopWindow.cxx:563
-msgid "Failure grabbing mouse"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:512
-msgid "Full (all available colors)"
-msgstr "Pełny (wszystkie dostępne kolory)"
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1059
-msgid "Full screen"
-msgstr "Pełny ekran"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:770
-msgid "Full-screen mode"
-msgstr "Tryb pełnoekranowy"
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:230
-msgid "Hide"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:238
-msgid "Hide Others"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:690
-#, fuzzy
-msgid "Input"
-msgstr "Wejścia:"
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:510
-msgid "Internal FLTK error. Exiting."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:384
-msgid "Invalid SetColourMapEntries from server!"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/DesktopWindow.cxx:106
-msgid "Invalid geometry specified!"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:708
-#, c-format
-msgid "Invalid parameter name on line: %d in file: %s"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/DesktopWindow.cxx:797
-msgid "Invalid screen layout computed for resize request!"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:204
-#, c-format
-msgid "Last used encoding: %s"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:631
-#, c-format
-msgid ""
-"Line 1 in file %s\n"
-"must contain the TigerVNC configuration file identifier string:\n"
-"\"%s\""
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:209
-#, c-format
-msgid "Line speed estimate: %d kbit/s"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:478
-#, c-format
-msgid "Listening on port %d\n"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/ServerDialog.cxx:69
-msgid "Load..."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:526
-msgid "Low (64 colors)"
-msgstr "Niski (64 kolory)"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:519
-msgid "Medium (256 colors)"
-msgstr "Średni (256 kolorów)"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:725
-msgid "Menu key"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:791
-#, fuzzy
-msgid "Misc."
-msgstr "Różne:"
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1026
-#, c-format
-msgid "Multiple characters given for key code %d (0x%04x): '%s'"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:218
-msgid "No"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:688
-#, c-format
-msgid "No scan code for extended virtual key 0x%02x"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:690
-#, c-format
-msgid "No scan code for virtual key 0x%02x"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:701
-#, c-format
-msgid "No symbol for extended virtual key 0x%02x"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:765
-#, c-format
-msgid "No symbol for key code %d (in the current state)"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:739
-#, c-format
-msgid "No symbol for key code 0x%02x (in the current state)"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:703
-#, c-format
-msgid "No symbol for virtual key 0x%02x"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:606
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:659
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:727
-msgid "None"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:220
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:88
-msgid "OK"
-msgstr "OK"
-
-#: /home/ossman/devel/tigervnc/vncviewer/UserDialog.cxx:74
-msgid "Opening password file failed"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1084
-#: /home/ossman/devel/tigervnc/vncviewer/ServerDialog.cxx:64
-msgid "Options..."
-msgstr "Opcje..."
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:463
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:464
-msgid "Parameters -listen and -via are incompatible"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:722
-msgid "Pass system keys directly to server (full screen)"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/UserDialog.cxx:87
-#: /home/ossman/devel/tigervnc/vncviewer/UserDialog.cxx:102
-msgid "Password:"
-msgstr "Hasło:"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:625
-msgid "Path to X509 CA certificate"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:632
-msgid "Path to X509 CRL file"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:188
-#, c-format
-msgid "Pixel format: %s"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:449
-msgid "Preferred encoding"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:214
-#, c-format
-msgid "Protocol version: %d.%d"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:233
-msgid "Quit"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1082
-msgid "Refresh screen"
-msgstr "Odśwież ekran"
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:199
-#, c-format
-msgid "Requested encoding: %s"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:749
-msgid "Resize remote session on connect"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:762
-msgid "Resize remote session to the local window"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1062
-msgid "Resize window to session"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/ServerDialog.cxx:74
-msgid "Save As..."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:741
-msgid "Screen"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:580
-msgid "Security"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:219
-#, c-format
-msgid "Security method: %s"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Win32PixelBuffer.cxx:83
-msgid "SelectObject failed"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1075
-#, c-format
-msgid "Send %s"
-msgstr "Wyślij %s"
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1080
-msgid "Send Ctrl-Alt-Del"
-msgstr "Wyślij Ctrl-Alt-Del"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:710
-msgid "Send clipboard to server"
-msgstr "Wyślij schowek do serwera"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:716
-#, fuzzy
-msgid "Send primary selection and cut buffer as clipboard"
-msgstr "Wyślij główny wybór i bufor wycinania jako schowek"
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:237
-msgid "Services"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:319
-#, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:799
-msgid "Shared (don't disconnect other viewers)"
-msgstr "Współdzielone (nie rozłączaj inne przeglądarki)"
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:239
-msgid "Show All"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:805
-msgid "Show dot when no cursor"
-msgstr "Wyświetl kropkę, kiedy nie ma kursora"
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:182
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:665
-msgid "Standard VNC (insecure without encryption)"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:618
-msgid "TLS with X509 certificates"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:612
-msgid "TLS with anonymous certificates"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:448
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:497
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:561
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:701
+#: vncviewer/CConn.cxx:166
 #, c-format
-msgid "The parameterArray contains a object of a invalid type at line %d."
+msgid "Pixel format: %s"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:664
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:680
+#: vncviewer/CConn.cxx:169
 #, c-format
-msgid "The value of the parameter %s on line %d in file %s is invalid."
+msgid "Requested encoding: %s"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:539
+#: vncviewer/CConn.cxx:173
+#, c-format
+msgid "Last used encoding: %s"
+msgstr ""
+
+#: vncviewer/CConn.cxx:177
+#, c-format
+msgid "Line speed estimate: %d kbit/s"
+msgstr ""
+
+#: vncviewer/CConn.cxx:181
+#, c-format
+msgid "Protocol version: %d.%d"
+msgstr ""
+
+#: vncviewer/CConn.cxx:185
+#, c-format
+msgid "Security method: %s"
+msgstr ""
+
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
+msgstr ""
+
+#: vncviewer/CConn.cxx:258
+#, c-format
+msgid "Authentication failed: %s"
+msgstr ""
+
+#: vncviewer/CConn.cxx:259
+#, c-format
+msgid ""
+"Failed to authenticate with the server. Reason given by the server:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:561
+#: vncviewer/CConn.cxx:521
 #, c-format
-msgid "Throughput %d kbit/s - full color is now %s"
+msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:210
-#, fuzzy
-msgid "TigerVNC Viewer"
-msgstr "O Przeglądarce VNC"
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:80
-#, fuzzy, c-format
-msgid ""
-"TigerVNC Viewer %d-bit v%s\n"
-"Built on: %s\n"
-"Copyright (C) 1999-%d TigerVNC Team and many others (see README.txt)\n"
-"See http://www.tigervnc.org for information on TigerVNC."
-msgstr ""
-"Przeglądarka TigerVNC %d-bit wersja %s (%s)\n"
-"%s\n"
-"Copyright (C) 1999-2011 TigerVNC Team and many others (see README.txt)\n"
-"Zobacz http://www.tigervnc.org, aby dowiedzieć się więcej o TigerVNC."
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1004
+#: vncviewer/CConn.cxx:524
 #, c-format
-msgid "Unknown FLTK key code %d (0x%04x)"
+msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:878
-#, c-format
-msgid "Unknown decimal separator: '%s'"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/parameters.cxx:271
-#, c-format
-msgid "Unknown escape sequence at character %d"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:430
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:437
-msgid "Unknown rect encoding"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:429
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:436
-#, c-format
-msgid "Unknown rect encoding %d"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:671
-msgid "Username and password (insecure without encryption)"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/UserDialog.cxx:99
-msgid "Username:"
-msgstr "Nazwa użytkownika:"
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:573
-#, c-format
-msgid "Using %s encoding"
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/X11PixelBuffer.cxx:80
-#, c-format
-msgid "Using default colormap and visual, %sdepth %d."
-msgstr ""
-
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:620
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/ServerDialog.cxx:42
-msgid "VNC Viewer: Connection Details"
-msgstr "Przeglądarka VNC: szczegóły połączenia"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:57
-msgid "VNC Viewer: Connection Options"
-msgstr "Przeglądarka VNC: opcje połączenia"
-
-#: /home/ossman/devel/tigervnc/vncviewer/UserDialog.cxx:86
-#: /home/ossman/devel/tigervnc/vncviewer/UserDialog.cxx:96
-msgid "VNC authentication"
-msgstr "Uwierzytelnianie VNC"
-
-#: /home/ossman/devel/tigervnc/vncviewer/Viewport.cxx:1176
-msgid "VNC connection info"
-msgstr "Informacje o połączeniu VNC"
-
-#: /home/ossman/devel/tigervnc/vncviewer/ServerDialog.cxx:49
-#: /home/ossman/devel/tigervnc/vncviewer/ServerDialog.cxx:54
-msgid "VNC server:"
-msgstr "Serwer VNC:"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:533
-msgid "Very low (8 colors)"
-msgstr "Bardzo niski (8 kolorów)"
-
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:698
-#, fuzzy
-msgid "View only (ignore mouse and keyboard)"
-msgstr "Tylko wyświetlaj (ignoruj mysz i klawiaturę)"
-
-#: /home/ossman/devel/tigervnc/vncviewer/vncviewer.cxx:219
-msgid "Yes"
+#: vncviewer/DesktopWindow.cxx:146
+msgid "Invalid geometry specified!"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:111
+#: vncviewer/DesktopWindow.cxx:167
+msgid "Reducing window size to fit on current monitor"
+msgstr ""
+
+#: vncviewer/DesktopWindow.cxx:681
+msgid "Adjusting window size to avoid accidental full-screen request"
+msgstr ""
+
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
-msgid "connected to host %s port %d"
+msgid "Press %s to open the context menu"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:563
-msgid "disabled"
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
+msgid "Failure grabbing keyboard"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/CConn.cxx:563
-msgid "enabled"
+#: vncviewer/DesktopWindow.cxx:1427
+msgid "Invalid screen layout computed for resize request!"
 msgstr ""
 
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:556
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
+msgid "Invalid state for 3 button emulation"
+msgstr ""
+
+#: vncviewer/KeyboardWin32.cxx:243
+#, c-format
+msgid "No scan code for extended virtual key 0x%02x"
+msgstr ""
+
+#: vncviewer/KeyboardWin32.cxx:245
+#, c-format
+msgid "No scan code for virtual key 0x%02x"
+msgstr ""
+
+#: vncviewer/KeyboardWin32.cxx:251
+#, c-format
+msgid "Invalid scan code 0x%02x"
+msgstr ""
+
+#: vncviewer/KeyboardWin32.cxx:263
+#, c-format
+msgid "No symbol for extended virtual key 0x%02x"
+msgstr ""
+
+#: vncviewer/KeyboardWin32.cxx:265
+#, c-format
+msgid "No symbol for virtual key 0x%02x"
+msgstr ""
+
+#: vncviewer/KeyboardWin32.cxx:424
+#, c-format
+msgid "Failed to update keyboard LED state: %lu"
+msgstr ""
+
+#: vncviewer/KeyboardX11.cxx:123
+#, c-format
+msgid "No symbol for key code %d (in the current state)"
+msgstr ""
+
+#: vncviewer/KeyboardX11.cxx:148
+#, c-format
+msgid "Failed to get keyboard LED state: %d"
+msgstr ""
+
+#: vncviewer/KeyboardX11.cxx:193
+msgid "Failed to update keyboard LED state"
+msgstr ""
+
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
+msgid "Failed to get system monitor configuration"
+msgstr ""
+
+#: vncviewer/MonitorIndicesParameter.cxx:73
+#, c-format
+msgid "Monitor index %d does not exist"
+msgstr ""
+
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
+msgid "TigerVNC options"
+msgstr ""
+
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
+msgid "Cancel"
+msgstr "Anuluj"
+
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
+msgid "OK"
+msgstr "OK"
+
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 #, fuzzy
-msgid "level (1=fast, 6=best [4-6 are rarely useful])"
-msgstr "poziom (1=szybki, 9=najlepszy)"
+msgid "Compression"
+msgstr "Własny poziom kompresji:"
 
-#: /home/ossman/devel/tigervnc/vncviewer/OptionsDialog.cxx:569
+#: vncviewer/OptionsDialog.cxx:524
+msgid "Auto select"
+msgstr "Automatyczne wykrywanie"
+
+#: vncviewer/OptionsDialog.cxx:536
+msgid "Preferred encoding"
+msgstr ""
+
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
+msgid "Color level"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:611
+msgid "Full"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:619
+msgid "Medium"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:627
+msgid "Low"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:635
+msgid "Very low"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:658
+msgid "Custom compression level:"
+msgstr "Własny poziom kompresji:"
+
+#: vncviewer/OptionsDialog.cxx:666
+msgid "level (0=fast, 9=best)"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:674
+msgid "Allow JPEG compression:"
+msgstr "Zezwolenie na kompresję JPEG:"
+
+#: vncviewer/OptionsDialog.cxx:682
 #, fuzzy
 msgid "quality (0=poor, 9=best)"
 msgstr "jakość (1=słaba, 9=najlepsza)"
 
-#: /home/ossman/devel/tigervnc/vncviewer/Win32PixelBuffer.cxx:63
-msgid "unable to create DIB section"
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
+msgid "Security"
 msgstr ""
+
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
+msgid "Encryption"
+msgstr ""
+
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
+msgid "None"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:730
+msgid "TLS with anonymous certificates"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:737
+msgid "TLS with X509 certificates"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:745
+msgid "Path to X509 CA certificate"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:753
+msgid "Path to X509 CRL file"
+msgstr ""
+
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
+#, fuzzy
+msgid "Authentication"
+msgstr "Uwierzytelnianie VNC"
+
+#: vncviewer/OptionsDialog.cxx:802
+msgid "Standard VNC (insecure without encryption)"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:809
+msgid "Username and password (insecure without encryption)"
+msgstr ""
+
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
+#, fuzzy
+msgid "Input"
+msgstr "Wejścia:"
+
+#: vncviewer/OptionsDialog.cxx:852
+#, fuzzy
+msgid "View only (ignore mouse and keyboard)"
+msgstr "Tylko wyświetlaj (ignoruj mysz i klawiaturę)"
+
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
+msgid "Mouse"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:873
+msgid "Emulate middle mouse button"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:880
+msgid "Show local cursor when not provided by server"
+msgstr ""
+
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
+msgid "Cursor type"
+msgstr ""
+
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
+msgid "Dot"
+msgstr ""
+
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
+msgid "System"
+msgstr ""
+
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
+msgid "Keyboard"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:925
+msgid "Pass system keys directly to server (full screen)"
+msgstr ""
+
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
+msgid "Menu key"
+msgstr ""
+
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
+msgid "Clipboard"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:968
+msgid "Accept clipboard from server"
+msgstr "Akceptuj schowek z serwera"
+
+#: vncviewer/OptionsDialog.cxx:977
+msgid "Also set primary selection"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:985
+msgid "Send clipboard to server"
+msgstr "Wyślij schowek do serwera"
+
+#: vncviewer/OptionsDialog.cxx:994
+msgid "Send primary selection as clipboard"
+msgstr ""
+
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
+msgid "Display"
+msgstr ""
+
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
+msgid "Display mode"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1045
+msgid "Windowed"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1054
+msgid "Full screen on current monitor"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1063
+msgid "Full screen on all monitors"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1072
+msgid "Full screen on selected monitor(s)"
+msgstr ""
+
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
+msgid "Miscellaneous"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1111
+msgid "Shared (don't disconnect other viewers)"
+msgstr "Współdzielone (nie rozłączaj inne przeglądarki)"
+
+#: vncviewer/OptionsDialog.cxx:1118
+msgid "Ask to reconnect on connection errors"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:73
+msgid "VNC server:"
+msgstr "Serwer VNC:"
+
+#: vncviewer/ServerDialog.cxx:80
+msgid "Options..."
+msgstr "Opcje..."
+
+#: vncviewer/ServerDialog.cxx:84
+msgid "Load..."
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:88
+msgid "Save as..."
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:102
+msgid "About..."
+msgstr "O programie..."
+
+#: vncviewer/ServerDialog.cxx:111
+msgid "Connect"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:147
+#, c-format
+msgid ""
+"Unable to load the server history:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:176 vncviewer/ServerDialog.cxx:216
+msgid "TigerVNC configuration (*.tigervnc)"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:177
+msgid "Select a TigerVNC configuration file"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
+#, c-format
+msgid ""
+"Unable to load the specified configuration file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:217
+msgid "Save the TigerVNC configuration to file"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:243
+#, c-format
+msgid "%s already exists. Do you want to overwrite?"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
+msgid "No"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:244
+msgid "Overwrite"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:260
+#, c-format
+msgid ""
+"Unable to save the specified configuration file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:294
+#, c-format
+msgid ""
+"Unable to save the default configuration:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:306
+#, c-format
+msgid ""
+"Unable to save the server history:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
+msgid "Could not determine VNC state directory path"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
+#, c-format
+msgid "Could not open \"%s\""
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
+#, c-format
+msgid "Failed to read line %d in file \"%s\""
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
+msgid "Line too long"
+msgstr ""
+
+#: vncviewer/UserDialog.cxx:130
+msgid "Opening password file failed"
+msgstr ""
+
+#: vncviewer/UserDialog.cxx:150
+msgid "VNC authentication"
+msgstr "Uwierzytelnianie VNC"
+
+#: vncviewer/UserDialog.cxx:157
+msgid "This connection is secure"
+msgstr ""
+
+#: vncviewer/UserDialog.cxx:161
+msgid "This connection is not secure"
+msgstr ""
+
+#: vncviewer/UserDialog.cxx:183
+msgid "Username:"
+msgstr "Nazwa użytkownika:"
+
+#: vncviewer/UserDialog.cxx:196
+msgid "Password:"
+msgstr "Hasło:"
+
+#: vncviewer/UserDialog.cxx:204
+msgid "Keep password for reconnect"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:749
+msgctxt "ContextMenu|"
+msgid "Disconn&ect"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:752
+msgctxt "ContextMenu|"
+msgid "&Full screen"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:755
+msgctxt "ContextMenu|"
+msgid "Minimi&ze"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:757
+msgctxt "ContextMenu|"
+msgid "Resize &window to session"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:762
+msgctxt "ContextMenu|"
+msgid "&Ctrl"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:765
+msgctxt "ContextMenu|"
+msgid "&Alt"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:771
+#, c-format
+msgctxt "ContextMenu|"
+msgid "Send %s"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:779
+msgctxt "ContextMenu|"
+msgid "Send Ctrl-Alt-&Del"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:782
+msgctxt "ContextMenu|"
+msgid "&Refresh screen"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:785
+msgctxt "ContextMenu|"
+msgid "&Options..."
+msgstr ""
+
+#: vncviewer/Viewport.cxx:787
+msgctxt "ContextMenu|"
+msgid "Connection &info..."
+msgstr ""
+
+#: vncviewer/Viewport.cxx:789
+msgctxt "ContextMenu|"
+msgid "About &TigerVNC..."
+msgstr ""
+
+#: vncviewer/Viewport.cxx:885
+msgid "VNC connection info"
+msgstr "Informacje o połączeniu VNC"
+
+#: vncviewer/Win32TouchHandler.cxx:49
+msgid "Window is registered for touch instead of gestures"
+msgstr ""
+
+#: vncviewer/Win32TouchHandler.cxx:84
+#, c-format
+msgid "Failed to set gesture configuration (error 0x%x)"
+msgstr ""
+
+#: vncviewer/Win32TouchHandler.cxx:96
+#, c-format
+msgid "Failed to get gesture information (error 0x%x)"
+msgstr ""
+
+#: vncviewer/Win32TouchHandler.cxx:364
+#, c-format
+msgid "Invalid mouse button %d, must be a number between 1 and 7."
+msgstr ""
+
+#: vncviewer/Win32TouchHandler.cxx:429
+#, c-format
+msgid "Unhandled key 0x%x - can't generate keyboard event."
+msgstr ""
+
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
+#, c-format
+msgid "Unable to get X Input 2 event mask for window 0x%08lx"
+msgstr ""
+
+#: vncviewer/XInputTouchHandler.cxx:105
+#, c-format
+msgid "Window 0x%08lx has no X Input 2 event mask"
+msgstr ""
+
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
+#, c-format
+msgid "Window 0x%08lx has more than one X Input 2 event mask"
+msgstr ""
+
+#: vncviewer/XInputTouchHandler.cxx:144
+#, c-format
+msgid "Failure grabbing device %i"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
+#: vncviewer/vncviewer.desktop.in.in:5
+msgid "Connect to VNC server and display remote desktop"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
+
+#. developer_name tag deprecated with Appstream 1.0
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
+msgid "The TigerVNC team"
+msgstr ""
+
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
+msgid "The name of the parameter is too large"
+msgstr ""
+
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
+msgid "The parameter is too large"
+msgstr ""
+
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
+msgid "Invalid format or too large value"
+msgstr ""
+
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
+msgid "Failed to create registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
+msgid "Failed to close registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
+#, c-format
+msgid "Failed to save \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
+#, c-format
+msgid "Failed to remove \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
+msgid "Failed to open registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:635
+#, c-format
+msgid "Failed to read server history entry %d: %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
+#, c-format
+msgid "Failed to read parameter \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
+msgid "Could not determine VNC config directory path"
+msgstr ""
+
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
+msgid "Could not encode parameter"
+msgstr ""
+
+#: vncviewer/parameters.cxx:872
+#, c-format
+msgid "Configuration file %s is in an invalid format"
+msgstr ""
+
+#: vncviewer/parameters.cxx:895
+msgid "Invalid format"
+msgstr ""
+
+#: vncviewer/parameters.cxx:939
+msgid "Unknown parameter"
+msgstr ""
+
+#: vncviewer/touch.cxx:75
+#, c-format
+msgid "Got message (0x%x) for an unhandled window"
+msgstr ""
+
+#: vncviewer/touch.cxx:138 vncviewer/touch.cxx:160
+#, c-format
+msgid "Invalid window 0x%08lx specified for pointer grab"
+msgstr ""
+
+#: vncviewer/touch.cxx:183 vncviewer/touch.cxx:184
+#, c-format
+msgid "Failed to create touch handler: %s"
+msgstr ""
+
+#: vncviewer/touch.cxx:188
+#, c-format
+msgid "Couldn't attach event handler to window (error 0x%x)"
+msgstr ""
+
+#: vncviewer/touch.cxx:215
+msgid "Failed to get event data for X Input event"
+msgstr ""
+
+#: vncviewer/touch.cxx:228
+msgid "X Input event for unknown window"
+msgstr ""
+
+#: vncviewer/touch.cxx:254
+msgid "X Input extension not available."
+msgstr ""
+
+#: vncviewer/touch.cxx:261
+msgid "X Input 2 (or newer) is not available."
+msgstr ""
+
+#: vncviewer/touch.cxx:266
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:103
+#, c-format
+msgid ""
+"TigerVNC v%s\n"
+"Built on: %s\n"
+"Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+"See https://www.tigervnc.org for information on TigerVNC."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:157
+#, c-format
+msgid ""
+"An unexpected error occurred when communicating with the server:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:194
+msgid "Internal FLTK error. Exiting."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:213
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"Attempt to reconnect?"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
+#, c-format
+msgid "Error starting new connection: %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:265
+#, c-format
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:394
+msgid "Yes"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:397
+msgid "Close"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:402
+#, fuzzy
+msgid "About"
+msgstr "O programie..."
+
+#: vncviewer/vncviewer.cxx:405
+msgid "Hide"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:408
+msgid "Quit"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:412
+msgid "Services"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:413
+msgid "Hide others"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:414
+msgid "Show all"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:423
+msgctxt "SysMenu|"
+msgid "&File"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:426
+msgctxt "SysMenu|File|"
+msgid "&New Connection"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:449
+#, c-format
+msgid ""
+"\n"
+"Usage: %s [parameters] [host][:displayNum]\n"
+"       %s [parameters] [host][::port]\n"
+"       %s [parameters] [unix socket]\n"
+"       %s [parameters] -listen [port]\n"
+"       %s [parameters] [.tigervnc file]\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:464
+#, c-format
+msgid ""
+"\n"
+"Options:\n"
+"\n"
+"  -display Xdisplay  - Specifies the X display for the viewer window\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
+"                       man page for details.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:471
+#, c-format
+msgid ""
+"\n"
+"Parameters can be turned on with -<param> or off with -<param>=0\n"
+"Parameters which take a value can be specified as -<param> <value>\n"
+"Other valid forms are <param>=<value> -<param>=<value> --<param>=<value>\n"
+"Parameter names are case-insensitive.  The parameters are:\n"
+"\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:556
+#, c-format
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:561
+#, c-format
+msgid "Could not create VNC config directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:567
+msgid "Could not determine VNC data directory path"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:573
+#, c-format
+msgid "Could not create VNC data directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:585
+#, c-format
+msgid "Could not create VNC state directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:704
+#, c-format
+msgid "%s: Unrecognized option '%s'\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
+#, c-format
+msgid "See '%s --help' for more information.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:713
+#, c-format
+msgid "%s: Extra argument '%s'\n"
+msgstr ""
+
+#. TRANSLATORS: "Parameters" are command line arguments, or settings
+#. from a file or the Windows registry.
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
+msgid "Parameters -listen and -via are incompatible"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:764
+msgid "Unable to listen for incoming connections"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:766
+#, c-format
+msgid "Listening on port %d"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:795
+#, c-format
+msgid ""
+"Failure waiting for incoming VNC connection:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:816
+#, c-format
+msgid ""
+"Failure setting up encrypted tunnel:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.desktop.in.in:4
+msgid "Remote desktop viewer"
+msgstr ""
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "O Przeglądarce VNC"
+
+#, fuzzy
+#~ msgid "About TigerVNC viewer..."
+#~ msgstr "O Przeglądarce VNC"
+
+#~ msgid "Alt"
+#~ msgstr "Alt"
+
+#, fuzzy
+#~ msgid "Authentication cancelled"
+#~ msgstr "Uwierzytelnianie VNC"
+
+#~ msgid "Connection info..."
+#~ msgstr "Informacje o połączeniu..."
+
+#~ msgid "Ctrl"
+#~ msgstr "Ctrl"
+
+#~ msgid "Dismiss menu"
+#~ msgstr "Zwolnij menu"
+
+#~ msgid "Exit viewer"
+#~ msgstr "Zakończ przeglądarkę"
+
+#~ msgid "Full (all available colors)"
+#~ msgstr "Pełny (wszystkie dostępne kolory)"
+
+#~ msgid "Full screen"
+#~ msgstr "Pełny ekran"
+
+#~ msgid "Full-screen mode"
+#~ msgstr "Tryb pełnoekranowy"
+
+#~ msgid "Low (64 colors)"
+#~ msgstr "Niski (64 kolory)"
+
+#~ msgid "Medium (256 colors)"
+#~ msgstr "Średni (256 kolorów)"
+
+#, fuzzy
+#~ msgid "Misc."
+#~ msgstr "Różne:"
+
+#~ msgid "Refresh screen"
+#~ msgstr "Odśwież ekran"
+
+#, c-format
+#~ msgid "Send %s"
+#~ msgstr "Wyślij %s"
+
+#~ msgid "Send Ctrl-Alt-Del"
+#~ msgstr "Wyślij Ctrl-Alt-Del"
+
+#, fuzzy
+#~ msgid "Send primary selection and cut buffer as clipboard"
+#~ msgstr "Wyślij główny wybór i bufor wycinania jako schowek"
+
+#~ msgid "Show dot when no cursor"
+#~ msgstr "Wyświetl kropkę, kiedy nie ma kursora"
+
+#, fuzzy
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "O Przeglądarce VNC"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "TigerVNC Viewer %d-bit v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC Team and many others (see README.txt)\n"
+#~ "See http://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "Przeglądarka TigerVNC %d-bit wersja %s (%s)\n"
+#~ "%s\n"
+#~ "Copyright (C) 1999-2011 TigerVNC Team and many others (see README.txt)\n"
+#~ "Zobacz http://www.tigervnc.org, aby dowiedzieć się więcej o TigerVNC."
+
+#~ msgid "VNC Viewer: Connection Details"
+#~ msgstr "Przeglądarka VNC: szczegóły połączenia"
+
+#~ msgid "VNC Viewer: Connection Options"
+#~ msgstr "Przeglądarka VNC: opcje połączenia"
+
+#~ msgid "Very low (8 colors)"
+#~ msgstr "Bardzo niski (8 kolorów)"
+
+#, fuzzy
+#~ msgid "level (1=fast, 6=best [4-6 are rarely useful])"
+#~ msgstr "poziom (1=szybki, 9=najlepszy)"
 
 #~ msgid "About VNCviewer..."
 #~ msgstr "O VNCviewer..."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -6,10 +6,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.9.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2019-10-18 10:14+0200\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2019-10-29 05:03-0200\n"
 "Last-Translator: Rafael Fontenelle <rafaelff@gnome.org>\n"
-"Language-Team: Brazilian Portuguese <ldpbr-translation@lists.sourceforge.net>\n"
+"Language-Team: Brazilian Portuguese <ldpbr-translation@lists.sourceforge."
+"net>\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -18,704 +19,1250 @@ msgstr ""
 "X-Generator: Virtaal 1.0.0-beta1\n"
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 
-#: vncviewer/CConn.cxx:99
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "Conectado ao soquete %s"
 
-#: vncviewer/CConn.cxx:106
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "Conectado ao host %s porta %d"
 
-#: vncviewer/CConn.cxx:157
+#: vncviewer/CConn.cxx:115
+#, c-format
+msgid ""
+"Failed to connect to \"%s\":\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Nome do desktop: %.80s"
 
-#: vncviewer/CConn.cxx:162
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Host: %.80s porta: %d"
 
-#: vncviewer/CConn.cxx:167
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Tamanho: %d x %d"
 
-#: vncviewer/CConn.cxx:175
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Formato de pixel: %s"
 
-#: vncviewer/CConn.cxx:182
-#, c-format
-msgid "(server default %s)"
-msgstr "(padrão do servidor %s)"
-
-#: vncviewer/CConn.cxx:187
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Codificação solicitada: %s"
 
-#: vncviewer/CConn.cxx:192
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Última codificação usada: %s"
 
-#: vncviewer/CConn.cxx:197
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Velocidade estimada da linha: %d kbit/s"
 
-#: vncviewer/CConn.cxx:202
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Versão do protocolo: %d.%d"
 
-#: vncviewer/CConn.cxx:207
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Método de segurança: %s"
 
-#: vncviewer/CConn.cxx:324
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
+msgstr ""
+
+#: vncviewer/CConn.cxx:258
 #, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "SetDesktopSize falhou: %d"
+msgid "Authentication failed: %s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:372
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "SetColourMapEntries inválido do servidor!"
+#: vncviewer/CConn.cxx:259
+#, c-format
+msgid ""
+"Failed to authenticate with the server. Reason given by the server:\n"
+"\n"
+"%s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:480
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Taxa de transferência %d kbit/s - alteração para qualidade %d"
 
-#: vncviewer/CConn.cxx:502
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "Taxa de transferência %d kbit/s - cor total agora habilitado"
 
-#: vncviewer/CConn.cxx:505
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "Taxa de transferência %d kbit/s - cor total agora está desabilitado"
 
-#: vncviewer/CConn.cxx:531
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Usando formato de pixel %s"
 
-#: vncviewer/DesktopWindow.cxx:122
+#: vncviewer/DesktopWindow.cxx:146
 msgid "Invalid geometry specified!"
 msgstr "Geometria inválida especificada!"
 
-#: vncviewer/DesktopWindow.cxx:495
-msgid "Adjusting window size to avoid accidental full screen request"
-msgstr "Ajustando tamanho de janela para evitar solicitação de tela cheia acidental"
+#: vncviewer/DesktopWindow.cxx:167
+msgid "Reducing window size to fit on current monitor"
+msgstr ""
 
-#: vncviewer/DesktopWindow.cxx:539
+#: vncviewer/DesktopWindow.cxx:681
+msgid "Adjusting window size to avoid accidental full-screen request"
+msgstr ""
+
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Pressione %s para abrir o menu de contexto"
 
-#: vncviewer/DesktopWindow.cxx:836 vncviewer/DesktopWindow.cxx:844
-#: vncviewer/DesktopWindow.cxx:864
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Falha ao se conectar com o teclado"
 
-#: vncviewer/DesktopWindow.cxx:938
-msgid "Failure grabbing mouse"
-msgstr "Falha ao se conectar com o mouse"
-
-#: vncviewer/DesktopWindow.cxx:1162
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
-msgstr "Layout de tela inválida computada para solicitação de redimensionamento!"
+msgstr ""
+"Layout de tela inválida computada para solicitação de redimensionamento!"
 
-#: vncviewer/OptionsDialog.cxx:57
-msgid "VNC Viewer: Connection Options"
-msgstr "Visualizador VNC: Opções da conexão"
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
+msgid "Invalid state for 3 button emulation"
+msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:83 vncviewer/ServerDialog.cxx:91
-#: vncviewer/vncviewer.cxx:282
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: vncviewer/OptionsDialog.cxx:88 vncviewer/vncviewer.cxx:281
-msgid "OK"
-msgstr "OK"
-
-#: vncviewer/OptionsDialog.cxx:423
-msgid "Compression"
-msgstr "Compressão"
-
-#: vncviewer/OptionsDialog.cxx:439
-msgid "Auto select"
-msgstr "Seleção automática"
-
-#: vncviewer/OptionsDialog.cxx:451
-msgid "Preferred encoding"
-msgstr "Codificação preferida"
-
-#: vncviewer/OptionsDialog.cxx:499
-msgid "Color level"
-msgstr "Profundidade de cores"
-
-#: vncviewer/OptionsDialog.cxx:510
-msgid "Full (all available colors)"
-msgstr "Completo (todas as cores)"
-
-#: vncviewer/OptionsDialog.cxx:517
-msgid "Medium (256 colors)"
-msgstr "Médio (256 cores)"
-
-#: vncviewer/OptionsDialog.cxx:524
-msgid "Low (64 colors)"
-msgstr "Baixo (64 cores)"
-
-#: vncviewer/OptionsDialog.cxx:531
-msgid "Very low (8 colors)"
-msgstr "Muito baixo (8 cores)"
-
-#: vncviewer/OptionsDialog.cxx:548
-msgid "Custom compression level:"
-msgstr "Compressão personalizada:"
-
-#: vncviewer/OptionsDialog.cxx:554
-msgid "level (1=fast, 6=best [4-6 are rarely useful])"
-msgstr "nível (1=rápido, 6=o melhor [4-6 raramente úteis])"
-
-#: vncviewer/OptionsDialog.cxx:561
-msgid "Allow JPEG compression:"
-msgstr "Permite compressão JPEG:"
-
-#: vncviewer/OptionsDialog.cxx:567
-msgid "quality (0=poor, 9=best)"
-msgstr "qualidade (0=ruim, 9=o melhor)"
-
-#: vncviewer/OptionsDialog.cxx:578
-msgid "Security"
-msgstr "Segurança"
-
-#: vncviewer/OptionsDialog.cxx:593
-msgid "Encryption"
-msgstr "Criptografia"
-
-#: vncviewer/OptionsDialog.cxx:604 vncviewer/OptionsDialog.cxx:657
-#: vncviewer/OptionsDialog.cxx:737
-msgid "None"
-msgstr "Nenhum"
-
-#: vncviewer/OptionsDialog.cxx:610
-msgid "TLS with anonymous certificates"
-msgstr "TLS com certificados anônimos"
-
-#: vncviewer/OptionsDialog.cxx:616
-msgid "TLS with X509 certificates"
-msgstr "TLS com certificados X509"
-
-# AC = Autoridade Certificadora
-#: vncviewer/OptionsDialog.cxx:623
-msgid "Path to X509 CA certificate"
-msgstr "Caminho para o certificado X509 de AC"
-
-#: vncviewer/OptionsDialog.cxx:630
-msgid "Path to X509 CRL file"
-msgstr "Caminho para o arquivo X509 de CRL"
-
-#: vncviewer/OptionsDialog.cxx:646
-msgid "Authentication"
-msgstr "Autenticação"
-
-#: vncviewer/OptionsDialog.cxx:663
-msgid "Standard VNC (insecure without encryption)"
-msgstr "VNC padrão (inseguro sem criptografia)"
-
-#: vncviewer/OptionsDialog.cxx:669
-msgid "Username and password (insecure without encryption)"
-msgstr "Usuário e senha (inseguro sem criptografia)"
-
-#: vncviewer/OptionsDialog.cxx:688
-msgid "Input"
-msgstr "Entrada"
-
-#: vncviewer/OptionsDialog.cxx:696
-msgid "View only (ignore mouse and keyboard)"
-msgstr "Visualizar apenas (ignora mouse e teclado)"
-
-#: vncviewer/OptionsDialog.cxx:702
-msgid "Accept clipboard from server"
-msgstr "Aceitar área de transferência do servidor"
-
-#: vncviewer/OptionsDialog.cxx:710
-msgid "Also set primary selection"
-msgstr "Também enviar seleção primária"
-
-#: vncviewer/OptionsDialog.cxx:717
-msgid "Send clipboard to server"
-msgstr "Enviar área de transferência para o servidor"
-
-#: vncviewer/OptionsDialog.cxx:725
-msgid "Send primary selection as clipboard"
-msgstr "Enviar seleção primária como área de transferência"
-
-#: vncviewer/OptionsDialog.cxx:732
-msgid "Pass system keys directly to server (full screen)"
-msgstr "Passar teclas de sistema diretamente para o servidor (tela cheia)"
-
-#: vncviewer/OptionsDialog.cxx:735
-msgid "Menu key"
-msgstr "Tecla de menu"
-
-#: vncviewer/OptionsDialog.cxx:751
-msgid "Screen"
-msgstr "Tela"
-
-#: vncviewer/OptionsDialog.cxx:759
-msgid "Resize remote session on connect"
-msgstr "Redimensionar a sessão remota ao conectar"
-
-#: vncviewer/OptionsDialog.cxx:772
-msgid "Resize remote session to the local window"
-msgstr "Redimensionar a sessão remota para a janela local"
-
-#: vncviewer/OptionsDialog.cxx:778
-msgid "Full-screen mode"
-msgstr "Modo tela cheia"
-
-#: vncviewer/OptionsDialog.cxx:784
-msgid "Enable full-screen mode over all monitors"
-msgstr "Ativar o modo de tela cheia em todos os monitores"
-
-#: vncviewer/OptionsDialog.cxx:793
-msgid "Misc."
-msgstr "Diversos"
-
-#: vncviewer/OptionsDialog.cxx:801
-msgid "Shared (don't disconnect other viewers)"
-msgstr "Compartilhado (não desconecta outros visualizadores)"
-
-#: vncviewer/OptionsDialog.cxx:807
-msgid "Show dot when no cursor"
-msgstr "Mostrar ponto quando estiver sem mouse"
-
-#: vncviewer/ServerDialog.cxx:42
-msgid "VNC Viewer: Connection Details"
-msgstr "Visualizador VNC: Detalhes da conexão"
-
-#: vncviewer/ServerDialog.cxx:49 vncviewer/ServerDialog.cxx:54
-msgid "VNC server:"
-msgstr "Servidor VNC:"
-
-#: vncviewer/ServerDialog.cxx:64
-msgid "Options..."
-msgstr "Opções..."
-
-#: vncviewer/ServerDialog.cxx:69
-msgid "Load..."
-msgstr "Carregar..."
-
-#: vncviewer/ServerDialog.cxx:74
-msgid "Save As..."
-msgstr "Salvar como..."
-
-#: vncviewer/ServerDialog.cxx:86
-msgid "About..."
-msgstr "Sobre..."
-
-#: vncviewer/ServerDialog.cxx:96
-msgid "Connect"
-msgstr "Conectar"
-
-#: vncviewer/ServerDialog.cxx:137 vncviewer/ServerDialog.cxx:171
-msgid "TigerVNC configuration (*.tigervnc)"
-msgstr "Configuração do TigerVNC (*.tigervnc)"
-
-#: vncviewer/ServerDialog.cxx:138
-msgid "Select a TigerVNC configuration file"
-msgstr "Selecionar um arquivo de configuração do TigerVNC"
-
-#: vncviewer/ServerDialog.cxx:172
-msgid "Save the TigerVNC configuration to file"
-msgstr "Salvar a configuração do TigerVNC para arquivo"
-
-#: vncviewer/ServerDialog.cxx:197
-#, c-format
-msgid "%s already exists. Do you want to overwrite?"
-msgstr "%s já existe. Você deseja sobrescrevê-lo?"
-
-#: vncviewer/ServerDialog.cxx:198 vncviewer/vncviewer.cxx:279
-msgid "No"
-msgstr "Não"
-
-#: vncviewer/ServerDialog.cxx:198
-msgid "Overwrite"
-msgstr "Sobrescrever"
-
-#: vncviewer/UserDialog.cxx:85
-msgid "Opening password file failed"
-msgstr "A abertura do arquivo de senha falhou"
-
-#: vncviewer/UserDialog.cxx:105
-msgid "VNC authentication"
-msgstr "Autenticação VNC"
-
-#: vncviewer/UserDialog.cxx:112
-msgid "This connection is secure"
-msgstr "Essa conexão é segura"
-
-#: vncviewer/UserDialog.cxx:116
-msgid "This connection is not secure"
-msgstr "Essa conexão não é segura"
-
-#: vncviewer/UserDialog.cxx:133
-msgid "Username:"
-msgstr "Nome de usuário:"
-
-#: vncviewer/UserDialog.cxx:146
-msgid "Password:"
-msgstr "Senha:"
-
-#: vncviewer/UserDialog.cxx:185
-msgid "Authentication cancelled"
-msgstr "Autenticação cancelada"
-
-#: vncviewer/Viewport.cxx:389
-#, c-format
-msgid "Failed to update keyboard LED state: %lu"
-msgstr "Falha ao atualizar estado do LED do teclado: %lu"
-
-#: vncviewer/Viewport.cxx:395 vncviewer/Viewport.cxx:401
-#, c-format
-msgid "Failed to update keyboard LED state: %d"
-msgstr "Falha ao atualizar estado do LED do teclado: %d"
-
-#: vncviewer/Viewport.cxx:431
-msgid "Failed to update keyboard LED state"
-msgstr "Falha ao atualizar estado do LED do teclado"
-
-#: vncviewer/Viewport.cxx:458 vncviewer/Viewport.cxx:466
-#: vncviewer/Viewport.cxx:483
-#, c-format
-msgid "Failed to get keyboard LED state: %d"
-msgstr "Falha ao obter estado do LED do teclado: %d"
-
-#: vncviewer/Viewport.cxx:833
-msgid "No key code specified on key press"
-msgstr "Nenhum código de tecla especificado no pressionamento de tecla"
-
-#: vncviewer/Viewport.cxx:982
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "Nenhum código de scan para a tecla virtual estendida 0x%02x"
 
-#: vncviewer/Viewport.cxx:984
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "Nenhum código de scan para a tecla virtual 0x%02x"
 
-#: vncviewer/Viewport.cxx:990
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "código de scan inválido 0x%02x"
 
-#: vncviewer/Viewport.cxx:1020
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "Nenhum símbolo para a tecla virtual estendida 0x%02x"
 
-#: vncviewer/Viewport.cxx:1022
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "Nenhum símbolo para a tecla virtual 0x%02x"
 
-#: vncviewer/Viewport.cxx:1115
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
-msgid "No symbol for key code 0x%02x (in the current state)"
-msgstr "Nenhum símbolo para a tecla virtual 0x%02x (no estado atual)"
+msgid "Failed to update keyboard LED state: %lu"
+msgstr "Falha ao atualizar estado do LED do teclado: %lu"
 
-#: vncviewer/Viewport.cxx:1148
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "Nenhum símbolo para a tecla virtual %d (no estado atual)"
 
-#: vncviewer/Viewport.cxx:1199
-msgctxt "ContextMenu|"
-msgid "E&xit viewer"
-msgstr "&Sair do visualizador"
+#: vncviewer/KeyboardX11.cxx:148
+#, c-format
+msgid "Failed to get keyboard LED state: %d"
+msgstr "Falha ao obter estado do LED do teclado: %d"
 
-#: vncviewer/Viewport.cxx:1202
+#: vncviewer/KeyboardX11.cxx:193
+msgid "Failed to update keyboard LED state"
+msgstr "Falha ao atualizar estado do LED do teclado"
+
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
+msgid "Failed to get system monitor configuration"
+msgstr ""
+
+#: vncviewer/MonitorIndicesParameter.cxx:73
+#, c-format
+msgid "Monitor index %d does not exist"
+msgstr ""
+
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
+msgid "TigerVNC options"
+msgstr ""
+
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
+msgid "OK"
+msgstr "OK"
+
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
+msgid "Compression"
+msgstr "Compressão"
+
+#: vncviewer/OptionsDialog.cxx:524
+msgid "Auto select"
+msgstr "Seleção automática"
+
+#: vncviewer/OptionsDialog.cxx:536
+msgid "Preferred encoding"
+msgstr "Codificação preferida"
+
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
+msgid "Color level"
+msgstr "Profundidade de cores"
+
+#: vncviewer/OptionsDialog.cxx:611
+msgid "Full"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:619
+msgid "Medium"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:627
+msgid "Low"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:635
+msgid "Very low"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:658
+msgid "Custom compression level:"
+msgstr "Compressão personalizada:"
+
+#: vncviewer/OptionsDialog.cxx:666
+msgid "level (0=fast, 9=best)"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:674
+msgid "Allow JPEG compression:"
+msgstr "Permite compressão JPEG:"
+
+#: vncviewer/OptionsDialog.cxx:682
+msgid "quality (0=poor, 9=best)"
+msgstr "qualidade (0=ruim, 9=o melhor)"
+
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
+msgid "Security"
+msgstr "Segurança"
+
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
+msgid "Encryption"
+msgstr "Criptografia"
+
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
+msgid "None"
+msgstr "Nenhum"
+
+#: vncviewer/OptionsDialog.cxx:730
+msgid "TLS with anonymous certificates"
+msgstr "TLS com certificados anônimos"
+
+#: vncviewer/OptionsDialog.cxx:737
+msgid "TLS with X509 certificates"
+msgstr "TLS com certificados X509"
+
+# AC = Autoridade Certificadora
+#: vncviewer/OptionsDialog.cxx:745
+msgid "Path to X509 CA certificate"
+msgstr "Caminho para o certificado X509 de AC"
+
+#: vncviewer/OptionsDialog.cxx:753
+msgid "Path to X509 CRL file"
+msgstr "Caminho para o arquivo X509 de CRL"
+
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
+msgid "Authentication"
+msgstr "Autenticação"
+
+#: vncviewer/OptionsDialog.cxx:802
+msgid "Standard VNC (insecure without encryption)"
+msgstr "VNC padrão (inseguro sem criptografia)"
+
+#: vncviewer/OptionsDialog.cxx:809
+msgid "Username and password (insecure without encryption)"
+msgstr "Usuário e senha (inseguro sem criptografia)"
+
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
+msgid "Input"
+msgstr "Entrada"
+
+#: vncviewer/OptionsDialog.cxx:852
+msgid "View only (ignore mouse and keyboard)"
+msgstr "Visualizar apenas (ignora mouse e teclado)"
+
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
+msgid "Mouse"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:873
+msgid "Emulate middle mouse button"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:880
+msgid "Show local cursor when not provided by server"
+msgstr ""
+
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
+msgid "Cursor type"
+msgstr ""
+
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
+msgid "Dot"
+msgstr ""
+
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
+msgid "System"
+msgstr ""
+
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
+msgid "Keyboard"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:925
+msgid "Pass system keys directly to server (full screen)"
+msgstr "Passar teclas de sistema diretamente para o servidor (tela cheia)"
+
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
+msgid "Menu key"
+msgstr "Tecla de menu"
+
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
+msgid "Clipboard"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:968
+msgid "Accept clipboard from server"
+msgstr "Aceitar área de transferência do servidor"
+
+#: vncviewer/OptionsDialog.cxx:977
+msgid "Also set primary selection"
+msgstr "Também enviar seleção primária"
+
+#: vncviewer/OptionsDialog.cxx:985
+msgid "Send clipboard to server"
+msgstr "Enviar área de transferência para o servidor"
+
+#: vncviewer/OptionsDialog.cxx:994
+msgid "Send primary selection as clipboard"
+msgstr "Enviar seleção primária como área de transferência"
+
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
+msgid "Display"
+msgstr ""
+
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
+msgid "Display mode"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1045
+msgid "Windowed"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1054
+msgid "Full screen on current monitor"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1063
+msgid "Full screen on all monitors"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1072
+msgid "Full screen on selected monitor(s)"
+msgstr ""
+
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
+msgid "Miscellaneous"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1111
+msgid "Shared (don't disconnect other viewers)"
+msgstr "Compartilhado (não desconecta outros visualizadores)"
+
+#: vncviewer/OptionsDialog.cxx:1118
+msgid "Ask to reconnect on connection errors"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:73
+msgid "VNC server:"
+msgstr "Servidor VNC:"
+
+#: vncviewer/ServerDialog.cxx:80
+msgid "Options..."
+msgstr "Opções..."
+
+#: vncviewer/ServerDialog.cxx:84
+msgid "Load..."
+msgstr "Carregar..."
+
+#: vncviewer/ServerDialog.cxx:88
+msgid "Save as..."
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:102
+msgid "About..."
+msgstr "Sobre..."
+
+#: vncviewer/ServerDialog.cxx:111
+msgid "Connect"
+msgstr "Conectar"
+
+#: vncviewer/ServerDialog.cxx:147
+#, c-format
+msgid ""
+"Unable to load the server history:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:176 vncviewer/ServerDialog.cxx:216
+msgid "TigerVNC configuration (*.tigervnc)"
+msgstr "Configuração do TigerVNC (*.tigervnc)"
+
+#: vncviewer/ServerDialog.cxx:177
+msgid "Select a TigerVNC configuration file"
+msgstr "Selecionar um arquivo de configuração do TigerVNC"
+
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
+#, c-format
+msgid ""
+"Unable to load the specified configuration file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:217
+msgid "Save the TigerVNC configuration to file"
+msgstr "Salvar a configuração do TigerVNC para arquivo"
+
+#: vncviewer/ServerDialog.cxx:243
+#, c-format
+msgid "%s already exists. Do you want to overwrite?"
+msgstr "%s já existe. Você deseja sobrescrevê-lo?"
+
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
+msgid "No"
+msgstr "Não"
+
+#: vncviewer/ServerDialog.cxx:244
+msgid "Overwrite"
+msgstr "Sobrescrever"
+
+#: vncviewer/ServerDialog.cxx:260
+#, c-format
+msgid ""
+"Unable to save the specified configuration file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:294
+#, c-format
+msgid ""
+"Unable to save the default configuration:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:306
+#, c-format
+msgid ""
+"Unable to save the server history:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
+msgid "Could not determine VNC state directory path"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
+#, c-format
+msgid "Could not open \"%s\""
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
+#, c-format
+msgid "Failed to read line %d in file \"%s\""
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
+msgid "Line too long"
+msgstr "Linha longa demais"
+
+#: vncviewer/UserDialog.cxx:130
+msgid "Opening password file failed"
+msgstr "A abertura do arquivo de senha falhou"
+
+#: vncviewer/UserDialog.cxx:150
+msgid "VNC authentication"
+msgstr "Autenticação VNC"
+
+#: vncviewer/UserDialog.cxx:157
+msgid "This connection is secure"
+msgstr "Essa conexão é segura"
+
+#: vncviewer/UserDialog.cxx:161
+msgid "This connection is not secure"
+msgstr "Essa conexão não é segura"
+
+#: vncviewer/UserDialog.cxx:183
+msgid "Username:"
+msgstr "Nome de usuário:"
+
+#: vncviewer/UserDialog.cxx:196
+msgid "Password:"
+msgstr "Senha:"
+
+#: vncviewer/UserDialog.cxx:204
+msgid "Keep password for reconnect"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:749
+msgctxt "ContextMenu|"
+msgid "Disconn&ect"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "&Tela cheia"
 
-#: vncviewer/Viewport.cxx:1205
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "Minimi&zar"
 
-#: vncviewer/Viewport.cxx:1207
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "Redimensionar a &janela para a sessão"
 
-#: vncviewer/Viewport.cxx:1212
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:1215
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:1221
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "Enviar %s"
 
-#: vncviewer/Viewport.cxx:1227
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Enviar Ctrl-Alt-&Del"
 
-#: vncviewer/Viewport.cxx:1230
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "&Atualizar tela"
 
-#: vncviewer/Viewport.cxx:1233
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&Opções..."
 
-#: vncviewer/Viewport.cxx:1235
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "&Informação de conexão..."
 
-#: vncviewer/Viewport.cxx:1237
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "Sobre o visualizador &TigerVNC..."
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:1240
-msgctxt "ContextMenu|"
-msgid "Dismiss &menu"
-msgstr "Recusar &menu"
-
-#: vncviewer/Viewport.cxx:1329
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "Informação de conexão VNC..."
 
-#: vncviewer/parameters.cxx:278 vncviewer/parameters.cxx:312
-#, c-format
-msgid "The name of the parameter %s was too large to write to the registry"
-msgstr "O nome do parâmetro %s era grande demais ser escrito no registro"
-
-#: vncviewer/parameters.cxx:284 vncviewer/parameters.cxx:291
-#, c-format
-msgid "The parameter %s was too large to write to the registry"
-msgstr "O parâmetro %s era grande demais para ser escrito no registro"
-
-#: vncviewer/parameters.cxx:297 vncviewer/parameters.cxx:318
-#, c-format
-msgid "Failed to write parameter %s of type %s to the registry: %ld"
-msgstr "Falha ao escrever parâmetro %s do tipo %s no registro: %ld"
-
-#: vncviewer/parameters.cxx:334 vncviewer/parameters.cxx:377
-#, c-format
-msgid "The name of the parameter %s was too large to read from the registry"
-msgstr "O nome do parâmetro %s era grande demais ser lido do registro"
-
-#: vncviewer/parameters.cxx:346 vncviewer/parameters.cxx:386
-#, c-format
-msgid "Failed to read parameter %s from the registry: %ld"
-msgstr "Falha ao ler parâmetro %s do registro: %ld"
-
-#: vncviewer/parameters.cxx:357
-#, c-format
-msgid "The parameter %s was too large to read from the registry"
-msgstr "O parâmetro %s era grande demais para ser lido do registro"
-
-#: vncviewer/parameters.cxx:406
-#, c-format
-msgid "Failed to create registry key: %ld"
-msgstr "Falha ao criar chave de registro: %ld"
-
-#: vncviewer/parameters.cxx:420 vncviewer/parameters.cxx:469
-#: vncviewer/parameters.cxx:532 vncviewer/parameters.cxx:666
-#, c-format
-msgid "Unknown parameter type for parameter %s"
-msgstr "Tipo de parâmetro desconhecido para o parâmetro %s"
-
-#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:476
-#, c-format
-msgid "Failed to close registry key: %ld"
-msgstr "Falha ao fechar chave de registro: %ld"
-
-#: vncviewer/parameters.cxx:443
-#, c-format
-msgid "Failed to open registry key: %ld"
-msgstr "Falha ao abrir chave de registro: %ld"
-
-#: vncviewer/parameters.cxx:500
-msgid "Failed to write configuration file, can't obtain home directory path."
-msgstr "Não foi possível escrever o arquivo de configuração, não foi possível obter o caminho do diretório HOME."
-
-#: vncviewer/parameters.cxx:514
-#, c-format
-msgid "Failed to write configuration file, can't open %s: %s"
-msgstr "Não foi possível escrever o arquivo de configuração, não foi possível abrir %s: %s"
-
-#: vncviewer/parameters.cxx:559
-msgid "Failed to read configuration file, can't obtain home directory path."
-msgstr "Não foi possível ler o arquivo de configuração, não foi possível obter o caminho do diretório HOME."
-
-#: vncviewer/parameters.cxx:573
-#, c-format
-msgid "Failed to read configuration file, can't open %s: %s"
-msgstr "Não foi possível ler o arquivo de configuração, não foi possível abrir %s: %s"
-
-#: vncviewer/parameters.cxx:586 vncviewer/parameters.cxx:591
-#: vncviewer/parameters.cxx:616 vncviewer/parameters.cxx:629
-#: vncviewer/parameters.cxx:645
-#, c-format
-msgid "Failed to read line %d in file %s: %s"
-msgstr "Falha ao ler a linha %d no arquivo %s: %s"
-
-#: vncviewer/parameters.cxx:592
-msgid "Line too long"
-msgstr "Linha longa demais"
-
-#: vncviewer/parameters.cxx:599
-#, c-format
-msgid "Configuration file %s is in an invalid format"
-msgstr "O arquivo de configuração %s está em um formato inválido"
-
-#: vncviewer/parameters.cxx:617
-msgid "Invalid format"
-msgstr "Formato inválido"
-
-#: vncviewer/parameters.cxx:630 vncviewer/parameters.cxx:646
-msgid "Invalid format or too large value"
-msgstr "Formato inválido ou valor grande demais"
-
-#: vncviewer/parameters.cxx:673
-#, c-format
-msgid "Unknown parameter %s on line %d in file %s"
-msgstr "Parâmetro %s desconhecido na linha %d no arquivo %s"
-
-#: vncviewer/vncviewer.cxx:100
-#, c-format
-msgid ""
-"TigerVNC Viewer %d-bit v%s\n"
-"Built on: %s\n"
-"Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
-"See https://www.tigervnc.org for information on TigerVNC."
+#: vncviewer/Win32TouchHandler.cxx:49
+msgid "Window is registered for touch instead of gestures"
 msgstr ""
-"Visualizador TigerVNC %d bits v%s\n"
-"Compilado em: %s\n"
-"Copyright (C) 1999-%d Equipe TigerVNC e muitos outros (veja README.rst)\n"
-"Veja https://www.tigervnc.org para informação sobre o TigerVNC."
 
-#: vncviewer/vncviewer.cxx:127
-msgid "About TigerVNC Viewer"
-msgstr "Sobre o Visualizador TigerVNC"
-
-#: vncviewer/vncviewer.cxx:140
-msgid "Internal FLTK error. Exiting."
-msgstr "Erro interno no FLTK. Saindo."
-
-#: vncviewer/vncviewer.cxx:158 vncviewer/vncviewer.cxx:170
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Erro ao iniciar novo Visualizador TigerVNC: %s"
+msgid "Failed to set gesture configuration (error 0x%x)"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:179
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC Viewer will now exit."
-msgstr "Sinal de terminação %d foi recebido. Visualizador TigerVNC vai fechar agora."
+msgid "Failed to get gesture information (error 0x%x)"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:271 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC Viewer"
-msgstr "Visualizador TigerVNC"
-
-#: vncviewer/vncviewer.cxx:280
-msgid "Yes"
-msgstr "Sim"
-
-#: vncviewer/vncviewer.cxx:283
-msgid "Close"
-msgstr "Fechar"
-
-#: vncviewer/vncviewer.cxx:288
-msgid "About"
-msgstr "Sobre"
-
-#: vncviewer/vncviewer.cxx:291
-msgid "Hide"
-msgstr "Ocultar"
-
-#: vncviewer/vncviewer.cxx:294
-msgid "Quit"
-msgstr "Sair"
-
-#: vncviewer/vncviewer.cxx:298
-msgid "Services"
-msgstr "Serviços"
-
-#: vncviewer/vncviewer.cxx:299
-msgid "Hide Others"
-msgstr "Ocultar Outros"
-
-#: vncviewer/vncviewer.cxx:300
-msgid "Show All"
-msgstr "Exibir Todos"
-
-#: vncviewer/vncviewer.cxx:309
-msgctxt "SysMenu|"
-msgid "&File"
-msgstr "&Arquivo"
-
-#: vncviewer/vncviewer.cxx:312
-msgctxt "SysMenu|File|"
-msgid "&New Connection"
-msgstr "&Nova Conexão"
-
-#: vncviewer/vncviewer.cxx:324
-msgid "Could not create VNC home directory: can't obtain home directory path."
-msgstr "Não foi possível criar o diretório HOME do VNC: não foi possível obter o caminho do diretório HOME."
-
-#: vncviewer/vncviewer.cxx:329
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
-msgid "Could not create VNC home directory: %s."
-msgstr "Não foi possível criar um diretório HOME do VNC: %s."
+msgid "Invalid mouse button %d, must be a number between 1 and 7."
+msgstr ""
 
-#. TRANSLATORS: "Parameters" are command line arguments, or settings
-#. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:602 vncviewer/vncviewer.cxx:604
-msgid "Parameters -listen and -via are incompatible"
-msgstr "Os parâmetros -listen e -via são incompatíveis"
-
-#: vncviewer/vncviewer.cxx:619
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
-msgid "Listening on port %d"
-msgstr "Ouvindo na porta %d"
+msgid "Unhandled key 0x%x - can't generate keyboard event."
+msgstr ""
 
-#: vncviewer/vncviewer.desktop.in.in:4
-msgid "Remote Desktop Viewer"
-msgstr "Visualização de área de trabalho remota"
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
+#, c-format
+msgid "Unable to get X Input 2 event mask for window 0x%08lx"
+msgstr ""
 
+#: vncviewer/XInputTouchHandler.cxx:105
+#, c-format
+msgid "Window 0x%08lx has no X Input 2 event mask"
+msgstr ""
+
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
+#, c-format
+msgid "Window 0x%08lx has more than one X Input 2 event mask"
+msgstr ""
+
+#: vncviewer/XInputTouchHandler.cxx:144
+#, c-format
+msgid "Failure grabbing device %i"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
 msgid "Connect to VNC server and display remote desktop"
 msgstr "Conecte a um servidor VNC e exiba a área de trabalho remota"
 
-#: vncviewer/vncviewer.desktop.in.in:7
-msgid "tigervnc"
-msgstr "tigervnc"
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
+
+#. developer_name tag deprecated with Appstream 1.0
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
+msgid "The TigerVNC team"
+msgstr ""
+
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
+msgid "The name of the parameter is too large"
+msgstr ""
+
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
+msgid "The parameter is too large"
+msgstr ""
+
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
+msgid "Invalid format or too large value"
+msgstr "Formato inválido ou valor grande demais"
+
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
+msgid "Failed to create registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
+msgid "Failed to close registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
+#, c-format
+msgid "Failed to save \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
+#, c-format
+msgid "Failed to remove \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
+msgid "Failed to open registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:635
+#, c-format
+msgid "Failed to read server history entry %d: %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
+#, c-format
+msgid "Failed to read parameter \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
+msgid "Could not determine VNC config directory path"
+msgstr ""
+
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
+msgid "Could not encode parameter"
+msgstr ""
+
+#: vncviewer/parameters.cxx:872
+#, c-format
+msgid "Configuration file %s is in an invalid format"
+msgstr "O arquivo de configuração %s está em um formato inválido"
+
+#: vncviewer/parameters.cxx:895
+msgid "Invalid format"
+msgstr "Formato inválido"
+
+#: vncviewer/parameters.cxx:939
+msgid "Unknown parameter"
+msgstr ""
+
+#: vncviewer/touch.cxx:75
+#, c-format
+msgid "Got message (0x%x) for an unhandled window"
+msgstr ""
+
+#: vncviewer/touch.cxx:138 vncviewer/touch.cxx:160
+#, c-format
+msgid "Invalid window 0x%08lx specified for pointer grab"
+msgstr ""
+
+#: vncviewer/touch.cxx:183 vncviewer/touch.cxx:184
+#, c-format
+msgid "Failed to create touch handler: %s"
+msgstr ""
+
+#: vncviewer/touch.cxx:188
+#, c-format
+msgid "Couldn't attach event handler to window (error 0x%x)"
+msgstr ""
+
+#: vncviewer/touch.cxx:215
+msgid "Failed to get event data for X Input event"
+msgstr ""
+
+#: vncviewer/touch.cxx:228
+msgid "X Input event for unknown window"
+msgstr ""
+
+#: vncviewer/touch.cxx:254
+msgid "X Input extension not available."
+msgstr ""
+
+#: vncviewer/touch.cxx:261
+msgid "X Input 2 (or newer) is not available."
+msgstr ""
+
+#: vncviewer/touch.cxx:266
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:103
+#, c-format
+msgid ""
+"TigerVNC v%s\n"
+"Built on: %s\n"
+"Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+"See https://www.tigervnc.org for information on TigerVNC."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:157
+#, c-format
+msgid ""
+"An unexpected error occurred when communicating with the server:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:194
+msgid "Internal FLTK error. Exiting."
+msgstr "Erro interno no FLTK. Saindo."
+
+#: vncviewer/vncviewer.cxx:213
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"Attempt to reconnect?"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
+#, c-format
+msgid "Error starting new connection: %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:265
+#, c-format
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:394
+msgid "Yes"
+msgstr "Sim"
+
+#: vncviewer/vncviewer.cxx:397
+msgid "Close"
+msgstr "Fechar"
+
+#: vncviewer/vncviewer.cxx:402
+msgid "About"
+msgstr "Sobre"
+
+#: vncviewer/vncviewer.cxx:405
+msgid "Hide"
+msgstr "Ocultar"
+
+#: vncviewer/vncviewer.cxx:408
+msgid "Quit"
+msgstr "Sair"
+
+#: vncviewer/vncviewer.cxx:412
+msgid "Services"
+msgstr "Serviços"
+
+#: vncviewer/vncviewer.cxx:413
+msgid "Hide others"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:414
+msgid "Show all"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:423
+msgctxt "SysMenu|"
+msgid "&File"
+msgstr "&Arquivo"
+
+#: vncviewer/vncviewer.cxx:426
+msgctxt "SysMenu|File|"
+msgid "&New Connection"
+msgstr "&Nova Conexão"
+
+#: vncviewer/vncviewer.cxx:449
+#, c-format
+msgid ""
+"\n"
+"Usage: %s [parameters] [host][:displayNum]\n"
+"       %s [parameters] [host][::port]\n"
+"       %s [parameters] [unix socket]\n"
+"       %s [parameters] -listen [port]\n"
+"       %s [parameters] [.tigervnc file]\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:464
+#, c-format
+msgid ""
+"\n"
+"Options:\n"
+"\n"
+"  -display Xdisplay  - Specifies the X display for the viewer window\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
+"                       man page for details.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:471
+#, c-format
+msgid ""
+"\n"
+"Parameters can be turned on with -<param> or off with -<param>=0\n"
+"Parameters which take a value can be specified as -<param> <value>\n"
+"Other valid forms are <param>=<value> -<param>=<value> --<param>=<value>\n"
+"Parameter names are case-insensitive.  The parameters are:\n"
+"\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:556
+#, c-format
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:561
+#, c-format
+msgid "Could not create VNC config directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:567
+msgid "Could not determine VNC data directory path"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:573
+#, c-format
+msgid "Could not create VNC data directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:585
+#, c-format
+msgid "Could not create VNC state directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:704
+#, c-format
+msgid "%s: Unrecognized option '%s'\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
+#, c-format
+msgid "See '%s --help' for more information.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:713
+#, c-format
+msgid "%s: Extra argument '%s'\n"
+msgstr ""
+
+#. TRANSLATORS: "Parameters" are command line arguments, or settings
+#. from a file or the Windows registry.
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
+msgid "Parameters -listen and -via are incompatible"
+msgstr "Os parâmetros -listen e -via são incompatíveis"
+
+#: vncviewer/vncviewer.cxx:764
+msgid "Unable to listen for incoming connections"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:766
+#, c-format
+msgid "Listening on port %d"
+msgstr "Ouvindo na porta %d"
+
+#: vncviewer/vncviewer.cxx:795
+#, c-format
+msgid ""
+"Failure waiting for incoming VNC connection:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:816
+#, c-format
+msgid ""
+"Failure setting up encrypted tunnel:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.desktop.in.in:4
+msgid "Remote desktop viewer"
+msgstr ""
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(padrão do servidor %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "SetDesktopSize falhou: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "SetColourMapEntries inválido do servidor!"
+
+#~ msgid "Adjusting window size to avoid accidental full screen request"
+#~ msgstr ""
+#~ "Ajustando tamanho de janela para evitar solicitação de tela cheia "
+#~ "acidental"
+
+#~ msgid "Failure grabbing mouse"
+#~ msgstr "Falha ao se conectar com o mouse"
+
+#~ msgid "VNC Viewer: Connection Options"
+#~ msgstr "Visualizador VNC: Opções da conexão"
+
+#~ msgid "Full (all available colors)"
+#~ msgstr "Completo (todas as cores)"
+
+#~ msgid "Medium (256 colors)"
+#~ msgstr "Médio (256 cores)"
+
+#~ msgid "Low (64 colors)"
+#~ msgstr "Baixo (64 cores)"
+
+#~ msgid "Very low (8 colors)"
+#~ msgstr "Muito baixo (8 cores)"
+
+#~ msgid "level (1=fast, 6=best [4-6 are rarely useful])"
+#~ msgstr "nível (1=rápido, 6=o melhor [4-6 raramente úteis])"
+
+#~ msgid "Screen"
+#~ msgstr "Tela"
+
+#~ msgid "Resize remote session on connect"
+#~ msgstr "Redimensionar a sessão remota ao conectar"
+
+#~ msgid "Resize remote session to the local window"
+#~ msgstr "Redimensionar a sessão remota para a janela local"
+
+#~ msgid "Full-screen mode"
+#~ msgstr "Modo tela cheia"
+
+#~ msgid "Enable full-screen mode over all monitors"
+#~ msgstr "Ativar o modo de tela cheia em todos os monitores"
+
+#~ msgid "Misc."
+#~ msgstr "Diversos"
+
+#~ msgid "Show dot when no cursor"
+#~ msgstr "Mostrar ponto quando estiver sem mouse"
+
+#~ msgid "VNC Viewer: Connection Details"
+#~ msgstr "Visualizador VNC: Detalhes da conexão"
+
+#~ msgid "Save As..."
+#~ msgstr "Salvar como..."
+
+#~ msgid "Authentication cancelled"
+#~ msgstr "Autenticação cancelada"
+
+#, c-format
+#~ msgid "Failed to update keyboard LED state: %d"
+#~ msgstr "Falha ao atualizar estado do LED do teclado: %d"
+
+#~ msgid "No key code specified on key press"
+#~ msgstr "Nenhum código de tecla especificado no pressionamento de tecla"
+
+#, c-format
+#~ msgid "No symbol for key code 0x%02x (in the current state)"
+#~ msgstr "Nenhum símbolo para a tecla virtual 0x%02x (no estado atual)"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "E&xit viewer"
+#~ msgstr "&Sair do visualizador"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "Sobre o visualizador &TigerVNC..."
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "Dismiss &menu"
+#~ msgstr "Recusar &menu"
+
+#, c-format
+#~ msgid "The name of the parameter %s was too large to write to the registry"
+#~ msgstr "O nome do parâmetro %s era grande demais ser escrito no registro"
+
+#, c-format
+#~ msgid "The parameter %s was too large to write to the registry"
+#~ msgstr "O parâmetro %s era grande demais para ser escrito no registro"
+
+#, c-format
+#~ msgid "Failed to write parameter %s of type %s to the registry: %ld"
+#~ msgstr "Falha ao escrever parâmetro %s do tipo %s no registro: %ld"
+
+#, c-format
+#~ msgid "The name of the parameter %s was too large to read from the registry"
+#~ msgstr "O nome do parâmetro %s era grande demais ser lido do registro"
+
+#, c-format
+#~ msgid "Failed to read parameter %s from the registry: %ld"
+#~ msgstr "Falha ao ler parâmetro %s do registro: %ld"
+
+#, c-format
+#~ msgid "The parameter %s was too large to read from the registry"
+#~ msgstr "O parâmetro %s era grande demais para ser lido do registro"
+
+#, c-format
+#~ msgid "Failed to create registry key: %ld"
+#~ msgstr "Falha ao criar chave de registro: %ld"
+
+#, c-format
+#~ msgid "Unknown parameter type for parameter %s"
+#~ msgstr "Tipo de parâmetro desconhecido para o parâmetro %s"
+
+#, c-format
+#~ msgid "Failed to close registry key: %ld"
+#~ msgstr "Falha ao fechar chave de registro: %ld"
+
+#, c-format
+#~ msgid "Failed to open registry key: %ld"
+#~ msgstr "Falha ao abrir chave de registro: %ld"
+
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Não foi possível escrever o arquivo de configuração, não foi possível "
+#~ "obter o caminho do diretório HOME."
+
+#, c-format
+#~ msgid "Failed to write configuration file, can't open %s: %s"
+#~ msgstr ""
+#~ "Não foi possível escrever o arquivo de configuração, não foi possível "
+#~ "abrir %s: %s"
+
+#~ msgid "Failed to read configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Não foi possível ler o arquivo de configuração, não foi possível obter o "
+#~ "caminho do diretório HOME."
+
+#, c-format
+#~ msgid "Failed to read configuration file, can't open %s: %s"
+#~ msgstr ""
+#~ "Não foi possível ler o arquivo de configuração, não foi possível abrir "
+#~ "%s: %s"
+
+#, c-format
+#~ msgid "Failed to read line %d in file %s: %s"
+#~ msgstr "Falha ao ler a linha %d no arquivo %s: %s"
+
+#, c-format
+#~ msgid "Unknown parameter %s on line %d in file %s"
+#~ msgstr "Parâmetro %s desconhecido na linha %d no arquivo %s"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC Viewer %d-bit v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "Visualizador TigerVNC %d bits v%s\n"
+#~ "Compilado em: %s\n"
+#~ "Copyright (C) 1999-%d Equipe TigerVNC e muitos outros (veja README.rst)\n"
+#~ "Veja https://www.tigervnc.org para informação sobre o TigerVNC."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "Sobre o Visualizador TigerVNC"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Erro ao iniciar novo Visualizador TigerVNC: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC Viewer will now exit."
+#~ msgstr ""
+#~ "Sinal de terminação %d foi recebido. Visualizador TigerVNC vai fechar "
+#~ "agora."
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "Visualizador TigerVNC"
+
+#~ msgid "Hide Others"
+#~ msgstr "Ocultar Outros"
+
+#~ msgid "Show All"
+#~ msgstr "Exibir Todos"
+
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
+#~ msgstr ""
+#~ "Não foi possível criar o diretório HOME do VNC: não foi possível obter o "
+#~ "caminho do diretório HOME."
+
+#, c-format
+#~ msgid "Could not create VNC home directory: %s."
+#~ msgstr "Não foi possível criar um diretório HOME do VNC: %s."
+
+#~ msgid "Remote Desktop Viewer"
+#~ msgstr "Visualização de área de trabalho remota"
+
+#~ msgid "tigervnc"
+#~ msgstr "tigervnc"
 
 #~ msgid "Enabling continuous updates"
 #~ msgstr "Ativando atualizações contínuas"
@@ -778,7 +1325,8 @@ msgstr "tigervnc"
 #~ msgstr "Codificação desconhecida"
 
 #~ msgid "Multiple characters given for key code %d (0x%04x): '%s'"
-#~ msgstr "Diversos caracteres fornecidos como código de chave %d (0x%04x): '%s'"
+#~ msgstr ""
+#~ "Diversos caracteres fornecidos como código de chave %d (0x%04x): '%s'"
 
 #~ msgid "Unknown FLTK key code %d (0x%04x)"
 #~ msgstr "Código de chave FLTK desconhecido %d (0x%04x)"

--- a/po/ro.po
+++ b/po/ro.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.14.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2025-01-14 16:15+0100\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2025-01-21 18:32+0100\n"
 "Last-Translator: Remus-Gabriel Chelu <remusgabriel.chelu@disroot.org>\n"
 "Language-Team: Romanian <translation-team-ro@lists.sourceforge.net>\n"
@@ -25,21 +25,22 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n==0 || (n!=1 && n%100>=1 && n%100<=19) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n==0 || (n!=1 && n%100>=1 && "
+"n%100<=19) ? 1 : 2);\n"
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: Poedit 3.5\n"
 
-#: vncviewer/CConn.cxx:102
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "Conectat la soclul %s"
 
-#: vncviewer/CConn.cxx:109
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "Conectat la gazda %s portul %d"
 
-#: vncviewer/CConn.cxx:114
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -80,37 +81,32 @@ msgstr ""
 # și nici bineînțeles „corespondentul”
 # românesc de, Remote Desktop =
 # Desktop la distanță
-#: vncviewer/CConn.cxx:151
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Numele biroului: %.80s"
 
-#: vncviewer/CConn.cxx:154
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Gazdă: %.80s port: %d"
 
-#: vncviewer/CConn.cxx:158
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Dimensiune: %d x %d"
 
-#: vncviewer/CConn.cxx:165
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Format pixel: %s"
 
-#: vncviewer/CConn.cxx:170
-#, c-format
-msgid "(server default %s)"
-msgstr "(server implicit %s)"
-
-#: vncviewer/CConn.cxx:173
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Codificarea solicitată: %s"
 
-#: vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Ultima codificare utilizată: %s"
@@ -121,31 +117,35 @@ msgstr "Ultima codificare utilizată: %s"
 # liniei”(legăturii/circuitului/firului)”
 # ===
 # Ok, sugestie aplicată
-#: vncviewer/CConn.cxx:181
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Viteza estimată a conexiunii: %d kbit/s"
 
-#: vncviewer/CConn.cxx:185
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Versiunea protocolului: %d.%d"
 
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Metoda de securitate: %s"
 
-#: vncviewer/CConn.cxx:250 vncviewer/CConn.cxx:252
-msgid "The connection was dropped by the server before the session could be established."
-msgstr "Conexiunea a fost întreruptă de server înainte ca sesiunea să poată fi stabilită."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
+msgstr ""
+"Conexiunea a fost întreruptă de server înainte ca sesiunea să poată fi "
+"stabilită."
 
-#: vncviewer/CConn.cxx:262
+#: vncviewer/CConn.cxx:258
 #, c-format
 msgid "Authentication failed: %s"
 msgstr "Autentificarea a eșuat: %s"
 
-#: vncviewer/CConn.cxx:263
+#: vncviewer/CConn.cxx:259
 #, c-format
 msgid ""
 "Failed to authenticate with the server. Reason given by the server:\n"
@@ -155,15 +155,6 @@ msgstr ""
 "Autentificarea cu serverul a eșuat. Motivul dat de server:\n"
 "\n"
 "%s"
-
-#: vncviewer/CConn.cxx:335
-#, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "Funcția SetDesktopSize() a eșuat: %d"
-
-#: vncviewer/CConn.cxx:408
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "Valoare SetColourMapEntries nevalidă de la server!"
 
 # R-GC, scrie:
 # am tradus acest mesaj, și următoarele două mesaje, în baza comentariului făcut
@@ -179,22 +170,26 @@ msgstr "Valoare SetColourMapEntries nevalidă de la server!"
 # //   If the bandwidth drops below 256 Kbps, we switch to palette mode.
 # //
 # Note: The system here is fairly arbitrary and should be replaced  with something more intelligent at the server end.”
-#: vncviewer/CConn.cxx:516
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Lățimea de bandă este de %d kbit/s - se trece la calitatea %d de JPEG"
 
-#: vncviewer/CConn.cxx:538
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
-msgstr "Lățimea de bandă este de %d kbit/s - nivelul de profunditate al culorii → «deplin», este acum activat acum"
+msgstr ""
+"Lățimea de bandă este de %d kbit/s - nivelul de profunditate al culorii → "
+"«deplin», este acum activat acum"
 
-#: vncviewer/CConn.cxx:541
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
-msgstr "Lățimea de bandă este de %d kbit/s - nivelul de profunditate al culorii → «deplin», este dezactivat acum"
+msgstr ""
+"Lățimea de bandă este de %d kbit/s - nivelul de profunditate al culorii → "
+"«deplin», este dezactivat acum"
 
-#: vncviewer/CConn.cxx:567
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Se utilizează formatul de pixel %s"
@@ -205,138 +200,130 @@ msgstr "Geometria specificată nu este validă!"
 
 #: vncviewer/DesktopWindow.cxx:167
 msgid "Reducing window size to fit on current monitor"
-msgstr "Se reduce dimensiunea ferestrei pentru a se potrivi pe monitorul actual"
+msgstr ""
+"Se reduce dimensiunea ferestrei pentru a se potrivi pe monitorul actual"
 
-#: vncviewer/DesktopWindow.cxx:646
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
-msgstr "Se ajustează dimensiunea ferestrei pentru a evita solicitarea accidentală a ecranului complet"
+msgstr ""
+"Se ajustează dimensiunea ferestrei pentru a evita solicitarea accidentală a "
+"ecranului complet"
 
-#: vncviewer/DesktopWindow.cxx:694
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Apăsați %s pentru a deschide meniul contextual"
 
-#: vncviewer/DesktopWindow.cxx:1094 vncviewer/DesktopWindow.cxx:1102
-#: vncviewer/DesktopWindow.cxx:1122
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Eroare la preluarea tastaturii"
 
-#: vncviewer/DesktopWindow.cxx:1411
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
 msgstr "Aspect nevalid al ecranului calculat pentru cererea de redimensionare!"
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "Stare nevalidă pentru emularea cu trei butoane"
 
-#: vncviewer/KeyboardWin32.cxx:242
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "Niciun cod de scanare pentru tasta virtuală extinsă 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:244
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "Niciun cod de scanare pentru tasta virtuală 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:250
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "Cod de scanare nevalid 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:262
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "Niciun simbol pentru tasta virtuală extinsă 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:264
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "Niciun simbol pentru tasta virtuală 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:423
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
 msgid "Failed to update keyboard LED state: %lu"
 msgstr "Nu s-a putut actualiza starea LED-ului tastaturii: %lu"
 
-#: vncviewer/KeyboardX11.cxx:104
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "Niciun simbol pentru codul tastei %d (în starea curentă)"
 
-#: vncviewer/KeyboardX11.cxx:129
+#: vncviewer/KeyboardX11.cxx:148
 #, c-format
 msgid "Failed to get keyboard LED state: %d"
 msgstr "Nu s-a putut obține starea LED-ului tastaturii: %d"
 
-#: vncviewer/KeyboardX11.cxx:174
+#: vncviewer/KeyboardX11.cxx:193
 msgid "Failed to update keyboard LED state"
 msgstr "Nu s-a putut actualiza starea LED-ului tastaturii"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:100
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "Nu s-a putut obține configurația monitorului sistemului"
 
-#: vncviewer/MonitorIndicesParameter.cxx:79
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "Configurație nevalidă specificată pentru %s"
-
-#: vncviewer/MonitorIndicesParameter.cxx:86
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "Indexul de monitor %d nu există"
 
-#: vncviewer/MonitorIndicesParameter.cxx:162
-#: vncviewer/MonitorIndicesParameter.cxx:182
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "Index de monitor nevalid „%s”"
-
-#: vncviewer/MonitorIndicesParameter.cxx:170
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "Caracter neașteptat „%c”"
-
-#: vncviewer/OptionsDialog.cxx:64
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
 msgid "TigerVNC options"
 msgstr "Opțiuni TigerVNC"
 
-#: vncviewer/OptionsDialog.cxx:97 vncviewer/ServerDialog.cxx:107
-#: vncviewer/vncviewer.cxx:397
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "Anulare"
 
-#: vncviewer/OptionsDialog.cxx:102 vncviewer/vncviewer.cxx:396
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "Ok"
 
-#: vncviewer/OptionsDialog.cxx:514
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "Comprimare"
 
-#: vncviewer/OptionsDialog.cxx:530
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "Selectare automată"
 
-#: vncviewer/OptionsDialog.cxx:541
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "Codificarea preferată"
 
-#: vncviewer/OptionsDialog.cxx:602
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "Nivelul de profunditate al culorii"
 
-#: vncviewer/OptionsDialog.cxx:614
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "Deplin"
 
-#: vncviewer/OptionsDialog.cxx:621
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "Mediu"
 
-#: vncviewer/OptionsDialog.cxx:628
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "Scăzut"
 
@@ -344,152 +331,167 @@ msgstr "Scăzut"
 msgid "Very low"
 msgstr "Foarte scăzut"
 
-#: vncviewer/OptionsDialog.cxx:657
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "Nivel de comprimare personalizat:"
 
-#: vncviewer/OptionsDialog.cxx:664
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "nivel (0 = rapid, 9 = cel mai bun)"
 
-#: vncviewer/OptionsDialog.cxx:671
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "Permite comprimarea JPEG:"
 
-#: vncviewer/OptionsDialog.cxx:678
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "calitate (0 = redusă, 9 = cea mai bună)"
 
-#: vncviewer/OptionsDialog.cxx:689
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "Securitate"
 
-#: vncviewer/OptionsDialog.cxx:703
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "Criptare"
 
-#: vncviewer/OptionsDialog.cxx:715 vncviewer/OptionsDialog.cxx:782
-#: vncviewer/OptionsDialog.cxx:905
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "Niciuna"
 
-#: vncviewer/OptionsDialog.cxx:722
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "TLS cu certificate anonime"
 
-#: vncviewer/OptionsDialog.cxx:728
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "TLS cu certificate X509"
 
-#: vncviewer/OptionsDialog.cxx:735
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "Ruta către certificatul CA X509"
 
-#: vncviewer/OptionsDialog.cxx:742
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "Ruta către fișierul CRL X509"
 
-#: vncviewer/OptionsDialog.cxx:770
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "Autentificare"
 
-#: vncviewer/OptionsDialog.cxx:788
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "VNC standard (nesigur fără criptare)"
 
-#: vncviewer/OptionsDialog.cxx:794
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "Nume de utilizator și parolă (nesigure fără criptare)"
 
-#: vncviewer/OptionsDialog.cxx:822
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "Intrare"
 
-#: vncviewer/OptionsDialog.cxx:835
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "Numai vizualizare (se ignoră mouse-ul și tastatura)"
 
-#: vncviewer/OptionsDialog.cxx:842
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "Mouse"
 
-#: vncviewer/OptionsDialog.cxx:854
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "Emulează butonul din mijloc al mouse-ului"
 
-#: vncviewer/OptionsDialog.cxx:860
+#: vncviewer/OptionsDialog.cxx:880
 msgid "Show local cursor when not provided by server"
 msgstr "Afișează cursorul local atunci când nu este furnizat de server"
 
-#: vncviewer/OptionsDialog.cxx:865
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
 msgid "Cursor type"
 msgstr "Tipul cursorului"
 
-#: vncviewer/OptionsDialog.cxx:867
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
 msgid "Dot"
 msgstr "Punct „Dot”"
 
-#: vncviewer/OptionsDialog.cxx:868
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
 msgid "System"
 msgstr "Sistem"
 
-#: vncviewer/OptionsDialog.cxx:888
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "Tastatură"
 
-#: vncviewer/OptionsDialog.cxx:900
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
 msgstr "Pasează tastele sistemului direct către server (ecran complet)"
 
-#: vncviewer/OptionsDialog.cxx:903
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "Tasta de meniu"
 
-#: vncviewer/OptionsDialog.cxx:926
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "Clipboard"
 
-#: vncviewer/OptionsDialog.cxx:938
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "Acceptă clipboard-ul de pe server"
 
-#: vncviewer/OptionsDialog.cxx:946
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "Stabilește, de asemenea, selecția principală"
 
-#: vncviewer/OptionsDialog.cxx:953
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "Trimite clipboard-ul la server"
 
-#: vncviewer/OptionsDialog.cxx:961
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "Trimite selecția principală ca clipboard"
 
-#: vncviewer/OptionsDialog.cxx:982
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "Afișare"
 
-#: vncviewer/OptionsDialog.cxx:996
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "Modul de afișare"
 
-#: vncviewer/OptionsDialog.cxx:1009
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "În fereastră"
 
-#: vncviewer/OptionsDialog.cxx:1017
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "Ecran complet pe monitorul actual"
 
-#: vncviewer/OptionsDialog.cxx:1025
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "Ecran complet pe toate monitoare"
 
-#: vncviewer/OptionsDialog.cxx:1033
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "Ecran complet pe monitorul(ele) selectat(e)"
 
-#: vncviewer/OptionsDialog.cxx:1062
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
 msgid "Miscellaneous"
 msgstr "Diverse"
 
@@ -498,17 +500,13 @@ msgstr "Diverse"
 # „→ lipsește închiderea parantezei”
 # ===
 # corectare făcută
-#: vncviewer/OptionsDialog.cxx:1070
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "Partajat (nu deconectează alte vizoare)"
 
-#: vncviewer/OptionsDialog.cxx:1076
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "Solicită reconectarea în cazul erorilor de conectare"
-
-#: vncviewer/ServerDialog.cxx:63
-msgid "VNC viewer: Connection details"
-msgstr "Vizor VNC: Detalii de conectare"
 
 #: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
@@ -553,7 +551,7 @@ msgstr "Configurația TigerVNC (*.tigervnc)"
 msgid "Select a TigerVNC configuration file"
 msgstr "Selectați un fișier de configurare TigerVNC"
 
-#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:517
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -573,7 +571,7 @@ msgstr "Salvați configurația TigerVNC în fișier"
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "%s există deja. Doriți să-l suprascrieți?"
 
-#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:394
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "Nu"
 
@@ -614,169 +612,173 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:351 vncviewer/ServerDialog.cxx:429
-#: vncviewer/vncviewer.cxx:580
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
 msgid "Could not determine VNC state directory path"
 msgstr "Nu s-a putut determina ruta directorului de stare al VNC"
 
-#: vncviewer/ServerDialog.cxx:363 vncviewer/ServerDialog.cxx:437
-#: vncviewer/parameters.cxx:671 vncviewer/parameters.cxx:752
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
 msgid "Could not open \"%s\""
 msgstr "Nu s-a putut deschide „%s”"
 
-#: vncviewer/ServerDialog.cxx:378 vncviewer/ServerDialog.cxx:387
-#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:773
-#: vncviewer/parameters.cxx:807 vncviewer/parameters.cxx:837
-#: vncviewer/parameters.cxx:844
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
 msgid "Failed to read line %d in file \"%s\""
 msgstr "Nu s-a putut citi linia %d din fișierul „%s”"
 
-#: vncviewer/ServerDialog.cxx:390 vncviewer/parameters.cxx:776
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "Linia este prea lungă"
 
-#: vncviewer/UserDialog.cxx:123
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "Deschiderea fișierului cu parole a eșuat"
 
-#: vncviewer/UserDialog.cxx:143
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "Autentificare VNC"
 
-#: vncviewer/UserDialog.cxx:150
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "Această conexiune este sigură"
 
-#: vncviewer/UserDialog.cxx:154
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "Această conexiune nu este sigură"
 
-#: vncviewer/UserDialog.cxx:176
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "Numele utilizatorului:"
 
-#: vncviewer/UserDialog.cxx:189
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "Parola:"
 
-#: vncviewer/UserDialog.cxx:197
+#: vncviewer/UserDialog.cxx:204
 msgid "Keep password for reconnect"
 msgstr "Păstrează parola pentru reconectare"
 
-#: vncviewer/Viewport.cxx:695
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
 msgid "Disconn&ect"
 msgstr "Deco&nectare"
 
-#: vncviewer/Viewport.cxx:698
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "&Ecran complet"
 
-#: vncviewer/Viewport.cxx:701
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "Minimi&zare"
 
-#: vncviewer/Viewport.cxx:703
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "Redimensionează &fereastra conform sesiunii"
 
-#: vncviewer/Viewport.cxx:708
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:711
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:717
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "Trimite %s"
 
-#: vncviewer/Viewport.cxx:724
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Trimite Ctrl-Alt-&Del"
 
-#: vncviewer/Viewport.cxx:727
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "&Reîmprospătează ecranul"
 
-#: vncviewer/Viewport.cxx:730
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&Opțiuni..."
 
-#: vncviewer/Viewport.cxx:732
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "&Informații despre conexiune..."
 
-#: vncviewer/Viewport.cxx:734
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "Despre vizorul &TigerVNC..."
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:830
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "Informații despre conexiunea VNC"
 
-#: vncviewer/Win32TouchHandler.cxx:48
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "Fereastra este înregistrată pentru atingere în loc de gesturi"
 
-#: vncviewer/Win32TouchHandler.cxx:83
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "Nu s-a putut definii configurația gesturilor (eroare 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:95
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "Nu s-au putut obține informații despre gesturi (eroare 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:360
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
-msgstr "Butonul mouse-ului %d nu este valid, trebuie să fie un număr între 1 și 7."
+msgstr ""
+"Butonul mouse-ului %d nu este valid, trebuie să fie un număr între 1 și 7."
 
-#: vncviewer/Win32TouchHandler.cxx:425
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
-msgstr "Tasta 0x%x necunoscută - nu se poate genera un eveniment de la tastatură."
+msgstr ""
+"Tasta 0x%x necunoscută - nu se poate genera un eveniment de la tastatură."
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:107
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
-msgstr "Nu se poate obține masca de eveniment X Input 2 pentru fereastra 0x%08lx"
+msgstr ""
+"Nu se poate obține masca de eveniment X Input 2 pentru fereastra 0x%08lx"
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr "Fereastra 0x%08lx nu are mască de eveniment X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:114
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr "Fereastra 0x%08lx are mai mult de o mască de eveniment X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "Eroare la preluarea dispozitivului %i"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-msgid "TigerVNC Viewer"
-msgstr "Vizor TigerVNC"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -784,100 +786,129 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr "Se conectează la serverul VNC și afișează biroul de la distanță"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
-msgstr "Calculatoare în rețea virtuală ⟶ (Virtual Network Computing) «VNC» este un sistem de afișare la distanță care vă permite să vizualizați și să interacționați cu un mediu de birou virtual care rulează pe un alt computer din rețea. Folosind VNC, puteți rula aplicații grafice pe o mașină de la distanță și puteți trimite numai afișarea din aceste aplicații pe dispozitivul local. Acest pachet conține un client care vă va permite să vă conectați la alte calculatoare care rulează un server VNC. VNC este independent de platformă și acceptă diverse sisteme de operare și arhitecturi atât ca servere, cât și ca clienți."
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+"Calculatoare în rețea virtuală ⟶ (Virtual Network Computing) «VNC» este un "
+"sistem de afișare la distanță care vă permite să vizualizați și să "
+"interacționați cu un mediu de birou virtual care rulează pe un alt computer "
+"din rețea. Folosind VNC, puteți rula aplicații grafice pe o mașină de la "
+"distanță și puteți trimite numai afișarea din aceste aplicații pe "
+"dispozitivul local. Acest pachet conține un client care vă va permite să vă "
+"conectați la alte calculatoare care rulează un server VNC. VNC este "
+"independent de platformă și acceptă diverse sisteme de operare și "
+"arhitecturi atât ca servere, cât și ca clienți."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
-msgstr "TigerVNC este o versiune de mare viteză a VNC bazată pe bazele codurilor RealVNC 4 și X.org. TigerVNC a început ca un efort de dezvoltare de ultimă generație pentru TightVNC pe platformele Unix și Linux, dar s-a despărțit de proiectul său părinte la începutul anului 2009, astfel încât TightVNC să se poată concentra pe platformele Windows. TigerVNC acceptă o variantă de codificare Tight care este mult accelerată prin utilizarea codec-ului JPEG libjpeg-turbo."
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+"TigerVNC este o versiune de mare viteză a VNC bazată pe bazele codurilor "
+"RealVNC 4 și X.org. TigerVNC a început ca un efort de dezvoltare de ultimă "
+"generație pentru TightVNC pe platformele Unix și Linux, dar s-a despărțit de "
+"proiectul său părinte la începutul anului 2009, astfel încât TightVNC să se "
+"poată concentra pe platformele Windows. TigerVNC acceptă o variantă de "
+"codificare Tight care este mult accelerată prin utilizarea codec-ului JPEG "
+"libjpeg-turbo."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC viewer connection to a CentOS machine"
-msgstr "Conexiune a vizorului TigerVNC la o mașină «GNU/Linux»"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC viewer connection to a macOS machine"
-msgstr "Conexiune a vizorului TigerVNC la o mașină «macOS»"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC viewer connection to a Windows machine"
-msgstr "Conexiune a vizorului TigerVNC la o mașină «Windows»"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
 #. developer_name tag deprecated with Appstream 1.0
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
-#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:48
 msgid "The TigerVNC team"
 msgstr "Echipa TigerVNC"
 
-#: vncviewer/parameters.cxx:319 vncviewer/parameters.cxx:344
-#: vncviewer/parameters.cxx:361 vncviewer/parameters.cxx:401
-#: vncviewer/parameters.cxx:421
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "Numele parametrului este prea lung"
 
-#: vncviewer/parameters.cxx:323 vncviewer/parameters.cxx:328
-#: vncviewer/parameters.cxx:379
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "Parametrul este prea lung"
 
-#: vncviewer/parameters.cxx:386 vncviewer/parameters.cxx:712
-#: vncviewer/parameters.cxx:822
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "Format nevalid sau valoare prea mare"
 
-#: vncviewer/parameters.cxx:440 vncviewer/parameters.cxx:473
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "Nu s-a putut crea cheia de registru"
 
-#: vncviewer/parameters.cxx:461 vncviewer/parameters.cxx:528
-#: vncviewer/parameters.cxx:571 vncviewer/parameters.cxx:638
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "Nu s-a putut închide cheia de registru"
 
-#: vncviewer/parameters.cxx:479 vncviewer/parameters.cxx:506
-#: vncviewer/parameters.cxx:680 vncviewer/parameters.cxx:692
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "Nu s-a putut salva „%s”: %s"
 
-#: vncviewer/parameters.cxx:489 vncviewer/parameters.cxx:520
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "Nu s-a putut elimina „%s”: %s"
 
-#: vncviewer/parameters.cxx:544 vncviewer/parameters.cxx:616
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "Nu s-a putut deschide cheia de registru"
 
-#: vncviewer/parameters.cxx:561
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "Nu s-a putut citi intrarea din istoricul serverului %d: %s"
 
-#: vncviewer/parameters.cxx:597 vncviewer/parameters.cxx:627
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "Nu s-a putut citi parametrul „%s”: %s"
 
-#: vncviewer/parameters.cxx:661 vncviewer/parameters.cxx:740
-#: vncviewer/vncviewer.cxx:546
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
 msgid "Could not determine VNC config directory path"
 msgstr "Nu s-a putut determina ruta directorului de configurare al VNC"
 
-#: vncviewer/parameters.cxx:682 vncviewer/parameters.cxx:694
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "Nu s-a putut codifica parametrul"
 
-#: vncviewer/parameters.cxx:785
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "Fișierul de configurare %s este într-un format nevalid"
 
-#: vncviewer/parameters.cxx:809
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "Format nevalid"
 
-#: vncviewer/parameters.cxx:846
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "Parametru necunoscut"
 
@@ -889,7 +920,9 @@ msgstr "S-a primit mesajul (0x%x) pentru o fereastră negestionată"
 #: vncviewer/touch.cxx:138 vncviewer/touch.cxx:160
 #, c-format
 msgid "Invalid window 0x%08lx specified for pointer grab"
-msgstr "Fereastra 0x%08lx nevalidă a fost specificată pentru preluarea indicatorului mouse-ului"
+msgstr ""
+"Fereastra 0x%08lx nevalidă a fost specificată pentru preluarea indicatorului "
+"mouse-ului"
 
 #: vncviewer/touch.cxx:183 vncviewer/touch.cxx:184
 #, c-format
@@ -899,11 +932,13 @@ msgstr "Nu s-a putut crea gestionarul de atingere: %s"
 #: vncviewer/touch.cxx:188
 #, c-format
 msgid "Couldn't attach event handler to window (error 0x%x)"
-msgstr "Nu s-a putut atașa gestionarul de evenimente la fereastră (eroare 0x%x)"
+msgstr ""
+"Nu s-a putut atașa gestionarul de evenimente la fereastră (eroare 0x%x)"
 
 #: vncviewer/touch.cxx:215
 msgid "Failed to get event data for X Input event"
-msgstr "Nu s-au putut obține datele despre eveniment pentru evenimentul X Input"
+msgstr ""
+"Nu s-au putut obține datele despre eveniment pentru evenimentul X Input"
 
 #: vncviewer/touch.cxx:228
 msgid "X Input event for unknown window"
@@ -918,34 +953,23 @@ msgid "X Input 2 (or newer) is not available."
 msgstr "X Input 2 (sau mai nouă) nu este disponibilă."
 
 #: vncviewer/touch.cxx:266
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
-msgstr "X Input 2 (sau mai nouă) nu este disponibilă. Gesturile tactile nu vor fi acceptate."
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+"X Input 2 (sau mai nouă) nu este disponibilă. Gesturile tactile nu vor fi "
+"acceptate."
 
-# R-GC, scrie:
-# după revizarea fișierului, DȘ, spune:
-# «→ aici poți ajusta puțin stilul înlocuind „vedeți” cu „consultați”»
-# ===
-# de acord cu faptul că în general,
-# see → consultați, dar să nu uităm că:
-# see == vedea, a se vedea
-# una este să consulți documentația, deobicei
-# echivalentul unui almanah sau al unei cărți,
-# și alta este să-ți arunci privirea pe-o listă,
-# deobicei mai mică decît o pagină
-#: vncviewer/vncviewer.cxx:104
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
 "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"Vizor TigerVNC versiunea %s\n"
-"Construit pe: %s\n"
-"Drepturi de autor © 1999-%d Echipa TigerVNC și mulți alții (vedeți fișierul README.rst)\n"
-"Consultați https://www.tigervnc.org pentru informații despre TigerVNC."
 
-#: vncviewer/vncviewer.cxx:158
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -956,15 +980,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:174
-msgid "About TigerVNC Viewer"
-msgstr "Despre vizorul TigerVNC"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:195
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "Eroare FLTK internă. Se finalizează."
 
-#: vncviewer/vncviewer.cxx:214
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -975,63 +999,59 @@ msgstr ""
 "\n"
 "Încercați să vă reconectați?"
 
-#: vncviewer/vncviewer.cxx:245 vncviewer/vncviewer.cxx:257
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Eroare la pornirea noului vizor TigerVNC: %s"
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:266
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC viewer will now exit."
-msgstr "Semnalul de terminare %d a fost primit. Vizorul TigerVNC se va închide acum."
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:391 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC viewer"
-msgstr "Vizor TigerVNC"
-
-#: vncviewer/vncviewer.cxx:395
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "Da"
 
-#: vncviewer/vncviewer.cxx:398
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "Închide"
 
-#: vncviewer/vncviewer.cxx:403
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "Despre"
 
-#: vncviewer/vncviewer.cxx:406
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "Ascunde"
 
-#: vncviewer/vncviewer.cxx:409
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "Ieșire"
 
-#: vncviewer/vncviewer.cxx:413
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "Servicii"
 
-#: vncviewer/vncviewer.cxx:414
+#: vncviewer/vncviewer.cxx:413
 msgid "Hide others"
 msgstr "Ascunde pe celelalte"
 
-#: vncviewer/vncviewer.cxx:415
+#: vncviewer/vncviewer.cxx:414
 msgid "Show all"
 msgstr "Afișează pe toate"
 
-#: vncviewer/vncviewer.cxx:424
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "&Fişier"
 
-#: vncviewer/vncviewer.cxx:427
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "Conexiune &nouă"
 
-#: vncviewer/vncviewer.cxx:450
+#: vncviewer/vncviewer.cxx:449
 #, c-format
 msgid ""
 "\n"
@@ -1048,24 +1068,19 @@ msgstr ""
 "           %s [parametri] -listen [port]\n"
 "           %s [parametri] [fișier .tigervnc]\n"
 
-#: vncviewer/vncviewer.cxx:465
+#: vncviewer/vncviewer.cxx:464
 #, c-format
 msgid ""
 "\n"
 "Options:\n"
 "\n"
 "  -display Xdisplay  - Specifies the X display for the viewer window\n"
-"  -geometry geometry - Initial position of the main VNC viewer window. See the\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
 "                       man page for details.\n"
 msgstr ""
-"\n"
-"Opțiuni:\n"
-"\n"
-"  -display afișajulX  - Specifică afișajul X pentru fereastra vizorului\n"
-"  -geometry geometria - Poziția inițială a ferestrei principale a vizorului VNC.\n"
-"                        Consultați pagina de manual pentru detalii.\n"
 
-#: vncviewer/vncviewer.cxx:472
+#: vncviewer/vncviewer.cxx:471
 #, c-format
 msgid ""
 "\n"
@@ -1078,77 +1093,92 @@ msgstr ""
 "\n"
 "Parametrii pot fi activați cu -<param> sau dezactivați cu -<param>=0\n"
 "Parametrii care iau o valoare pot fi specificați ca -<param> <valoare>\n"
-"Alte forme valide sunt <param>=<valoare> -<param>=<valoare> --<param>=<valoare>\n"
+"Alte forme valide sunt <param>=<valoare> -<param>=<valoare> --"
+"<param>=<valoare>\n"
 "Numele parametrilor nu sunt sensibile la majuscule.  Parametrii sunt:\n"
 "\n"
 
-#: vncviewer/vncviewer.cxx:527
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
-msgstr "FullScreenAllMonitors este învechit, stabiliți în schimb FullScreenMode la „all”"
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+"FullScreenAllMonitors este învechit, stabiliți în schimb FullScreenMode la "
+"„all”"
 
-#: vncviewer/vncviewer.cxx:532
-msgid "DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' instead"
-msgstr "DotWhenNoCursor este depreciat, stabiliți AlwaysCursor la 1 și CursorType la „Dot” în schimb"
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+"DotWhenNoCursor este depreciat, stabiliți AlwaysCursor la 1 și CursorType la "
+"„Dot” în schimb"
 
-#: vncviewer/vncviewer.cxx:553
-msgid "~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
-msgstr "~/.vnc este depreciat, vă rugăm să consultați «man vncviewer» pentru căile de migrare."
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+"~/.vnc este depreciat, vă rugăm să consultați «man vncviewer» pentru căile "
+"de migrare."
 
-#: vncviewer/vncviewer.cxx:557
+#: vncviewer/vncviewer.cxx:556
 #, c-format
-msgid "%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC location."
-msgstr "%%APPDATA%%\\vnc este depreciat, vă rugăm să treceți la locația %%APPDATA%%\\TigerVNC."
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+"%%APPDATA%%\\vnc este depreciat, vă rugăm să treceți la locația %%APPDATA%%"
+"\\TigerVNC."
 
-#: vncviewer/vncviewer.cxx:562
+#: vncviewer/vncviewer.cxx:561
 #, c-format
 msgid "Could not create VNC config directory \"%s\": %s"
 msgstr "Nu s-a putut crea directorul de configurare al VNC „%s”: %s"
 
-#: vncviewer/vncviewer.cxx:568
+#: vncviewer/vncviewer.cxx:567
 msgid "Could not determine VNC data directory path"
 msgstr "Nu s-a putut determina ruta directorului de date al VNC"
 
-#: vncviewer/vncviewer.cxx:574
+#: vncviewer/vncviewer.cxx:573
 #, c-format
 msgid "Could not create VNC data directory \"%s\": %s"
 msgstr "Nu s-a putut crea directorul de date al VNC „%s”: %s"
 
-#: vncviewer/vncviewer.cxx:586
+#: vncviewer/vncviewer.cxx:585
 #, c-format
 msgid "Could not create VNC state directory \"%s\": %s"
 msgstr "Nu s-a putut crea directorul de stare al VNC „%s”: %s"
 
-#: vncviewer/vncviewer.cxx:703
+#: vncviewer/vncviewer.cxx:704
 #, c-format
 msgid "%s: Unrecognized option '%s'\n"
 msgstr "%s: opțiune nerecunoscută „%s”\n"
 
-#: vncviewer/vncviewer.cxx:705 vncviewer/vncviewer.cxx:713
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
 #, c-format
 msgid "See '%s --help' for more information.\n"
 msgstr "Consultați «%s --help» pentru mai multe informații.\n"
 
-#: vncviewer/vncviewer.cxx:712
+#: vncviewer/vncviewer.cxx:713
 #, c-format
 msgid "%s: Extra argument '%s'\n"
 msgstr "%s: Argument extra „%s”\n"
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:748 vncviewer/vncviewer.cxx:749
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "Parametrii „-listen” și „-via” sunt incompatibili"
 
-#: vncviewer/vncviewer.cxx:763
+#: vncviewer/vncviewer.cxx:764
 msgid "Unable to listen for incoming connections"
 msgstr "Nu se poate asculta pentru conexiunile primite"
 
-#: vncviewer/vncviewer.cxx:765
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "Se ascultă pe portul %d"
 
-#: vncviewer/vncviewer.cxx:794
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -1159,7 +1189,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:815
+#: vncviewer/vncviewer.cxx:816
 #, c-format
 msgid ""
 "Failure setting up encrypted tunnel:\n"
@@ -1173,6 +1203,107 @@ msgstr ""
 #: vncviewer/vncviewer.desktop.in.in:4
 msgid "Remote desktop viewer"
 msgstr "Vizor pentru birou la distanță"
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(server implicit %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "Funcția SetDesktopSize() a eșuat: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "Valoare SetColourMapEntries nevalidă de la server!"
+
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "Configurație nevalidă specificată pentru %s"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "Index de monitor nevalid „%s”"
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "Caracter neașteptat „%c”"
+
+#~ msgid "VNC viewer: Connection details"
+#~ msgstr "Vizor VNC: Detalii de conectare"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "Despre vizorul &TigerVNC..."
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "Vizor TigerVNC"
+
+#~ msgid "TigerVNC viewer connection to a CentOS machine"
+#~ msgstr "Conexiune a vizorului TigerVNC la o mașină «GNU/Linux»"
+
+#~ msgid "TigerVNC viewer connection to a macOS machine"
+#~ msgstr "Conexiune a vizorului TigerVNC la o mașină «macOS»"
+
+#~ msgid "TigerVNC viewer connection to a Windows machine"
+#~ msgstr "Conexiune a vizorului TigerVNC la o mașină «Windows»"
+
+# R-GC, scrie:
+# după revizarea fișierului, DȘ, spune:
+# «→ aici poți ajusta puțin stilul înlocuind „vedeți” cu „consultați”»
+# ===
+# de acord cu faptul că în general,
+# see → consultați, dar să nu uităm că:
+# see == vedea, a se vedea
+# una este să consulți documentația, deobicei
+# echivalentul unui almanah sau al unei cărți,
+# și alta este să-ți arunci privirea pe-o listă,
+# deobicei mai mică decît o pagină
+#, c-format
+#~ msgid ""
+#~ "TigerVNC viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "Vizor TigerVNC versiunea %s\n"
+#~ "Construit pe: %s\n"
+#~ "Drepturi de autor © 1999-%d Echipa TigerVNC și mulți alții (vedeți "
+#~ "fișierul README.rst)\n"
+#~ "Consultați https://www.tigervnc.org pentru informații despre TigerVNC."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "Despre vizorul TigerVNC"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Eroare la pornirea noului vizor TigerVNC: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC viewer will now exit."
+#~ msgstr ""
+#~ "Semnalul de terminare %d a fost primit. Vizorul TigerVNC se va închide "
+#~ "acum."
+
+#~ msgid "TigerVNC viewer"
+#~ msgstr "Vizor TigerVNC"
+
+#, c-format
+#~ msgid ""
+#~ "\n"
+#~ "Options:\n"
+#~ "\n"
+#~ "  -display Xdisplay  - Specifies the X display for the viewer window\n"
+#~ "  -geometry geometry - Initial position of the main VNC viewer window. "
+#~ "See the\n"
+#~ "                       man page for details.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Opțiuni:\n"
+#~ "\n"
+#~ "  -display afișajulX  - Specifică afișajul X pentru fereastra vizorului\n"
+#~ "  -geometry geometria - Poziția inițială a ferestrei principale a "
+#~ "vizorului VNC.\n"
+#~ "                        Consultați pagina de manual pentru detalii.\n"
 
 #~ msgid "Show dot when no cursor"
 #~ msgstr "Afișează un punct când nu există cursor al mouse-ului"
@@ -1198,7 +1329,9 @@ msgstr "Vizor pentru birou la distanță"
 #~ msgstr "Diverse"
 
 #~ msgid "Failed to get monitor name because X11 RandR could not be found"
-#~ msgstr "Nu s-a putut obține numele monitorului deoarece X11 RandR nu a putut fi găsit"
+#~ msgstr ""
+#~ "Nu s-a putut obține numele monitorului deoarece X11 RandR nu a putut fi "
+#~ "găsit"
 
 #~ msgid "Failed to get information about CRTC %d"
 #~ msgstr "Nu s-au putut obține informații despre CRTC %d"

--- a/po/ru.po
+++ b/po/ru.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.14.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2025-01-14 16:15+0100\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2025-03-26 21:38+0300\n"
 "Last-Translator: Yuri Kozlov <yuray@komyakino.ru>\n"
 "Language-Team: Russian <gnu@d07.ru>\n"
@@ -18,20 +18,21 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Bugs: Report translation errors to the Language-Team address.\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Lokalize 24.12.0\n"
 
-#: vncviewer/CConn.cxx:102
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "Подключён к сокету %s"
 
-#: vncviewer/CConn.cxx:109
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "Подключён к компьютеру %s, порт %d"
 
-#: vncviewer/CConn.cxx:114
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -42,66 +43,63 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:151
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Имя компьютера: %.80s"
 
-#: vncviewer/CConn.cxx:154
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Компьютер: %.80s порт: %d"
 
-#: vncviewer/CConn.cxx:158
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Размер: %d x %d"
 
-#: vncviewer/CConn.cxx:165
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Формат пикселей: %s"
 
-#: vncviewer/CConn.cxx:170
-#, c-format
-msgid "(server default %s)"
-msgstr "(сервер по умолчанию %s)"
-
-#: vncviewer/CConn.cxx:173
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Запрошено кодирование: %s"
 
-#: vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Используется кодирование: %s"
 
-#: vncviewer/CConn.cxx:181
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Скорость соединения: %d кбит/с"
 
-#: vncviewer/CConn.cxx:185
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Версия протокола: %d.%d"
 
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Метод защиты: %s"
 
-#: vncviewer/CConn.cxx:250 vncviewer/CConn.cxx:252
-msgid "The connection was dropped by the server before the session could be established."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
 msgstr "Соединение прервано сервером до установления сеанса."
 
-#: vncviewer/CConn.cxx:262
+#: vncviewer/CConn.cxx:258
 #, c-format
 msgid "Authentication failed: %s"
 msgstr "Ошибка аутентификации: %s"
 
-#: vncviewer/CConn.cxx:263
+#: vncviewer/CConn.cxx:259
 #, c-format
 msgid ""
 "Failed to authenticate with the server. Reason given by the server:\n"
@@ -112,31 +110,22 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:335
-#, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "Ошибка SetDesktopSize: %d"
-
-#: vncviewer/CConn.cxx:408
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "С сервера получен недопустимый SetColourMapEntries"
-
-#: vncviewer/CConn.cxx:516
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Пропускная способность %d кбит/с. Установлено качество %d"
 
-#: vncviewer/CConn.cxx:538
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "Пропускная способность %d кбит/с — включено полноцветное отображение"
 
-#: vncviewer/CConn.cxx:541
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "Пропускная способность %d кбит/с — полноцветное отображение выключено"
 
-#: vncviewer/CConn.cxx:567
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Используется формат пикселей %s"
@@ -149,136 +138,127 @@ msgstr "Указан недопустимый размер экрана."
 msgid "Reducing window size to fit on current monitor"
 msgstr "Уменьшается размер окна, чтобы поместиться в текущем мониторе"
 
-#: vncviewer/DesktopWindow.cxx:646
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
-msgstr "Подгоняется размер окна, чтобы избегать случайных запросов переключения в полный экран"
+msgstr ""
+"Подгоняется размер окна, чтобы избегать случайных запросов переключения в "
+"полный экран"
 
-#: vncviewer/DesktopWindow.cxx:694
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Нажмите %s, чтобы открыть контекстное меню"
 
-#: vncviewer/DesktopWindow.cxx:1094 vncviewer/DesktopWindow.cxx:1102
-#: vncviewer/DesktopWindow.cxx:1122
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Не удалось перехватить клавиатуру"
 
-#: vncviewer/DesktopWindow.cxx:1411
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
 msgstr "Для запроса на изменение размера рассчитан недопустимый макет экрана."
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "Некорректное состояние для эмуляция средней кнопки"
 
-#: vncviewer/KeyboardWin32.cxx:242
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "Нет скан-кода для дополнительной виртуальной клавиши 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:244
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "Нет скан-кода для виртуальной клавиши 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:250
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "Некорректный скан-код 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:262
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "Нет символа для расширенной виртуальной клавиши 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:264
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "Нет символа для виртуальной клавиши 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:423
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
 msgid "Failed to update keyboard LED state: %lu"
 msgstr "Не удалось обновить состояние LED клавиатуры: %lu"
 
-#: vncviewer/KeyboardX11.cxx:104
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "Нет символа для кода клавиши %d (в текущем состоянии)"
 
-#: vncviewer/KeyboardX11.cxx:129
+#: vncviewer/KeyboardX11.cxx:148
 #, c-format
 msgid "Failed to get keyboard LED state: %d"
 msgstr "Не удалось получить состояние LED клавиатуры: %d"
 
-#: vncviewer/KeyboardX11.cxx:174
+#: vncviewer/KeyboardX11.cxx:193
 msgid "Failed to update keyboard LED state"
 msgstr "Не удалось обновить состояние LED клавиатуры"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:100
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "Не удалось получить настройки системного монитора"
 
-#: vncviewer/MonitorIndicesParameter.cxx:79
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "Задано недопустимое значение для %s"
-
-#: vncviewer/MonitorIndicesParameter.cxx:86
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "Монитор с индексом %d не существует"
 
-#: vncviewer/MonitorIndicesParameter.cxx:162
-#: vncviewer/MonitorIndicesParameter.cxx:182
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "Некорректный индекс монитора «%s»"
-
-#: vncviewer/MonitorIndicesParameter.cxx:170
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "Неожиданный символ «%c»"
-
-#: vncviewer/OptionsDialog.cxx:64
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
 msgid "TigerVNC options"
 msgstr "Параметры TigerVNC"
 
-#: vncviewer/OptionsDialog.cxx:97 vncviewer/ServerDialog.cxx:107
-#: vncviewer/vncviewer.cxx:397
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "Отмена"
 
-#: vncviewer/OptionsDialog.cxx:102 vncviewer/vncviewer.cxx:396
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "ОК"
 
-#: vncviewer/OptionsDialog.cxx:514
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "Сжатие"
 
-#: vncviewer/OptionsDialog.cxx:530
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "Автоматический выбор"
 
-#: vncviewer/OptionsDialog.cxx:541
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "Вид кодирования"
 
-#: vncviewer/OptionsDialog.cxx:602
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "Глубина цвета"
 
-#: vncviewer/OptionsDialog.cxx:614
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "Полная"
 
-#: vncviewer/OptionsDialog.cxx:621
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "Средняя"
 
-#: vncviewer/OptionsDialog.cxx:628
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "Низкая"
 
@@ -286,166 +266,177 @@ msgstr "Низкая"
 msgid "Very low"
 msgstr "Очень низкая"
 
-#: vncviewer/OptionsDialog.cxx:657
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "Уровень сжатия:"
 
-#: vncviewer/OptionsDialog.cxx:664
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "уровень (0=быстрое, 9=лучшее)"
 
-#: vncviewer/OptionsDialog.cxx:671
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "Разрешить сжатие JPEG:"
 
-#: vncviewer/OptionsDialog.cxx:678
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "качество (0=наихудшее, 9=наилучшее)"
 
-#: vncviewer/OptionsDialog.cxx:689
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "Безопасность"
 
-#: vncviewer/OptionsDialog.cxx:703
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "Шифрование"
 
-#: vncviewer/OptionsDialog.cxx:715 vncviewer/OptionsDialog.cxx:782
-#: vncviewer/OptionsDialog.cxx:905
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "Нет"
 
-#: vncviewer/OptionsDialog.cxx:722
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "TLS с анонимными сертификатами"
 
-#: vncviewer/OptionsDialog.cxx:728
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "TLS с сертификатами X509"
 
-#: vncviewer/OptionsDialog.cxx:735
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "Путь к сертификату X509 CA"
 
-#: vncviewer/OptionsDialog.cxx:742
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "Путь к файлу X509 CRL"
 
-#: vncviewer/OptionsDialog.cxx:770
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "Авторизация"
 
-#: vncviewer/OptionsDialog.cxx:788
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "Стандартный VNC (без защиты и шифрования)"
 
-#: vncviewer/OptionsDialog.cxx:794
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "Имя пользователя и пароль (без защиты и шифрования)"
 
-#: vncviewer/OptionsDialog.cxx:822
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "Ввод"
 
-#: vncviewer/OptionsDialog.cxx:835
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "Только просмотр (не перехватывать мышь и клавиатуру)"
 
-#: vncviewer/OptionsDialog.cxx:842
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "Мышь"
 
-#: vncviewer/OptionsDialog.cxx:854
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "Эмулировать среднюю кнопку мыши"
 
-#: vncviewer/OptionsDialog.cxx:860
+#: vncviewer/OptionsDialog.cxx:880
 msgid "Show local cursor when not provided by server"
 msgstr "Показывать локальный курсор, когда он не предоставляется сервером"
 
-#: vncviewer/OptionsDialog.cxx:865
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
 msgid "Cursor type"
 msgstr "Тип курсора"
 
-#: vncviewer/OptionsDialog.cxx:867
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
 msgid "Dot"
 msgstr "Dot"
 
-#: vncviewer/OptionsDialog.cxx:868
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
 msgid "System"
 msgstr "System"
 
-#: vncviewer/OptionsDialog.cxx:888
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "Клавиатура"
 
-#: vncviewer/OptionsDialog.cxx:900
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
 msgstr "Отправлять сочетания клавиш (для полного экрана)"
 
-#: vncviewer/OptionsDialog.cxx:903
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "Вызов меню:"
 
-#: vncviewer/OptionsDialog.cxx:926
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "Буфер обмена"
 
-#: vncviewer/OptionsDialog.cxx:938
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "Принимать буфер обмена с сервера"
 
-#: vncviewer/OptionsDialog.cxx:946
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "Также принимать мышиный буфер"
 
-#: vncviewer/OptionsDialog.cxx:953
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "Отправлять буфер обмена на сервер"
 
-#: vncviewer/OptionsDialog.cxx:961
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "Отправлять мышиный буфер туда же, куда и буфер обмена"
 
-#: vncviewer/OptionsDialog.cxx:982
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "Экран"
 
-#: vncviewer/OptionsDialog.cxx:996
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "Режим экрана"
 
-#: vncviewer/OptionsDialog.cxx:1009
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "Оконный режим"
 
-#: vncviewer/OptionsDialog.cxx:1017
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "Полноэкранный режим на текущем мониторе"
 
-#: vncviewer/OptionsDialog.cxx:1025
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "Полноэкранный режим на всех мониторах"
 
-#: vncviewer/OptionsDialog.cxx:1033
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "Полноэкранный режим на выбранных мониторах"
 
-#: vncviewer/OptionsDialog.cxx:1062
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
 msgid "Miscellaneous"
 msgstr "Разное"
 
-#: vncviewer/OptionsDialog.cxx:1070
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "Совместная работа (не отключать других клиентов)"
 
-#: vncviewer/OptionsDialog.cxx:1076
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "Запрашивать о переподключении при ошибках соединения"
-
-#: vncviewer/ServerDialog.cxx:63
-msgid "VNC viewer: Connection details"
-msgstr "VNC viewer: информация о соединении"
 
 #: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
@@ -490,7 +481,7 @@ msgstr "Настройки TigerVNC (*.tigervnc)"
 msgid "Select a TigerVNC configuration file"
 msgstr "Выбрать файл настроек TigerVNC"
 
-#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:517
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -510,7 +501,7 @@ msgstr "Сохранить настройки TigerVNC в файл"
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "Файл «%s» уже существует, перезаписать?"
 
-#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:394
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "Нет"
 
@@ -551,169 +542,171 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:351 vncviewer/ServerDialog.cxx:429
-#: vncviewer/vncviewer.cxx:580
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
 msgid "Could not determine VNC state directory path"
 msgstr "Невозможно определить путь к каталогу состояния VNC"
 
-#: vncviewer/ServerDialog.cxx:363 vncviewer/ServerDialog.cxx:437
-#: vncviewer/parameters.cxx:671 vncviewer/parameters.cxx:752
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
 msgid "Could not open \"%s\""
 msgstr "Невозможно открыть «%s»"
 
-#: vncviewer/ServerDialog.cxx:378 vncviewer/ServerDialog.cxx:387
-#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:773
-#: vncviewer/parameters.cxx:807 vncviewer/parameters.cxx:837
-#: vncviewer/parameters.cxx:844
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
 msgid "Failed to read line %d in file \"%s\""
 msgstr "Не удалось прочитать строку %d из файла «%s»"
 
-#: vncviewer/ServerDialog.cxx:390 vncviewer/parameters.cxx:776
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "Строка слишком длинная"
 
-#: vncviewer/UserDialog.cxx:123
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "Не удалось открыть файл с паролем"
 
-#: vncviewer/UserDialog.cxx:143
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "Аутентификация VNC"
 
-#: vncviewer/UserDialog.cxx:150
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "Это соединение защищено"
 
-#: vncviewer/UserDialog.cxx:154
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "Это соединение не защищено"
 
-#: vncviewer/UserDialog.cxx:176
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "Имя пользователя:"
 
-#: vncviewer/UserDialog.cxx:189
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "Пароль:"
 
-#: vncviewer/UserDialog.cxx:197
+#: vncviewer/UserDialog.cxx:204
 msgid "Keep password for reconnect"
 msgstr "Сохранить пароль для переподключения"
 
-#: vncviewer/Viewport.cxx:695
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
 msgid "Disconn&ect"
 msgstr "От&ключиться"
 
-#: vncviewer/Viewport.cxx:698
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "Полный &экран"
 
-#: vncviewer/Viewport.cxx:701
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "&Свернуть"
 
-#: vncviewer/Viewport.cxx:703
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "Изменить &размер окна"
 
-#: vncviewer/Viewport.cxx:708
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:711
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:717
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "Отправить %s"
 
-#: vncviewer/Viewport.cxx:724
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Отправить Ctrl-Alt-&Del"
 
-#: vncviewer/Viewport.cxx:727
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "&Обновить экран"
 
-#: vncviewer/Viewport.cxx:730
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&Параметры…"
 
-#: vncviewer/Viewport.cxx:732
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "Сведен&ия о соединении…"
 
-#: vncviewer/Viewport.cxx:734
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "О &TigerVNC…"
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:830
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "Сведения о соединении VNC"
 
-#: vncviewer/Win32TouchHandler.cxx:48
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "Для окна зарегистрировано управление прикосновениями, а не жестами"
 
-#: vncviewer/Win32TouchHandler.cxx:83
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "Не удалось задать параметры жестов (ошибка 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:95
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "Не удалось получить информацию о жестах (ошибка 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:360
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr "Некорректная кнопка мыши %d: должно быть число от 1 до 7."
 
-#: vncviewer/Win32TouchHandler.cxx:425
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
-msgstr "Необработанная кнопка 0x%x: невозможно сгенерировать событие клавиатуры."
+msgstr ""
+"Необработанная кнопка 0x%x: невозможно сгенерировать событие клавиатуры."
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:107
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
 msgstr "Невозможно получить маску событий X Input 2 для окна 0x%08lx"
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr "У окна 0x%08lx нет маски событий X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:114
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr "У окна 0x%08lx больше одной маски событий X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "Не удалось перехватить устройство %i"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-msgid "TigerVNC Viewer"
-msgstr "TigerVNC Viewer"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -721,100 +714,127 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr "Подключиться к серверу VNC и показать удалённый рабочий стол"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
-msgstr "Virtual Network Computing (VNC) — система удалённого рабочего стола, которая позволяет просматривать и взаимодействовать по сети с виртуальным окружением, запущенном на другом компьютере.С помощью VNC вы можете запускать графические приложения на удалённой машине и получать отображение этих приложений на локальной машине. Этот пакет содержит клиентскую часть, которая позволяет подключиться к другим рабочим столам, запущенным сервером VNC. VNC не зависит от платформы и поддерживает различные операционные системы и архитектуры как для серверов так и для клиентов."
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+"Virtual Network Computing (VNC) — система удалённого рабочего стола, которая "
+"позволяет просматривать и взаимодействовать по сети с виртуальным "
+"окружением, запущенном на другом компьютере.С помощью VNC вы можете "
+"запускать графические приложения на удалённой машине и получать отображение "
+"этих приложений на локальной машине. Этот пакет содержит клиентскую часть, "
+"которая позволяет подключиться к другим рабочим столам, запущенным сервером "
+"VNC. VNC не зависит от платформы и поддерживает различные операционные "
+"системы и архитектуры как для серверов так и для клиентов."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
-msgstr "TigerVNC — высокоскоростная версия VNC, в основе лежит код RealVNC 4 и X.org. TigerVNC начиналась как разработка следующего поколения TightVNC для платформ Unix и Linux, но отделилась от родительского проекта в начале 2009 года для того, чтобы TightVNC смогла сфокусироваться на платформе Windows. TigerVNC поддерживает вариант кодирования Tight, который был значительно ускорен с помощью кодека libjpeg-turbo JPEG."
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+"TigerVNC — высокоскоростная версия VNC, в основе лежит код RealVNC 4 и X."
+"org. TigerVNC начиналась как разработка следующего поколения TightVNC для "
+"платформ Unix и Linux, но отделилась от родительского проекта в начале 2009 "
+"года для того, чтобы TightVNC смогла сфокусироваться на платформе Windows. "
+"TigerVNC поддерживает вариант кодирования Tight, который был значительно "
+"ускорен с помощью кодека libjpeg-turbo JPEG."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC viewer connection to a CentOS machine"
-msgstr "Подключение TigerVNC viewer к машине CentOS"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC viewer connection to a macOS machine"
-msgstr "Подключение TigerVNC viewer к машине macOS"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC viewer connection to a Windows machine"
-msgstr "Подключение TigerVNC viewer к машине Windows"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
 #. developer_name tag deprecated with Appstream 1.0
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
-#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:48
 msgid "The TigerVNC team"
 msgstr "Команда TigerVNC"
 
-#: vncviewer/parameters.cxx:319 vncviewer/parameters.cxx:344
-#: vncviewer/parameters.cxx:361 vncviewer/parameters.cxx:401
-#: vncviewer/parameters.cxx:421
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "Название параметра слишком длинное"
 
-#: vncviewer/parameters.cxx:323 vncviewer/parameters.cxx:328
-#: vncviewer/parameters.cxx:379
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "Параметр слишком длинный"
 
-#: vncviewer/parameters.cxx:386 vncviewer/parameters.cxx:712
-#: vncviewer/parameters.cxx:822
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "Недопустимый формат или слишком большое значение"
 
-#: vncviewer/parameters.cxx:440 vncviewer/parameters.cxx:473
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "Не удалось создать ключ реестра"
 
-#: vncviewer/parameters.cxx:461 vncviewer/parameters.cxx:528
-#: vncviewer/parameters.cxx:571 vncviewer/parameters.cxx:638
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "Не удалось закрыть ключ реестра"
 
-#: vncviewer/parameters.cxx:479 vncviewer/parameters.cxx:506
-#: vncviewer/parameters.cxx:680 vncviewer/parameters.cxx:692
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "Не удалось сохранить «%s»: %s"
 
-#: vncviewer/parameters.cxx:489 vncviewer/parameters.cxx:520
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "Не удалось удалить «%s»: %s"
 
-#: vncviewer/parameters.cxx:544 vncviewer/parameters.cxx:616
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "Не удалось открыть ключ реестра"
 
-#: vncviewer/parameters.cxx:561
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "Не удалось прочитать элемент истории сервера %d: %s"
 
-#: vncviewer/parameters.cxx:597 vncviewer/parameters.cxx:627
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "Не удалось прочитать параметр «%s»: %s"
 
-#: vncviewer/parameters.cxx:661 vncviewer/parameters.cxx:740
-#: vncviewer/vncviewer.cxx:546
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
 msgid "Could not determine VNC config directory path"
 msgstr "Невозможно определить путь к каталогу настроек VNC"
 
-#: vncviewer/parameters.cxx:682 vncviewer/parameters.cxx:694
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "Не удалось закодировать параметр"
 
-#: vncviewer/parameters.cxx:785
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "Недопустимый формат файла конфигурации %s"
 
-#: vncviewer/parameters.cxx:809
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "Недопустимый формат"
 
-#: vncviewer/parameters.cxx:846
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "Неизвестный параметр"
 
@@ -855,23 +875,23 @@ msgid "X Input 2 (or newer) is not available."
 msgstr "Расширение X Input 2 (или новее) недоступно."
 
 #: vncviewer/touch.cxx:266
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
-msgstr "Расширение X Input 2.2 (или новее) недоступно. Прикосновения жестов не будут поддерживаться."
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+"Расширение X Input 2.2 (или новее) недоступно. Прикосновения жестов не будут "
+"поддерживаться."
 
-#: vncviewer/vncviewer.cxx:104
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
 "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"TigerVNC viewer v%s\n"
-"Сборка от: %s\n"
-"Copyright (C) 1999-%d, команда TigerVNC и многие другие (см. README.rst)\n"
-"Информация о TigerVNC на сайте https://www.tigervnc.org"
 
-#: vncviewer/vncviewer.cxx:158
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -882,15 +902,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:174
-msgid "About TigerVNC Viewer"
-msgstr "О TigerVNC viewer"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:195
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "Внутренняя ошибка FLTK. Выход."
 
-#: vncviewer/vncviewer.cxx:214
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -901,63 +921,59 @@ msgstr ""
 "\n"
 "Попытаться переподключиться?"
 
-#: vncviewer/vncviewer.cxx:245 vncviewer/vncviewer.cxx:257
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Не удалось запустить новый TigerVNC Viewer: %s"
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:266
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC viewer will now exit."
-msgstr "Получен сигнал завершения работы %d. TigerVNC viewer будет закрыт."
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:391 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC viewer"
-msgstr "TigerVNC viewer"
-
-#: vncviewer/vncviewer.cxx:395
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "Да"
 
-#: vncviewer/vncviewer.cxx:398
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "Закрыть"
 
-#: vncviewer/vncviewer.cxx:403
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "О программе"
 
-#: vncviewer/vncviewer.cxx:406
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "Скрыть"
 
-#: vncviewer/vncviewer.cxx:409
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "Выход"
 
-#: vncviewer/vncviewer.cxx:413
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "Службы"
 
-#: vncviewer/vncviewer.cxx:414
+#: vncviewer/vncviewer.cxx:413
 msgid "Hide others"
 msgstr "Скрыть прочее"
 
-#: vncviewer/vncviewer.cxx:415
+#: vncviewer/vncviewer.cxx:414
 msgid "Show all"
 msgstr "Показать всё"
 
-#: vncviewer/vncviewer.cxx:424
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "&Файл"
 
-#: vncviewer/vncviewer.cxx:427
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "&Новое соединение"
 
-#: vncviewer/vncviewer.cxx:450
+#: vncviewer/vncviewer.cxx:449
 #, c-format
 msgid ""
 "\n"
@@ -974,24 +990,19 @@ msgstr ""
 "       %s [параметры] -listen [порт]\n"
 "       %s [параметры] [файл .tigervnc]\n"
 
-#: vncviewer/vncviewer.cxx:465
+#: vncviewer/vncviewer.cxx:464
 #, c-format
 msgid ""
 "\n"
 "Options:\n"
 "\n"
 "  -display Xdisplay  - Specifies the X display for the viewer window\n"
-"  -geometry geometry - Initial position of the main VNC viewer window. See the\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
 "                       man page for details.\n"
 msgstr ""
-"\n"
-"Параметры:\n"
-"\n"
-"  -display Xdisplay   - Задать X-дисплей для окна программы\n"
-"  -geometry геометрия - Начальное положение основного окна VNC.\n"
-"                      Подробности в справочной странице.\n"
 
-#: vncviewer/vncviewer.cxx:472
+#: vncviewer/vncviewer.cxx:471
 #, c-format
 msgid ""
 "\n"
@@ -1010,73 +1021,84 @@ msgstr ""
 "Имена параметров не чувствительны к регистру. Возможные параметры:\n"
 "\n"
 
-#: vncviewer/vncviewer.cxx:527
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
-msgstr "FullScreenAllMonitors устарел, задайте FullScreenMode со значением «all»"
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+"FullScreenAllMonitors устарел, задайте FullScreenMode со значением «all»"
 
-#: vncviewer/vncviewer.cxx:532
-msgid "DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' instead"
-msgstr "DotWhenNoCursor устарел, вместо него используйте AlwaysCursor равным 1 и CursorType равным «Dot»"
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+"DotWhenNoCursor устарел, вместо него используйте AlwaysCursor равным 1 и "
+"CursorType равным «Dot»"
 
-#: vncviewer/vncviewer.cxx:553
-msgid "~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
-msgstr "Каталог ~/.vnc устарел, по «man vncviewer» можно найти информацию об изменениях в путях."
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+"Каталог ~/.vnc устарел, по «man vncviewer» можно найти информацию об "
+"изменениях в путях."
 
-#: vncviewer/vncviewer.cxx:557
+#: vncviewer/vncviewer.cxx:556
 #, c-format
-msgid "%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC location."
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
 msgstr "%%APPDATA%%\\vnc устарел, используйте %%APPDATA%%\\TigerVNC."
 
-#: vncviewer/vncviewer.cxx:562
+#: vncviewer/vncviewer.cxx:561
 #, c-format
 msgid "Could not create VNC config directory \"%s\": %s"
 msgstr "Невозможно создать каталог настроек VNC «%s»: %s"
 
-#: vncviewer/vncviewer.cxx:568
+#: vncviewer/vncviewer.cxx:567
 msgid "Could not determine VNC data directory path"
 msgstr "Невозможно определить путь к каталогу данных VNC"
 
-#: vncviewer/vncviewer.cxx:574
+#: vncviewer/vncviewer.cxx:573
 #, c-format
 msgid "Could not create VNC data directory \"%s\": %s"
 msgstr "Невозможно создать каталог данных VNC «%s»: %s"
 
-#: vncviewer/vncviewer.cxx:586
+#: vncviewer/vncviewer.cxx:585
 #, c-format
 msgid "Could not create VNC state directory \"%s\": %s"
 msgstr "Невозможно создать каталог состояния VNC «%s»: %s"
 
-#: vncviewer/vncviewer.cxx:703
+#: vncviewer/vncviewer.cxx:704
 #, c-format
 msgid "%s: Unrecognized option '%s'\n"
 msgstr "%s: Нераспознанный параметр «%s»\n"
 
-#: vncviewer/vncviewer.cxx:705 vncviewer/vncviewer.cxx:713
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
 #, c-format
 msgid "See '%s --help' for more information.\n"
 msgstr "По команде «%s --help» можно получить дополнительную информацию.\n"
 
-#: vncviewer/vncviewer.cxx:712
+#: vncviewer/vncviewer.cxx:713
 #, c-format
 msgid "%s: Extra argument '%s'\n"
 msgstr "%s: Лишний аргумент «%s»\n"
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:748 vncviewer/vncviewer.cxx:749
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "Параметры -listen и -via несовместимы"
 
-#: vncviewer/vncviewer.cxx:763
+#: vncviewer/vncviewer.cxx:764
 msgid "Unable to listen for incoming connections"
 msgstr "Невозможно прослушивать входящие соединения"
 
-#: vncviewer/vncviewer.cxx:765
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "Прослушивается порт %d"
 
-#: vncviewer/vncviewer.cxx:794
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -1087,7 +1109,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:815
+#: vncviewer/vncviewer.cxx:816
 #, c-format
 msgid ""
 "Failure setting up encrypted tunnel:\n"
@@ -1101,6 +1123,92 @@ msgstr ""
 #: vncviewer/vncviewer.desktop.in.in:4
 msgid "Remote desktop viewer"
 msgstr "Просмотр удалённых рабочих столов"
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(сервер по умолчанию %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "Ошибка SetDesktopSize: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "С сервера получен недопустимый SetColourMapEntries"
+
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "Задано недопустимое значение для %s"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "Некорректный индекс монитора «%s»"
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "Неожиданный символ «%c»"
+
+#~ msgid "VNC viewer: Connection details"
+#~ msgstr "VNC viewer: информация о соединении"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "О &TigerVNC…"
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "TigerVNC Viewer"
+
+#~ msgid "TigerVNC viewer connection to a CentOS machine"
+#~ msgstr "Подключение TigerVNC viewer к машине CentOS"
+
+#~ msgid "TigerVNC viewer connection to a macOS machine"
+#~ msgstr "Подключение TigerVNC viewer к машине macOS"
+
+#~ msgid "TigerVNC viewer connection to a Windows machine"
+#~ msgstr "Подключение TigerVNC viewer к машине Windows"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "TigerVNC viewer v%s\n"
+#~ "Сборка от: %s\n"
+#~ "Copyright (C) 1999-%d, команда TigerVNC и многие другие (см. README.rst)\n"
+#~ "Информация о TigerVNC на сайте https://www.tigervnc.org"
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "О TigerVNC viewer"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Не удалось запустить новый TigerVNC Viewer: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC viewer will now exit."
+#~ msgstr "Получен сигнал завершения работы %d. TigerVNC viewer будет закрыт."
+
+#~ msgid "TigerVNC viewer"
+#~ msgstr "TigerVNC viewer"
+
+#, c-format
+#~ msgid ""
+#~ "\n"
+#~ "Options:\n"
+#~ "\n"
+#~ "  -display Xdisplay  - Specifies the X display for the viewer window\n"
+#~ "  -geometry geometry - Initial position of the main VNC viewer window. "
+#~ "See the\n"
+#~ "                       man page for details.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Параметры:\n"
+#~ "\n"
+#~ "  -display Xdisplay   - Задать X-дисплей для окна программы\n"
+#~ "  -geometry геометрия - Начальное положение основного окна VNC.\n"
+#~ "                      Подробности в справочной странице.\n"
 
 #~ msgid "VNC Viewer: Connection Options"
 #~ msgstr "VNC Viewer: параметры соединения"
@@ -1181,20 +1289,28 @@ msgstr "Просмотр удалённых рабочих столов"
 #~ msgid "The parameter %s was too large to read from the registry"
 #~ msgstr "Параметр %s слишком длинный для чтения из реестра"
 
-#~ msgid "Failed to write configuration file, can't obtain home directory path."
-#~ msgstr "Не удалось создать домашний каталог VNC: не удаётся получить путь к домашнему каталогу."
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Не удалось создать домашний каталог VNC: не удаётся получить путь к "
+#~ "домашнему каталогу."
 
 #~ msgid "Failed to write configuration file, can't open %s: %s"
 #~ msgstr "Не удалось записать файл конфигурации: не удаётся открыть %s: %s"
 
 #~ msgid "Failed to read configuration file, can't obtain home directory path."
-#~ msgstr "Не удалось прочитать файл конфигурации: не удаётся получить путь к домашнему каталогу."
+#~ msgstr ""
+#~ "Не удалось прочитать файл конфигурации: не удаётся получить путь к "
+#~ "домашнему каталогу."
 
 #~ msgid "Unknown parameter %s on line %d in file %s"
 #~ msgstr "Неизвестный параметр %s в строке %d файла %s"
 
-#~ msgid "Could not create VNC home directory: can't obtain home directory path."
-#~ msgstr "Не удалось создать домашний каталог VNC: не удаётся получить путь к домашнему каталогу."
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
+#~ msgstr ""
+#~ "Не удалось создать домашний каталог VNC: не удаётся получить путь к "
+#~ "домашнему каталогу."
 
 #~ msgid "tigervnc"
 #~ msgstr "tigervnc"
@@ -1248,7 +1364,9 @@ msgstr "Просмотр удалённых рабочих столов"
 #~ msgstr "Поддерживаются только полноцветные экраны"
 
 #~ msgid "Using default colormap and visual, TrueColor, depth %d."
-#~ msgstr "Используется стандартная цветовая карта и визуальное оформление, TrueColor, глубина %d."
+#~ msgstr ""
+#~ "Используется стандартная цветовая карта и визуальное оформление, "
+#~ "TrueColor, глубина %d."
 
 #~ msgid "Unknown encoding %d"
 #~ msgstr "Неизвестное кодирование %d"

--- a/po/sk.po
+++ b/po/sk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.14.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2025-01-14 16:15+0100\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2025-01-23 14:21+0100\n"
 "Last-Translator: Marián Haburaj <hajkomajko5@gmail.com>\n"
 "Language-Team: Slovak <sk-i18n@lists.linux.sk>\n"
@@ -19,17 +19,17 @@ msgstr ""
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: Poedit 3.5\n"
 
-#: vncviewer/CConn.cxx:102
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "Pripojené na socket %s"
 
-#: vncviewer/CConn.cxx:109
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "Pripojené na stroj %s port %d"
 
-#: vncviewer/CConn.cxx:114
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -40,66 +40,64 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:151
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Názov plochy: %.80s"
 
-#: vncviewer/CConn.cxx:154
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Stroj: %.80s port: %d"
 
-#: vncviewer/CConn.cxx:158
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Veľkosť: %d x %d"
 
-#: vncviewer/CConn.cxx:165
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Formát pixelu: %s"
 
-#: vncviewer/CConn.cxx:170
-#, c-format
-msgid "(server default %s)"
-msgstr "(predvolené serveru %s)"
-
-#: vncviewer/CConn.cxx:173
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Požadované kódovanie: %s"
 
-#: vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Naposledy použité kódovanie: %s"
 
-#: vncviewer/CConn.cxx:181
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Predpokladaná rýchlosť linky: %d kbit/s"
 
-#: vncviewer/CConn.cxx:185
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Verzia protokolu: %d.%d"
 
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Metóda zabezpečenia: %s"
 
-#: vncviewer/CConn.cxx:250 vncviewer/CConn.cxx:252
-msgid "The connection was dropped by the server before the session could be established."
-msgstr "Spojenie bolo prerušené serverom skôr, než mohla byť nadviazaná relácia."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
+msgstr ""
+"Spojenie bolo prerušené serverom skôr, než mohla byť nadviazaná relácia."
 
-#: vncviewer/CConn.cxx:262
+#: vncviewer/CConn.cxx:258
 #, c-format
 msgid "Authentication failed: %s"
 msgstr "Autentifikácia zlyhala: %s"
 
-#: vncviewer/CConn.cxx:263
+#: vncviewer/CConn.cxx:259
 #, c-format
 msgid ""
 "Failed to authenticate with the server. Reason given by the server:\n"
@@ -110,31 +108,22 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:335
-#, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "Požiadavka SetDesktopSize zlyhala: %d"
-
-#: vncviewer/CConn.cxx:408
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "Neplatná správa SetColourMapEntries od serveru!"
-
-#: vncviewer/CConn.cxx:516
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Dátový tok %d kbit/s - mením na kvalitu %d"
 
-#: vncviewer/CConn.cxx:538
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "Dátový tok %d kbit/s - plné farby sú teraz zapnuté"
 
-#: vncviewer/CConn.cxx:541
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "Dátový tok %d kbit/s - plné farby sú teraz vypnuté"
 
-#: vncviewer/CConn.cxx:567
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Používaný formát pixelu %s"
@@ -147,136 +136,128 @@ msgstr "Zadaná neplatná geometria!"
 msgid "Reducing window size to fit on current monitor"
 msgstr "Zmenšovanie veľkosti okna, aby sa zmestilo na súčasný monitor"
 
-#: vncviewer/DesktopWindow.cxx:646
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
-msgstr "Upravovanie veľkosti okna na vyhnutie sa náhodným požiadavkám na celú obrazovku"
+msgstr ""
+"Upravovanie veľkosti okna na vyhnutie sa náhodným požiadavkám na celú "
+"obrazovku"
 
-#: vncviewer/DesktopWindow.cxx:694
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Stlač %s na otvorenie kontextovej ponuky"
 
-#: vncviewer/DesktopWindow.cxx:1094 vncviewer/DesktopWindow.cxx:1102
-#: vncviewer/DesktopWindow.cxx:1122
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Chyba pri preberaní klávesnice"
 
-#: vncviewer/DesktopWindow.cxx:1411
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
-msgstr "Vypočítané neplatné rozloženie obrazovky pre požiadavku na zmenu veľkosti!"
+msgstr ""
+"Vypočítané neplatné rozloženie obrazovky pre požiadavku na zmenu veľkosti!"
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "Neplatný stav pre 3-tlačidlovú emuláciu"
 
-#: vncviewer/KeyboardWin32.cxx:242
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "Žiaden scan kód pre rozšírený virtuálny kláves 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:244
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "Žiaden scan kód pre virtuálny kláves 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:250
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "Neplatný scan kód 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:262
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "Žiaden symbol pre rozšírený virtuálny kláves 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:264
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "Žiaden symbol pre virtuálny kláves 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:423
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
 msgid "Failed to update keyboard LED state: %lu"
 msgstr "Zlyhalo aktualizovanie stavu diód na klávesnici: %lu"
 
-#: vncviewer/KeyboardX11.cxx:104
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "Žiaden symbol pre kód klávesy %d (v súčasnom stave)"
 
-#: vncviewer/KeyboardX11.cxx:129
+#: vncviewer/KeyboardX11.cxx:148
 #, c-format
 msgid "Failed to get keyboard LED state: %d"
 msgstr "Zlyhalo získanie stavu diód na klávesnici: %d"
 
-#: vncviewer/KeyboardX11.cxx:174
+#: vncviewer/KeyboardX11.cxx:193
 msgid "Failed to update keyboard LED state"
 msgstr "Zlyhalo aktualizovanie stavu diód na klávesnici"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:100
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "Nepodarilo sa získať nastavenie monitora systému"
 
-#: vncviewer/MonitorIndicesParameter.cxx:79
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "Zadané neplatné nastavenie pre %s"
-
-#: vncviewer/MonitorIndicesParameter.cxx:86
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "Monitor s číslom %d neexistuje"
 
-#: vncviewer/MonitorIndicesParameter.cxx:162
-#: vncviewer/MonitorIndicesParameter.cxx:182
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "Neplatné číslo monitoru \"%s\""
-
-#: vncviewer/MonitorIndicesParameter.cxx:170
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "Neočakávaný znak \"%c\""
-
-#: vncviewer/OptionsDialog.cxx:64
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
 msgid "TigerVNC options"
 msgstr "Nastavenia TigerVNC"
 
-#: vncviewer/OptionsDialog.cxx:97 vncviewer/ServerDialog.cxx:107
-#: vncviewer/vncviewer.cxx:397
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: vncviewer/OptionsDialog.cxx:102 vncviewer/vncviewer.cxx:396
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "OK"
 
-#: vncviewer/OptionsDialog.cxx:514
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "Kompresia"
 
-#: vncviewer/OptionsDialog.cxx:530
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "Automatický výber"
 
-#: vncviewer/OptionsDialog.cxx:541
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "Uprednostňované kódovanie"
 
-#: vncviewer/OptionsDialog.cxx:602
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "Farebnosť"
 
-#: vncviewer/OptionsDialog.cxx:614
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "Plná"
 
-#: vncviewer/OptionsDialog.cxx:621
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "Stredná"
 
-#: vncviewer/OptionsDialog.cxx:628
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "Malá"
 
@@ -284,166 +265,177 @@ msgstr "Malá"
 msgid "Very low"
 msgstr "Veľmi malá"
 
-#: vncviewer/OptionsDialog.cxx:657
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "Vlastný stupeň kompresie:"
 
-#: vncviewer/OptionsDialog.cxx:664
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "úroveň (0=rýchla, 9=najlepšia)"
 
-#: vncviewer/OptionsDialog.cxx:671
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "Povoliť kompresiu JPEG:"
 
-#: vncviewer/OptionsDialog.cxx:678
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "kvalita (0=nízka, 9=najlepšia)"
 
-#: vncviewer/OptionsDialog.cxx:689
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "Bezpečnosť"
 
-#: vncviewer/OptionsDialog.cxx:703
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "Šifrovanie"
 
-#: vncviewer/OptionsDialog.cxx:715 vncviewer/OptionsDialog.cxx:782
-#: vncviewer/OptionsDialog.cxx:905
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "Žiadne"
 
-#: vncviewer/OptionsDialog.cxx:722
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "TLS s anonymnými certifikátmi"
 
-#: vncviewer/OptionsDialog.cxx:728
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "TLS s X509 certifikátmi"
 
-#: vncviewer/OptionsDialog.cxx:735
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "Cesta k X509 certifikátu autority"
 
-#: vncviewer/OptionsDialog.cxx:742
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "Cesta k X509 súboru so zoznamom zneplatnených certifikátov"
 
-#: vncviewer/OptionsDialog.cxx:770
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "Autentifikácia"
 
-#: vncviewer/OptionsDialog.cxx:788
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "Štandardné VNC (nezabezpečené bez šifrovania)"
 
-#: vncviewer/OptionsDialog.cxx:794
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "Používateľské meno a heslo (nezabezpečené bez šifrovania)"
 
-#: vncviewer/OptionsDialog.cxx:822
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "Vstup"
 
-#: vncviewer/OptionsDialog.cxx:835
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "Iba prezerať (ignorovať myš a klávesnicu)"
 
-#: vncviewer/OptionsDialog.cxx:842
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "Myš"
 
-#: vncviewer/OptionsDialog.cxx:854
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "Emulovať stredné tlačidlo myši"
 
-#: vncviewer/OptionsDialog.cxx:860
+#: vncviewer/OptionsDialog.cxx:880
 msgid "Show local cursor when not provided by server"
 msgstr "Zobraziť lokálny kurzor, keď nie je poskytovaný serverom"
 
-#: vncviewer/OptionsDialog.cxx:865
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
 msgid "Cursor type"
 msgstr "Typ kurzoru"
 
-#: vncviewer/OptionsDialog.cxx:867
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
 msgid "Dot"
 msgstr "Bodka"
 
-#: vncviewer/OptionsDialog.cxx:868
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
 msgid "System"
 msgstr "Systémový"
 
-#: vncviewer/OptionsDialog.cxx:888
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "Klávesnica"
 
-#: vncviewer/OptionsDialog.cxx:900
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
 msgstr "Podávať systémové klávesy priamo na server (celá obrazovka)"
 
-#: vncviewer/OptionsDialog.cxx:903
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "Kláves pre zobrazenie ponuky"
 
-#: vncviewer/OptionsDialog.cxx:926
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "Schránka"
 
-#: vncviewer/OptionsDialog.cxx:938
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "Akceptovať schránku zo servera"
 
-#: vncviewer/OptionsDialog.cxx:946
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "Tiež nastaviť hlavný výber"
 
-#: vncviewer/OptionsDialog.cxx:953
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "Posielať schránku serveru"
 
-#: vncviewer/OptionsDialog.cxx:961
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "Poslať hlavný výber ako schránku"
 
-#: vncviewer/OptionsDialog.cxx:982
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "Zobrazenie"
 
-#: vncviewer/OptionsDialog.cxx:996
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "Režim zobrazenia"
 
-#: vncviewer/OptionsDialog.cxx:1009
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "V okne"
 
-#: vncviewer/OptionsDialog.cxx:1017
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "Celá obrazovka na tomto monitore"
 
-#: vncviewer/OptionsDialog.cxx:1025
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "Celá obrazovka na všetkých monitoroch"
 
-#: vncviewer/OptionsDialog.cxx:1033
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "Celá obrazovka na zvolených monitoroch"
 
-#: vncviewer/OptionsDialog.cxx:1062
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
 msgid "Miscellaneous"
 msgstr "Rôzne"
 
-#: vncviewer/OptionsDialog.cxx:1070
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "Zdieľané (neodpojiť iných klientov)"
 
-#: vncviewer/OptionsDialog.cxx:1076
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "Spýtať sa na opätovné pripojenie pri chybe v spojení"
-
-#: vncviewer/ServerDialog.cxx:63
-msgid "VNC viewer: Connection details"
-msgstr "Priehliadač VNC: Detaily o pripojení"
 
 #: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
@@ -488,7 +480,7 @@ msgstr "Nastavenie TigerVNC (*.tigervnc)"
 msgid "Select a TigerVNC configuration file"
 msgstr "Zvoliť súbor s nastaveniami TigerVNC"
 
-#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:517
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -508,7 +500,7 @@ msgstr "Uložiť nastavenie TigerVNC do súboru"
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "%s už existuje. Chceš ho prepísať?"
 
-#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:394
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "Nie"
 
@@ -549,169 +541,170 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:351 vncviewer/ServerDialog.cxx:429
-#: vncviewer/vncviewer.cxx:580
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
 msgid "Could not determine VNC state directory path"
 msgstr "Nemožno určiť cestu k adresáru stavu VNC"
 
-#: vncviewer/ServerDialog.cxx:363 vncviewer/ServerDialog.cxx:437
-#: vncviewer/parameters.cxx:671 vncviewer/parameters.cxx:752
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
 msgid "Could not open \"%s\""
 msgstr "Nedá sa otvoriť \"%s\""
 
-#: vncviewer/ServerDialog.cxx:378 vncviewer/ServerDialog.cxx:387
-#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:773
-#: vncviewer/parameters.cxx:807 vncviewer/parameters.cxx:837
-#: vncviewer/parameters.cxx:844
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
 msgid "Failed to read line %d in file \"%s\""
 msgstr "Nedá sa prečítať riadok %d v súbore \"%s\""
 
-#: vncviewer/ServerDialog.cxx:390 vncviewer/parameters.cxx:776
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "Príliš dlhý riadok"
 
-#: vncviewer/UserDialog.cxx:123
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "Zlyhalo otváranie súboru s heslami"
 
-#: vncviewer/UserDialog.cxx:143
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "VNC autorizácia"
 
-#: vncviewer/UserDialog.cxx:150
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "Toto spojenie je zabezpečené"
 
-#: vncviewer/UserDialog.cxx:154
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "Toto spojenie nie je zabezpečené"
 
-#: vncviewer/UserDialog.cxx:176
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "Meno používateľa:"
 
-#: vncviewer/UserDialog.cxx:189
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "Heslo:"
 
-#: vncviewer/UserDialog.cxx:197
+#: vncviewer/UserDialog.cxx:204
 msgid "Keep password for reconnect"
 msgstr "Ponechať heslo pre opätovné pripojenie"
 
-#: vncviewer/Viewport.cxx:695
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
 msgid "Disconn&ect"
 msgstr "O&dpojiť"
 
-#: vncviewer/Viewport.cxx:698
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "&Režim celej obrazovky"
 
-#: vncviewer/Viewport.cxx:701
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "Minimali&zovať"
 
-#: vncviewer/Viewport.cxx:703
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "Prispôsobiť &veľkosť okna relácii"
 
-#: vncviewer/Viewport.cxx:708
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:711
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:717
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "Poslať %s"
 
-#: vncviewer/Viewport.cxx:724
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Poslať Ctrl-Alt-&Del"
 
-#: vncviewer/Viewport.cxx:727
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "Obnoviť ob&razovku"
 
-#: vncviewer/Viewport.cxx:730
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "V&oľby..."
 
-#: vncviewer/Viewport.cxx:732
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "&Informácie o pripojení..."
 
-#: vncviewer/Viewport.cxx:734
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "O prehliadači &TigerVNC..."
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:830
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "Informácie o VNC pripojení"
 
-#: vncviewer/Win32TouchHandler.cxx:48
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "Okno je registrované na dotyk namiesto ku gestám"
 
-#: vncviewer/Win32TouchHandler.cxx:83
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "Zlyhalo nastavenie pre gestá (chyba 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:95
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "Zlyhalo získanie informácií o gestách (chyba 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:360
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr "Neplatné číslo tlačidla myši %d, musí to byť číslo medzi 1 a 7."
 
-#: vncviewer/Win32TouchHandler.cxx:425
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
 msgstr "Neriadený kláves 0x%x - nedá sa vytvoriť udalosť klávesnice."
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:107
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
 msgstr "Maska udalosti X Input 2 pre okno 0x%08lx sa nedá načítať"
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr "Okno 0x%08lx nemá masku udalosti X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:114
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr "Okno 0x%08lx má viac než jednu masku udalosti X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "Chyba pri preberaní zariadenia %i"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-msgid "TigerVNC Viewer"
-msgstr "Prehliadač TigerVNC"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -719,100 +712,127 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr "Pripojiť sa na VNC server a zobraziť vzdialenú plochu"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
-msgstr "Virtual Network Computing (VNC) je technológia vzdialenej plochy, ktorá vám umožní zobraziť a interagovať s prostredím vzdialenej plochy, ktorá je spustená na inom počítači v sieti. Pomocou VNC môžete mať spustené grafické aplikácie na vzdialenom stroji a posielať len obraz z týchto aplikácií do vášho lokálneho zariadenia. Tento balík obsahuje klienta, ktorý vám umožní pripojiť sa k iným plochám, na ktorých je spustený VNC server. VNC je nezávislé na platforme a podporuje rôzne operačné systémy a architektúry tak ako na serveri, tak aj u klienta."
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+"Virtual Network Computing (VNC) je technológia vzdialenej plochy, ktorá vám "
+"umožní zobraziť a interagovať s prostredím vzdialenej plochy, ktorá je "
+"spustená na inom počítači v sieti. Pomocou VNC môžete mať spustené grafické "
+"aplikácie na vzdialenom stroji a posielať len obraz z týchto aplikácií do "
+"vášho lokálneho zariadenia. Tento balík obsahuje klienta, ktorý vám umožní "
+"pripojiť sa k iným plochám, na ktorých je spustený VNC server. VNC je "
+"nezávislé na platforme a podporuje rôzne operačné systémy a architektúry tak "
+"ako na serveri, tak aj u klienta."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
-msgstr "TigerVNC je vysokorýchlostná verzia VNC založená na kóde RealVNC 4 a X.org. TigerVNC sa začala ako snaha o vývoj novej generácie TightVNC pre Unix a Linux, ale oddelilo sa od rodičovského projektu na začiatku roka 2009, a tak sa TigerVNC mohlo sústrediť na platformu Windows. TigerVNC podporuje variant Tight kódovania, ktorý je značne zrýchlený použitím JPEG kodeku libjpeg-turbo."
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+"TigerVNC je vysokorýchlostná verzia VNC založená na kóde RealVNC 4 a X.org. "
+"TigerVNC sa začala ako snaha o vývoj novej generácie TightVNC pre Unix a "
+"Linux, ale oddelilo sa od rodičovského projektu na začiatku roka 2009, a tak "
+"sa TigerVNC mohlo sústrediť na platformu Windows. TigerVNC podporuje variant "
+"Tight kódovania, ktorý je značne zrýchlený použitím JPEG kodeku libjpeg-"
+"turbo."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC viewer connection to a CentOS machine"
-msgstr "Pripojenie prehliadača TigerVNC k stroju s CentOS"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC viewer connection to a macOS machine"
-msgstr "Pripojenie prehliadača TigerVNC k stroju s macOS"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC viewer connection to a Windows machine"
-msgstr "Pripojenie prehliadača TigerVNC k stroju s Windows"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
 #. developer_name tag deprecated with Appstream 1.0
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
-#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:48
 msgid "The TigerVNC team"
 msgstr "TigerVNC tím"
 
-#: vncviewer/parameters.cxx:319 vncviewer/parameters.cxx:344
-#: vncviewer/parameters.cxx:361 vncviewer/parameters.cxx:401
-#: vncviewer/parameters.cxx:421
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "Názov parametru je veľmi dlhý"
 
-#: vncviewer/parameters.cxx:323 vncviewer/parameters.cxx:328
-#: vncviewer/parameters.cxx:379
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "Parameter je veľmi dlhý"
 
-#: vncviewer/parameters.cxx:386 vncviewer/parameters.cxx:712
-#: vncviewer/parameters.cxx:822
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "Neplatný formát alebo veľmi veľká hodnota"
 
-#: vncviewer/parameters.cxx:440 vncviewer/parameters.cxx:473
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "Zlyhalo vytvorenie kľúča v registry"
 
-#: vncviewer/parameters.cxx:461 vncviewer/parameters.cxx:528
-#: vncviewer/parameters.cxx:571 vncviewer/parameters.cxx:638
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "Zlyhalo zatvorenie kľúča v registry"
 
-#: vncviewer/parameters.cxx:479 vncviewer/parameters.cxx:506
-#: vncviewer/parameters.cxx:680 vncviewer/parameters.cxx:692
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "Zlyhalo uloženie \"%s\": %s"
 
-#: vncviewer/parameters.cxx:489 vncviewer/parameters.cxx:520
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "Zlyhalo vymazanie \"%s\": %s"
 
-#: vncviewer/parameters.cxx:544 vncviewer/parameters.cxx:616
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "Zlyhalo otvorenie kľúča v registry"
 
-#: vncviewer/parameters.cxx:561
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "Zlyhalo prečítanie záznamu histórie servera %d: %s"
 
-#: vncviewer/parameters.cxx:597 vncviewer/parameters.cxx:627
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "Zlyhalo prečítanie parametra \"%s\": %s"
 
-#: vncviewer/parameters.cxx:661 vncviewer/parameters.cxx:740
-#: vncviewer/vncviewer.cxx:546
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
 msgid "Could not determine VNC config directory path"
 msgstr "Nedá sa určiť cesta k adresáru s nastaveniami VNC"
 
-#: vncviewer/parameters.cxx:682 vncviewer/parameters.cxx:694
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "Nedá sa zakódovať parameter"
 
-#: vncviewer/parameters.cxx:785
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "Súbor s nastaveniami %s je v neplatnom formáte"
 
-#: vncviewer/parameters.cxx:809
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "Neplatný formát"
 
-#: vncviewer/parameters.cxx:846
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "Neznámy parameter"
 
@@ -853,23 +873,22 @@ msgid "X Input 2 (or newer) is not available."
 msgstr "X Input 2 (alebo novšie) nie je dostupné."
 
 #: vncviewer/touch.cxx:266
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
-msgstr "X Input 2 (alebo novšie) nie je dostupné. Dotykové gestá nebudú podporované."
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+"X Input 2 (alebo novšie) nie je dostupné. Dotykové gestá nebudú podporované."
 
-#: vncviewer/vncviewer.cxx:104
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
 "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"Prehliadač TigerVNC v%s\n"
-"Postavený na: %s\n"
-"Copyright (C) 1999-%d Tím TigerVNC a mnohí ďalší (pozri README.rst)\n"
-"Pre informácie o TigerVNC navštívte https://www.tigervnc.org."
 
-#: vncviewer/vncviewer.cxx:158
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -880,15 +899,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:174
-msgid "About TigerVNC Viewer"
-msgstr "O aplikácií prehliadač TigerVNC"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:195
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "Interná FLTK chyba. Ukončuje sa."
 
-#: vncviewer/vncviewer.cxx:214
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -899,63 +918,59 @@ msgstr ""
 "\n"
 "Pokúsiť sa znova spojiť?"
 
-#: vncviewer/vncviewer.cxx:245 vncviewer/vncviewer.cxx:257
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Chyba pri spustení prehliadača TigerVNC: %s"
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:266
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC viewer will now exit."
-msgstr "Vnútorný signál na ukončenie %d bol prijatý. Prehliadač TigerVNC sa teraz ukončí."
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:391 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC viewer"
-msgstr "Prehliadač TigerVNC"
-
-#: vncviewer/vncviewer.cxx:395
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "Áno"
 
-#: vncviewer/vncviewer.cxx:398
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "Zatvoriť"
 
-#: vncviewer/vncviewer.cxx:403
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "O programe"
 
-#: vncviewer/vncviewer.cxx:406
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "Skryť"
 
-#: vncviewer/vncviewer.cxx:409
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "Odísť"
 
-#: vncviewer/vncviewer.cxx:413
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "Služby"
 
-#: vncviewer/vncviewer.cxx:414
+#: vncviewer/vncviewer.cxx:413
 msgid "Hide others"
 msgstr "Skryť ostatné"
 
-#: vncviewer/vncviewer.cxx:415
+#: vncviewer/vncviewer.cxx:414
 msgid "Show all"
 msgstr "Zobraziť všetky"
 
-#: vncviewer/vncviewer.cxx:424
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "&Súbor"
 
-#: vncviewer/vncviewer.cxx:427
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "&Nové pripojenie"
 
-#: vncviewer/vncviewer.cxx:450
+#: vncviewer/vncviewer.cxx:449
 #, c-format
 msgid ""
 "\n"
@@ -972,24 +987,19 @@ msgstr ""
 "       %s[parametre] -listen [port]\n"
 "       %s[parametre] [.tigervnc súbor]\n"
 
-#: vncviewer/vncviewer.cxx:465
+#: vncviewer/vncviewer.cxx:464
 #, c-format
 msgid ""
 "\n"
 "Options:\n"
 "\n"
 "  -display Xdisplay  - Specifies the X display for the viewer window\n"
-"  -geometry geometry - Initial position of the main VNC viewer window. See the\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
 "                       man page for details.\n"
 msgstr ""
-"\n"
-"Možnosti:\n"
-"\n"
-"  -display Xdisplay  - Špecifikuje X displej pre okno prehliadača\n"
-"  -geometry geometry - Počiatočná poloha hlavného okna prehliadača VNC. Pozri\n"
-"                       stránku man pre detaily.\n"
 
-#: vncviewer/vncviewer.cxx:472
+#: vncviewer/vncviewer.cxx:471
 #, c-format
 msgid ""
 "\n"
@@ -1002,77 +1012,91 @@ msgstr ""
 "\n"
 "Parametre môžu byť zapnuté s -<param> alebo vypnuté s -<param>=0\n"
 "Parametre, ktoré vyžadujú hodnotu môžu byť zadané ako -<param> <value>\n"
-"Ostatné správne formáty sú <param>=<value> -<param>=<value> --<param>=<value>\n"
+"Ostatné správne formáty sú <param>=<value> -<param>=<value> --"
+"<param>=<value>\n"
 "Názvy parametrov nie sú citlivé na veľkosť písmen. Parametre sú:\n"
 "\n"
 
-#: vncviewer/vncviewer.cxx:527
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
-msgstr "FullScreenAllMonitors je zastaralé, nastavte FullScreenMode na \"all\" radšej"
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+"FullScreenAllMonitors je zastaralé, nastavte FullScreenMode na \"all\" radšej"
 
-#: vncviewer/vncviewer.cxx:532
-msgid "DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' instead"
-msgstr "DotWhenNoCursor je zastaralé, nastav hodnotu AlwaysCursos na 1 a CursorType na 'Dot' namiesto toho"
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+"DotWhenNoCursor je zastaralé, nastav hodnotu AlwaysCursos na 1 a CursorType "
+"na 'Dot' namiesto toho"
 
-#: vncviewer/vncviewer.cxx:553
-msgid "~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
-msgstr "~/.vnc je zastaralé, prosím poraďte sa s \"man vncviewer\" pre možnosti, ktoré možno použiť."
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+"~/.vnc je zastaralé, prosím poraďte sa s \"man vncviewer\" pre možnosti, "
+"ktoré možno použiť."
 
-#: vncviewer/vncviewer.cxx:557
+#: vncviewer/vncviewer.cxx:556
 #, c-format
-msgid "%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC location."
-msgstr "%%APPDATA%%\\vnc je zastaralé, prosím prejdite na %%APPDATA%%\\TigerVNC priečinok."
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+"%%APPDATA%%\\vnc je zastaralé, prosím prejdite na %%APPDATA%%\\TigerVNC "
+"priečinok."
 
-#: vncviewer/vncviewer.cxx:562
+#: vncviewer/vncviewer.cxx:561
 #, c-format
 msgid "Could not create VNC config directory \"%s\": %s"
 msgstr "Nedá sa vytvoriť VNC adresár s nastaveniami: \"%s\": %s"
 
-#: vncviewer/vncviewer.cxx:568
+#: vncviewer/vncviewer.cxx:567
 msgid "Could not determine VNC data directory path"
 msgstr "Nedá sa určiť cesta k VNC adresáru pre údaje"
 
-#: vncviewer/vncviewer.cxx:574
+#: vncviewer/vncviewer.cxx:573
 #, c-format
 msgid "Could not create VNC data directory \"%s\": %s"
 msgstr "Nedá sa vytvoriť VNC adresár pre údaje: \"%s\": %s"
 
-#: vncviewer/vncviewer.cxx:586
+#: vncviewer/vncviewer.cxx:585
 #, c-format
 msgid "Could not create VNC state directory \"%s\": %s"
 msgstr "Nedá sa vytvoriť VNC adresár pre stavy: \"%s\": %s"
 
-#: vncviewer/vncviewer.cxx:703
+#: vncviewer/vncviewer.cxx:704
 #, c-format
 msgid "%s: Unrecognized option '%s'\n"
 msgstr "%s: Nerozpoznané nastavenie '%s'\n"
 
-#: vncviewer/vncviewer.cxx:705 vncviewer/vncviewer.cxx:713
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
 #, c-format
 msgid "See '%s --help' for more information.\n"
 msgstr "Pozri '%s --help' pre viac informácií.\n"
 
-#: vncviewer/vncviewer.cxx:712
+#: vncviewer/vncviewer.cxx:713
 #, c-format
 msgid "%s: Extra argument '%s'\n"
 msgstr "%s: Dodatočný argument '%s'\n"
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:748 vncviewer/vncviewer.cxx:749
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "Parametre -listen a -via sa navzájom vylučujú"
 
-#: vncviewer/vncviewer.cxx:763
+#: vncviewer/vncviewer.cxx:764
 msgid "Unable to listen for incoming connections"
 msgstr "Nedajú sa zachytávať prichádzajúce spojenia"
 
-#: vncviewer/vncviewer.cxx:765
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "Načúva sa na porte %d"
 
-#: vncviewer/vncviewer.cxx:794
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -1083,7 +1107,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:815
+#: vncviewer/vncviewer.cxx:816
 #, c-format
 msgid ""
 "Failure setting up encrypted tunnel:\n"
@@ -1097,6 +1121,95 @@ msgstr ""
 #: vncviewer/vncviewer.desktop.in.in:4
 msgid "Remote desktop viewer"
 msgstr "Prehliadač vzdialenej plochy"
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(predvolené serveru %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "Požiadavka SetDesktopSize zlyhala: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "Neplatná správa SetColourMapEntries od serveru!"
+
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "Zadané neplatné nastavenie pre %s"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "Neplatné číslo monitoru \"%s\""
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "Neočakávaný znak \"%c\""
+
+#~ msgid "VNC viewer: Connection details"
+#~ msgstr "Priehliadač VNC: Detaily o pripojení"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "O prehliadači &TigerVNC..."
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "Prehliadač TigerVNC"
+
+#~ msgid "TigerVNC viewer connection to a CentOS machine"
+#~ msgstr "Pripojenie prehliadača TigerVNC k stroju s CentOS"
+
+#~ msgid "TigerVNC viewer connection to a macOS machine"
+#~ msgstr "Pripojenie prehliadača TigerVNC k stroju s macOS"
+
+#~ msgid "TigerVNC viewer connection to a Windows machine"
+#~ msgstr "Pripojenie prehliadača TigerVNC k stroju s Windows"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "Prehliadač TigerVNC v%s\n"
+#~ "Postavený na: %s\n"
+#~ "Copyright (C) 1999-%d Tím TigerVNC a mnohí ďalší (pozri README.rst)\n"
+#~ "Pre informácie o TigerVNC navštívte https://www.tigervnc.org."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "O aplikácií prehliadač TigerVNC"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Chyba pri spustení prehliadača TigerVNC: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC viewer will now exit."
+#~ msgstr ""
+#~ "Vnútorný signál na ukončenie %d bol prijatý. Prehliadač TigerVNC sa teraz "
+#~ "ukončí."
+
+#~ msgid "TigerVNC viewer"
+#~ msgstr "Prehliadač TigerVNC"
+
+#, c-format
+#~ msgid ""
+#~ "\n"
+#~ "Options:\n"
+#~ "\n"
+#~ "  -display Xdisplay  - Specifies the X display for the viewer window\n"
+#~ "  -geometry geometry - Initial position of the main VNC viewer window. "
+#~ "See the\n"
+#~ "                       man page for details.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Možnosti:\n"
+#~ "\n"
+#~ "  -display Xdisplay  - Špecifikuje X displej pre okno prehliadača\n"
+#~ "  -geometry geometry - Počiatočná poloha hlavného okna prehliadača VNC. "
+#~ "Pozri\n"
+#~ "                       stránku man pre detaily.\n"
 
 #~ msgid "Show dot when no cursor"
 #~ msgstr "Zobraziť bodku, ak kurzor nie je zobrazený"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc-1.14.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2025-01-14 16:15+0100\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2025-05-18 09:05+0200\n"
 "Last-Translator: Мирослав Николић <miroslavnikolic@rocketmail.com>\n"
 "Language-Team: Serbian <(nothing)>\n"
@@ -15,21 +15,22 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: Poedit 3.5\n"
 
-#: vncviewer/CConn.cxx:102
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "Повезан на прикључницу „%s“"
 
-#: vncviewer/CConn.cxx:109
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "Повезан са домаћином „%s“ прикључник %d"
 
-#: vncviewer/CConn.cxx:114
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -40,66 +41,63 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:151
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Назив радне површи: %.80s"
 
-#: vncviewer/CConn.cxx:154
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Домаћин: %.80s прикључник: %d"
 
-#: vncviewer/CConn.cxx:158
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Величина: %d x %d"
 
-#: vncviewer/CConn.cxx:165
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Формат пиксела: %s"
 
-#: vncviewer/CConn.cxx:170
-#, c-format
-msgid "(server default %s)"
-msgstr "(основно на серверу %s)"
-
-#: vncviewer/CConn.cxx:173
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Затражено кодирање: %s"
 
-#: vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Последње коришћено кодирање: %s"
 
-#: vncviewer/CConn.cxx:181
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Процењена брзина линије: %d kbit/s"
 
-#: vncviewer/CConn.cxx:185
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Издања протокола: %d.%d"
 
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Метода безбедности: %s"
 
-#: vncviewer/CConn.cxx:250 vncviewer/CConn.cxx:252
-msgid "The connection was dropped by the server before the session could be established."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
 msgstr "Сервер је одбацио везу пре него ли је сесија могла да се успостави."
 
-#: vncviewer/CConn.cxx:262
+#: vncviewer/CConn.cxx:258
 #, c-format
 msgid "Authentication failed: %s"
 msgstr "Потврђивање идентитета није успело: %s"
 
-#: vncviewer/CConn.cxx:263
+#: vncviewer/CConn.cxx:259
 #, c-format
 msgid ""
 "Failed to authenticate with the server. Reason given by the server:\n"
@@ -110,31 +108,22 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:335
-#, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "Неуспело подешавање величине радне површи: %d"
-
-#: vncviewer/CConn.cxx:408
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "Неисправни уноси подешавања мапе боје са сервера!"
-
-#: vncviewer/CConn.cxx:516
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Пропусност је %d kbit/s — мењам на квалитет %d"
 
-#: vncviewer/CConn.cxx:538
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "Пропусност је %d kbit/s — пуна боја је сада омогућена"
 
-#: vncviewer/CConn.cxx:541
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "Пропусност је %d kbit/s — пуна боја је сада онемогућена"
 
-#: vncviewer/CConn.cxx:567
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Користим формат пиксела %s"
@@ -147,136 +136,128 @@ msgstr "Наведена је неисправна геометрија!"
 msgid "Reducing window size to fit on current monitor"
 msgstr "Смањујем величину прозора да стане на текући монитор"
 
-#: vncviewer/DesktopWindow.cxx:646
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
-msgstr "Прилагођавам величину прозора да би се избегли случајни захтеви за целим екраном"
+msgstr ""
+"Прилагођавам величину прозора да би се избегли случајни захтеви за целим "
+"екраном"
 
-#: vncviewer/DesktopWindow.cxx:694
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Притисните „%s“ да отворите приручни изборник"
 
-#: vncviewer/DesktopWindow.cxx:1094 vncviewer/DesktopWindow.cxx:1102
-#: vncviewer/DesktopWindow.cxx:1122
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Неуспех хватања тастатуре"
 
-#: vncviewer/DesktopWindow.cxx:1411
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
-msgstr "Прорачунат је неодговарајући распоред екрана за захтев промене величине!"
+msgstr ""
+"Прорачунат је неодговарајући распоред екрана за захтев промене величине!"
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "Неисправно стање за опонашање 3 дугмета"
 
-#: vncviewer/KeyboardWin32.cxx:242
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "Нема шифре прегледа за проширени виртуелни кључ 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:244
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "Нема шифре прегледа за виртуелни кључ 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:250
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "Неисправан код скенирања 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:262
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "Нема симбола за проширени виртуелни кључ 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:264
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "Нема симбола за виртуелни кључ 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:423
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
 msgid "Failed to update keyboard LED state: %lu"
 msgstr "Нисам успео да освежим стање диоде тастатуре: %lu"
 
-#: vncviewer/KeyboardX11.cxx:104
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "Нема симбола за шифру кључа %d (у текућем стању)"
 
-#: vncviewer/KeyboardX11.cxx:129
+#: vncviewer/KeyboardX11.cxx:148
 #, c-format
 msgid "Failed to get keyboard LED state: %d"
 msgstr "Нисам успео да добавим стање диоде тастатуре: %d"
 
-#: vncviewer/KeyboardX11.cxx:174
+#: vncviewer/KeyboardX11.cxx:193
 msgid "Failed to update keyboard LED state"
 msgstr "Нисам успео да освежим стање диоде тастатуре"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:100
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "Нисам успео да добавим подешавање монитора система"
 
-#: vncviewer/MonitorIndicesParameter.cxx:79
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "Неисправно подешавање је наведено за „%s“"
-
-#: vncviewer/MonitorIndicesParameter.cxx:86
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "Индекс монитора %d не постоји"
 
-#: vncviewer/MonitorIndicesParameter.cxx:162
-#: vncviewer/MonitorIndicesParameter.cxx:182
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "Неисправан индекс монитора „%s“"
-
-#: vncviewer/MonitorIndicesParameter.cxx:170
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "Неочекивани знак „%c“"
-
-#: vncviewer/OptionsDialog.cxx:64
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
 msgid "TigerVNC options"
 msgstr "Опције ТигарВНЦ-а"
 
-#: vncviewer/OptionsDialog.cxx:97 vncviewer/ServerDialog.cxx:107
-#: vncviewer/vncviewer.cxx:397
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "Откажи"
 
-#: vncviewer/OptionsDialog.cxx:102 vncviewer/vncviewer.cxx:396
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "У реду"
 
-#: vncviewer/OptionsDialog.cxx:514
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "Сажимање"
 
-#: vncviewer/OptionsDialog.cxx:530
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "Сам изабери"
 
-#: vncviewer/OptionsDialog.cxx:541
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "Жељено кодирање"
 
-#: vncviewer/OptionsDialog.cxx:602
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "Ниво боје"
 
-#: vncviewer/OptionsDialog.cxx:614
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "Пуна"
 
-#: vncviewer/OptionsDialog.cxx:621
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "Средња"
 
-#: vncviewer/OptionsDialog.cxx:628
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "Слаба"
 
@@ -284,166 +265,177 @@ msgstr "Слаба"
 msgid "Very low"
 msgstr "Врло слаба"
 
-#: vncviewer/OptionsDialog.cxx:657
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "Произвољни ниво сажимања:"
 
-#: vncviewer/OptionsDialog.cxx:664
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "ниво (0=брзо, 9=најбоље)"
 
-#: vncviewer/OptionsDialog.cxx:671
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "Дозволи ЈПЕГ сажимање:"
 
-#: vncviewer/OptionsDialog.cxx:678
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "квалитет (0=лош, 9=најбољи)"
 
-#: vncviewer/OptionsDialog.cxx:689
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "Безбедност"
 
-#: vncviewer/OptionsDialog.cxx:703
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "Шифровање"
 
-#: vncviewer/OptionsDialog.cxx:715 vncviewer/OptionsDialog.cxx:782
-#: vncviewer/OptionsDialog.cxx:905
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "Ништа"
 
-#: vncviewer/OptionsDialog.cxx:722
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "ТЛС са анонимним уверењима"
 
-#: vncviewer/OptionsDialog.cxx:728
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "ТЛС са X509 уверењима"
 
-#: vncviewer/OptionsDialog.cxx:735
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "Путања до X509 уверења"
 
-#: vncviewer/OptionsDialog.cxx:742
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "Путања до X509 ЦРЛ датотеке"
 
-#: vncviewer/OptionsDialog.cxx:770
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "Потврђивање идентитета"
 
-#: vncviewer/OptionsDialog.cxx:788
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "Стандардни ВНЦ (несигурно без шифровања)"
 
-#: vncviewer/OptionsDialog.cxx:794
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "Корисник и лозинка (несигурно без шифровања)"
 
-#: vncviewer/OptionsDialog.cxx:822
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "Улаз"
 
-#: vncviewer/OptionsDialog.cxx:835
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "Само преглед (занемари миша и тастатуру)"
 
-#: vncviewer/OptionsDialog.cxx:842
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "Миш"
 
-#: vncviewer/OptionsDialog.cxx:854
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "Опонашај средње дугме миша"
 
-#: vncviewer/OptionsDialog.cxx:860
+#: vncviewer/OptionsDialog.cxx:880
 msgid "Show local cursor when not provided by server"
 msgstr "Прикажи локални курзор када га сервер не достави"
 
-#: vncviewer/OptionsDialog.cxx:865
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
 msgid "Cursor type"
 msgstr "Врста курзора"
 
-#: vncviewer/OptionsDialog.cxx:867
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
 msgid "Dot"
 msgstr "Тачка"
 
-#: vncviewer/OptionsDialog.cxx:868
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
 msgid "System"
 msgstr "Систем"
 
-#: vncviewer/OptionsDialog.cxx:888
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "Тастатура"
 
-#: vncviewer/OptionsDialog.cxx:900
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
 msgstr "Проследи системске кључеве директно на сервер (пун екран)"
 
-#: vncviewer/OptionsDialog.cxx:903
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "Тастер изборника"
 
-#: vncviewer/OptionsDialog.cxx:926
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "Остава"
 
-#: vncviewer/OptionsDialog.cxx:938
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "Прихвати оставу са сервера"
 
-#: vncviewer/OptionsDialog.cxx:946
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "Такође постави први избор"
 
-#: vncviewer/OptionsDialog.cxx:953
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "Пошаљи оставу на сервер"
 
-#: vncviewer/OptionsDialog.cxx:961
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "Пошаљи први избор као оставу"
 
-#: vncviewer/OptionsDialog.cxx:982
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "Приказ"
 
-#: vncviewer/OptionsDialog.cxx:996
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "Режим приказа"
 
-#: vncviewer/OptionsDialog.cxx:1009
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "Упрозорен"
 
-#: vncviewer/OptionsDialog.cxx:1017
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "Цео екран на текућем монитору"
 
-#: vncviewer/OptionsDialog.cxx:1025
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "Цео екран на свим мониторима"
 
-#: vncviewer/OptionsDialog.cxx:1033
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "Цео екран на изабраном монитору"
 
-#: vncviewer/OptionsDialog.cxx:1062
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
 msgid "Miscellaneous"
 msgstr "Разно"
 
-#: vncviewer/OptionsDialog.cxx:1070
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "Дељено (не прекидај везу другим прегледачима)"
 
-#: vncviewer/OptionsDialog.cxx:1076
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "Питај за поновно повезивање при грешкама везе"
-
-#: vncviewer/ServerDialog.cxx:63
-msgid "VNC viewer: Connection details"
-msgstr "ВНЦ прегледач: Појединости повезивања"
 
 #: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
@@ -488,7 +480,7 @@ msgstr "Подешавање ТиграВНЦ (*.tigervnc)"
 msgid "Select a TigerVNC configuration file"
 msgstr "Изаберите датотеку подешавања ТиграВНЦ"
 
-#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:517
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -508,7 +500,7 @@ msgstr "Сачувајте подешавање ТиграВНЦ у датоте
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "„%s“ већ постоји. Желите ли да је препишете?"
 
-#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:394
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "Не"
 
@@ -549,169 +541,170 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:351 vncviewer/ServerDialog.cxx:429
-#: vncviewer/vncviewer.cxx:580
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
 msgid "Could not determine VNC state directory path"
 msgstr "Не могу да одредим путању фасцикле ВНЦ стања"
 
-#: vncviewer/ServerDialog.cxx:363 vncviewer/ServerDialog.cxx:437
-#: vncviewer/parameters.cxx:671 vncviewer/parameters.cxx:752
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
 msgid "Could not open \"%s\""
 msgstr "Не могу да отворим „%s“"
 
-#: vncviewer/ServerDialog.cxx:378 vncviewer/ServerDialog.cxx:387
-#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:773
-#: vncviewer/parameters.cxx:807 vncviewer/parameters.cxx:837
-#: vncviewer/parameters.cxx:844
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
 msgid "Failed to read line %d in file \"%s\""
 msgstr "Нисам успео да прочитам %d. ред у датотеци „%s“"
 
-#: vncviewer/ServerDialog.cxx:390 vncviewer/parameters.cxx:776
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "Ред је предуг"
 
-#: vncviewer/UserDialog.cxx:123
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "Отварање датотеке лозинке није успело"
 
-#: vncviewer/UserDialog.cxx:143
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "Потврђивање идентитета ВНЦ-а"
 
-#: vncviewer/UserDialog.cxx:150
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "Ова веза је безбедна"
 
-#: vncviewer/UserDialog.cxx:154
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "Ова веза није безбедна"
 
-#: vncviewer/UserDialog.cxx:176
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "Корисник:"
 
-#: vncviewer/UserDialog.cxx:189
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "Лозинка:"
 
-#: vncviewer/UserDialog.cxx:197
+#: vncviewer/UserDialog.cxx:204
 msgid "Keep password for reconnect"
 msgstr "Задржи лозинку за поновно повезивање"
 
-#: vncviewer/Viewport.cxx:695
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
 msgid "Disconn&ect"
 msgstr "Пре&кини везу"
 
-#: vncviewer/Viewport.cxx:698
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "&Пун екран"
 
-#: vncviewer/Viewport.cxx:701
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "&Умањи"
 
-#: vncviewer/Viewport.cxx:703
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "&Величина прозора на сесију"
 
-#: vncviewer/Viewport.cxx:708
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ктрл"
 
-#: vncviewer/Viewport.cxx:711
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Алт"
 
-#: vncviewer/Viewport.cxx:717
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "Пошаљи „%s“"
 
-#: vncviewer/Viewport.cxx:724
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Пошаљи Ктрл-Алт-&Дел"
 
-#: vncviewer/Viewport.cxx:727
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "&Освежи екран"
 
-#: vncviewer/Viewport.cxx:730
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&Могућности..."
 
-#: vncviewer/Viewport.cxx:732
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "Подаци о &вези..."
 
-#: vncviewer/Viewport.cxx:734
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "О &програму..."
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:830
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "Подаци о ВНЦ вези"
 
-#: vncviewer/Win32TouchHandler.cxx:48
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "Прозор је регистрован за додир уместо покрета"
 
-#: vncviewer/Win32TouchHandler.cxx:83
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "Нисам успео да поставим подешавање покрета (грешка 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:95
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "Нисам успео да добавим информације покрета (грешка 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:360
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr "Неисправно дугме миша %d, мора бити број између 1 и 7."
 
-#: vncviewer/Win32TouchHandler.cxx:425
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
 msgstr "Необрадиви тастер 0x%x – не могу да створим догађај тастатуре."
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:107
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
 msgstr "Не могу да добавим маску „X Input 2“ догађаја за прозор 0x%08lx"
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr "Прозор 0x%08lx нема маску „X Input 2“ догађаја"
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:114
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr "Прозор 0x%08lx има више од једне маске „X Input 2“ догађаја"
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "Неуспех хватања уређаја %i"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-msgid "TigerVNC Viewer"
-msgstr "Прегледач ТигарВНЦ"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -719,100 +712,127 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr "Повежите се на ВНЦ сервер и прикажите удаљену радну површ"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
-msgstr "Виртуелно мрежно рачунарство (VNC) је систем удаљеног приказа који вам омогућава да видте и радите са виртуелним окружењем радне површи које ради на другом рачунару на мрежи. Коришћењем ВМР-а, можете да покрећете графичке програме на удаљеном рачунару и да пошаљете само приказ тих програма вашем локалном уређају. Овај пакет садржи клијента који ће вам омогућити да се повежете са другим радним површима на којима ради ВМР сервер. ВМР је независан од платформе и подржава разне оперативне системе и архитектуре као и сервере и клијенте."
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+"Виртуелно мрежно рачунарство (VNC) је систем удаљеног приказа који вам "
+"омогућава да видте и радите са виртуелним окружењем радне површи које ради "
+"на другом рачунару на мрежи. Коришћењем ВМР-а, можете да покрећете графичке "
+"програме на удаљеном рачунару и да пошаљете само приказ тих програма вашем "
+"локалном уређају. Овај пакет садржи клијента који ће вам омогућити да се "
+"повежете са другим радним површима на којима ради ВМР сервер. ВМР је "
+"независан од платформе и подржава разне оперативне системе и архитектуре као "
+"и сервере и клијенте."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
-msgstr "ТигарВНЦ великобрзинско издање ВНЦ-а засновано на основама „RealVNC“-у 4 и „X.org“ кода. ТигарВНЦ је започео као развојно залагање следеће генерације за „TightVNC“ на Јуникс и Линукс платформама, али се издваја из свог родитељског пројекта у раним 2009 тако да се „TightVNC“ може фокусирати на Виндоуз платформама. ТигарВНЦ подржава варијанту „Tight“ кодирања тако да је поприлично убрзан коришћењем „libjpeg-turbo“ ЈПЕГ кодека."
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+"ТигарВНЦ великобрзинско издање ВНЦ-а засновано на основама „RealVNC“-у 4 и "
+"„X.org“ кода. ТигарВНЦ је започео као развојно залагање следеће генерације "
+"за „TightVNC“ на Јуникс и Линукс платформама, али се издваја из свог "
+"родитељског пројекта у раним 2009 тако да се „TightVNC“ може фокусирати на "
+"Виндоуз платформама. ТигарВНЦ подржава варијанту „Tight“ кодирања тако да је "
+"поприлично убрзан коришћењем „libjpeg-turbo“ ЈПЕГ кодека."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC viewer connection to a CentOS machine"
-msgstr "Веза ТигарВНЦ прегледача са CentOS рачунаром"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC viewer connection to a macOS machine"
-msgstr "Веза ТигарВНЦ прегледача са macOS рачунаром"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC viewer connection to a Windows machine"
-msgstr "Веза ТигарВНЦ прегледача са Виндоуз рачунаром"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
 #. developer_name tag deprecated with Appstream 1.0
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
-#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:48
 msgid "The TigerVNC team"
 msgstr "Тим ТигарВНЦ-а"
 
-#: vncviewer/parameters.cxx:319 vncviewer/parameters.cxx:344
-#: vncviewer/parameters.cxx:361 vncviewer/parameters.cxx:401
-#: vncviewer/parameters.cxx:421
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "Назив параметра је превелик"
 
-#: vncviewer/parameters.cxx:323 vncviewer/parameters.cxx:328
-#: vncviewer/parameters.cxx:379
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "Параметар је превелик"
 
-#: vncviewer/parameters.cxx:386 vncviewer/parameters.cxx:712
-#: vncviewer/parameters.cxx:822
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "Неисправан запис или предуга вредност"
 
-#: vncviewer/parameters.cxx:440 vncviewer/parameters.cxx:473
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "Нисам успео да направим кључ регистра"
 
-#: vncviewer/parameters.cxx:461 vncviewer/parameters.cxx:528
-#: vncviewer/parameters.cxx:571 vncviewer/parameters.cxx:638
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "Нисам успео да затворим кључ регистра"
 
-#: vncviewer/parameters.cxx:479 vncviewer/parameters.cxx:506
-#: vncviewer/parameters.cxx:680 vncviewer/parameters.cxx:692
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "Нисам успео да сачувам „%s“: %s"
 
-#: vncviewer/parameters.cxx:489 vncviewer/parameters.cxx:520
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "Нисам успео да уклоним „%s“: %s"
 
-#: vncviewer/parameters.cxx:544 vncviewer/parameters.cxx:616
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "Нисам успео да отворим кључ регистра"
 
-#: vncviewer/parameters.cxx:561
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "Нисам успео да прочитам унос историјата сервера %d: %s"
 
-#: vncviewer/parameters.cxx:597 vncviewer/parameters.cxx:627
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "Нисам успео да прочитам параметар „%s“: %s"
 
-#: vncviewer/parameters.cxx:661 vncviewer/parameters.cxx:740
-#: vncviewer/vncviewer.cxx:546
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
 msgid "Could not determine VNC config directory path"
 msgstr "Не могу да одредим путању фасцикле ВНЦ подешавања"
 
-#: vncviewer/parameters.cxx:682 vncviewer/parameters.cxx:694
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "Не могу да кодирам параметар"
 
-#: vncviewer/parameters.cxx:785
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "Датотека подешавања „%s“ је у неисправном запису"
 
-#: vncviewer/parameters.cxx:809
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "Неисправан запис"
 
-#: vncviewer/parameters.cxx:846
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "Непознат параметар"
 
@@ -853,23 +873,22 @@ msgid "X Input 2 (or newer) is not available."
 msgstr "„X Input 2“ (или новије) није доступно."
 
 #: vncviewer/touch.cxx:266
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
-msgstr "„X Input 2“ (или новије) није доступно. Покрети додира неће бити подржани."
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+"„X Input 2“ (или новије) није доступно. Покрети додира неће бити подржани."
 
-#: vncviewer/vncviewer.cxx:104
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
 "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"Прегледач ТигарВНЦ и%s\n"
-"Изграђен: %s\n"
-"Ауторска права © 1999-%d Тим ТигарВНЦ-а и многи други (видите „README.rst“)\n"
-"Посетите „https://www.tigervnc.org“ да сазнате више о програму."
 
-#: vncviewer/vncviewer.cxx:158
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -880,15 +899,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:174
-msgid "About TigerVNC Viewer"
-msgstr "О програму"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:195
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "Унутрашња ФЛТК грешка. Излазим."
 
-#: vncviewer/vncviewer.cxx:214
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -899,63 +918,59 @@ msgstr ""
 "\n"
 "Да покушам да се поново повежем?"
 
-#: vncviewer/vncviewer.cxx:245 vncviewer/vncviewer.cxx:257
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Грешка покретања новог примерка програма: %s"
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:266
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC viewer will now exit."
-msgstr "Примљен је сигнал за окончавање %d. Програм ће сада изаћи."
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:391 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC viewer"
-msgstr "Прегледач ТигарВНЦ"
-
-#: vncviewer/vncviewer.cxx:395
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "Да"
 
-#: vncviewer/vncviewer.cxx:398
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "Затвори"
 
-#: vncviewer/vncviewer.cxx:403
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "О програму"
 
-#: vncviewer/vncviewer.cxx:406
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "Сакриј"
 
-#: vncviewer/vncviewer.cxx:409
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "Изађи"
 
-#: vncviewer/vncviewer.cxx:413
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "Услуге"
 
-#: vncviewer/vncviewer.cxx:414
+#: vncviewer/vncviewer.cxx:413
 msgid "Hide others"
 msgstr "Сакриј остале"
 
-#: vncviewer/vncviewer.cxx:415
+#: vncviewer/vncviewer.cxx:414
 msgid "Show all"
 msgstr "Прикажи све"
 
-#: vncviewer/vncviewer.cxx:424
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "&Датотека"
 
-#: vncviewer/vncviewer.cxx:427
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "&Нова веза"
 
-#: vncviewer/vncviewer.cxx:450
+#: vncviewer/vncviewer.cxx:449
 #, c-format
 msgid ""
 "\n"
@@ -972,24 +987,19 @@ msgstr ""
 "       %s [parametri] -listen [prikqučnik]\n"
 "       %s [parametri] [.tigervnc datteka]\n"
 
-#: vncviewer/vncviewer.cxx:465
+#: vncviewer/vncviewer.cxx:464
 #, c-format
 msgid ""
 "\n"
 "Options:\n"
 "\n"
 "  -display Xdisplay  - Specifies the X display for the viewer window\n"
-"  -geometry geometry - Initial position of the main VNC viewer window. See the\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
 "                       man page for details.\n"
 msgstr ""
-"\n"
-"Опције:\n"
-"\n"
-"  -display Xdisplay  – Наводи X приказ за прозор прегледача\n"
-"  -geometry geometry – почетни почожај главног прозора VNC прегледача. Вифите\n"
-"                       страницу упутства за више о томе.\n"
 
-#: vncviewer/vncviewer.cxx:472
+#: vncviewer/vncviewer.cxx:471
 #, c-format
 msgid ""
 "\n"
@@ -1002,77 +1012,88 @@ msgstr ""
 "\n"
 "Параметри се могу укључити са „-<param>“ или искључити са „-<param>=0“\n"
 "Параметри који имају вредност се могу навести као „-<param> <vrednost>“\n"
-"Други исправни облици су „<param>=<vrednost> -<param>=<vrednost> --<param>=<vrednost>“\n"
+"Други исправни облици су „<param>=<vrednost> -<param>=<vrednost> --"
+"<param>=<vrednost>“\n"
 "Називи параметара нису осетљиви на величину слова.  Параметри су:\n"
 "\n"
 
-#: vncviewer/vncviewer.cxx:527
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
-msgstr "„FullScreenAllMonitors“ је застарело, поставите „FullScreenMode“ на „all“"
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+"„FullScreenAllMonitors“ је застарело, поставите „FullScreenMode“ на „all“"
 
-#: vncviewer/vncviewer.cxx:532
-msgid "DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' instead"
-msgstr "„DotWhenNoCursor“ је застарело, поставите „AlwaysCursor“ на 1 и „CursorType“ на „Dot“ (тачка)"
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+"„DotWhenNoCursor“ је застарело, поставите „AlwaysCursor“ на 1 и „CursorType“ "
+"на „Dot“ (тачка)"
 
-#: vncviewer/vncviewer.cxx:553
-msgid "~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
-msgstr "„~/.vnc“ је застарело, погледајте „man vncviewer“ за путање за пресељење."
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+"„~/.vnc“ је застарело, погледајте „man vncviewer“ за путање за пресељење."
 
-#: vncviewer/vncviewer.cxx:557
+#: vncviewer/vncviewer.cxx:556
 #, c-format
-msgid "%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC location."
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
 msgstr "„%%APPDATA%%\\vnc“ је застарело, пређите на „%%APPDATA%%\\TigerVNC“."
 
-#: vncviewer/vncviewer.cxx:562
+#: vncviewer/vncviewer.cxx:561
 #, c-format
 msgid "Could not create VNC config directory \"%s\": %s"
 msgstr "Не могу да направим фасциклу подешавања ВНЦ-а „%s“: %s"
 
-#: vncviewer/vncviewer.cxx:568
+#: vncviewer/vncviewer.cxx:567
 msgid "Could not determine VNC data directory path"
 msgstr "Не могу да одредим путању фасцикле ВНЦ података"
 
-#: vncviewer/vncviewer.cxx:574
+#: vncviewer/vncviewer.cxx:573
 #, c-format
 msgid "Could not create VNC data directory \"%s\": %s"
 msgstr "Не могу да направим фасциклу података ВНЦ-а „%s“: %s"
 
-#: vncviewer/vncviewer.cxx:586
+#: vncviewer/vncviewer.cxx:585
 #, c-format
 msgid "Could not create VNC state directory \"%s\": %s"
 msgstr "Не могу да направим фасциклу стања ВНЦ-а „%s“: %s"
 
-#: vncviewer/vncviewer.cxx:703
+#: vncviewer/vncviewer.cxx:704
 #, c-format
 msgid "%s: Unrecognized option '%s'\n"
 msgstr "%s: Непозната опција „%s“\n"
 
-#: vncviewer/vncviewer.cxx:705 vncviewer/vncviewer.cxx:713
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
 #, c-format
 msgid "See '%s --help' for more information.\n"
 msgstr "Видите „%s --help“ за више информација.\n"
 
-#: vncviewer/vncviewer.cxx:712
+#: vncviewer/vncviewer.cxx:713
 #, c-format
 msgid "%s: Extra argument '%s'\n"
 msgstr "%s: Додатни аргумент „%s“\n"
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:748 vncviewer/vncviewer.cxx:749
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "Параметри „-listen“ и „-via“ нису сагласни"
 
-#: vncviewer/vncviewer.cxx:763
+#: vncviewer/vncviewer.cxx:764
 msgid "Unable to listen for incoming connections"
 msgstr "Не могу да ослушкујем долазне везе"
 
-#: vncviewer/vncviewer.cxx:765
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "Ослушкујем на прикључнику %d"
 
-#: vncviewer/vncviewer.cxx:794
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -1083,7 +1104,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:815
+#: vncviewer/vncviewer.cxx:816
 #, c-format
 msgid ""
 "Failure setting up encrypted tunnel:\n"
@@ -1097,6 +1118,94 @@ msgstr ""
 #: vncviewer/vncviewer.desktop.in.in:4
 msgid "Remote desktop viewer"
 msgstr "Прегледач удаљених радних површи"
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(основно на серверу %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "Неуспело подешавање величине радне површи: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "Неисправни уноси подешавања мапе боје са сервера!"
+
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "Неисправно подешавање је наведено за „%s“"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "Неисправан индекс монитора „%s“"
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "Неочекивани знак „%c“"
+
+#~ msgid "VNC viewer: Connection details"
+#~ msgstr "ВНЦ прегледач: Појединости повезивања"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "О &програму..."
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "Прегледач ТигарВНЦ"
+
+#~ msgid "TigerVNC viewer connection to a CentOS machine"
+#~ msgstr "Веза ТигарВНЦ прегледача са CentOS рачунаром"
+
+#~ msgid "TigerVNC viewer connection to a macOS machine"
+#~ msgstr "Веза ТигарВНЦ прегледача са macOS рачунаром"
+
+#~ msgid "TigerVNC viewer connection to a Windows machine"
+#~ msgstr "Веза ТигарВНЦ прегледача са Виндоуз рачунаром"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "Прегледач ТигарВНЦ и%s\n"
+#~ "Изграђен: %s\n"
+#~ "Ауторска права © 1999-%d Тим ТигарВНЦ-а и многи други (видите „README."
+#~ "rst“)\n"
+#~ "Посетите „https://www.tigervnc.org“ да сазнате више о програму."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "О програму"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Грешка покретања новог примерка програма: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC viewer will now exit."
+#~ msgstr "Примљен је сигнал за окончавање %d. Програм ће сада изаћи."
+
+#~ msgid "TigerVNC viewer"
+#~ msgstr "Прегледач ТигарВНЦ"
+
+#, c-format
+#~ msgid ""
+#~ "\n"
+#~ "Options:\n"
+#~ "\n"
+#~ "  -display Xdisplay  - Specifies the X display for the viewer window\n"
+#~ "  -geometry geometry - Initial position of the main VNC viewer window. "
+#~ "See the\n"
+#~ "                       man page for details.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Опције:\n"
+#~ "\n"
+#~ "  -display Xdisplay  – Наводи X приказ за прозор прегледача\n"
+#~ "  -geometry geometry – почетни почожај главног прозора VNC прегледача. "
+#~ "Вифите\n"
+#~ "                       страницу упутства за више о томе.\n"
 
 #~ msgid "Show dot when no cursor"
 #~ msgstr "Прикажи тачку када нема курзора"
@@ -1177,20 +1286,29 @@ msgstr "Прегледач удаљених радних површи"
 #~ msgid "The parameter %s was too large to read from the registry"
 #~ msgstr "Параметар „%s“ беше превелик за читање из регистра"
 
-#~ msgid "Failed to write configuration file, can't obtain home directory path."
-#~ msgstr "Нисам успео да упишем датотеку подешавања, не могу да добијем путању личне фасцикле."
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Нисам успео да упишем датотеку подешавања, не могу да добијем путању "
+#~ "личне фасцикле."
 
 #~ msgid "Failed to write configuration file, can't open %s: %s"
-#~ msgstr "Нисам успео да упишем датотеку подешавања, не могу да отворим „%s“: %s"
+#~ msgstr ""
+#~ "Нисам успео да упишем датотеку подешавања, не могу да отворим „%s“: %s"
 
 #~ msgid "Failed to read configuration file, can't obtain home directory path."
-#~ msgstr "Нисам успео да прочитам датотеку подешавања, не могу да добијем путању личне фасцикле."
+#~ msgstr ""
+#~ "Нисам успео да прочитам датотеку подешавања, не могу да добијем путању "
+#~ "личне фасцикле."
 
 #~ msgid "Unknown parameter %s on line %d in file %s"
 #~ msgstr "Непознат параметар „%s“ у %d. реду у датотеци „%s“"
 
-#~ msgid "Could not create VNC home directory: can't obtain home directory path."
-#~ msgstr "Не могу да направим личну фасциклу ВНЦ-а: не могу да добијем путању личне фасцикле."
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
+#~ msgstr ""
+#~ "Не могу да направим личну фасциклу ВНЦ-а: не могу да добијем путању личне "
+#~ "фасцикле."
 
 #~ msgid "tigervnc"
 #~ msgstr "tigervnc"

--- a/po/sv.po
+++ b/po/sv.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.14.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2025-01-14 16:15+0100\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2025-01-22 07:43+0100\n"
 "Last-Translator: Luna Jernberg <droidbittin@gmail.com>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -23,17 +23,17 @@ msgstr ""
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: Poedit 3.5\n"
 
-#: vncviewer/CConn.cxx:102
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "Ansluten till uttaget %s"
 
-#: vncviewer/CConn.cxx:109
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "Ansluten till värden %s port %d"
 
-#: vncviewer/CConn.cxx:114
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -44,66 +44,63 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:151
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Skrivbordsnamn: %.80s"
 
-#: vncviewer/CConn.cxx:154
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Värd: %.80s port: %d"
 
-#: vncviewer/CConn.cxx:158
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Storlek: %d x %d"
 
-#: vncviewer/CConn.cxx:165
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Pixelformat: %s"
 
-#: vncviewer/CConn.cxx:170
-#, c-format
-msgid "(server default %s)"
-msgstr "(serverstandard %s)"
-
-#: vncviewer/CConn.cxx:173
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Begärd kodning: %s"
 
-#: vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Senast använd kodning: %s"
 
-#: vncviewer/CConn.cxx:181
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Uppskattad hastighet på förbindelsen: %d kbit/s"
 
-#: vncviewer/CConn.cxx:185
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Protokollversion: %d.%d"
 
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Säkerhetsmetod: %s"
 
-#: vncviewer/CConn.cxx:250 vncviewer/CConn.cxx:252
-msgid "The connection was dropped by the server before the session could be established."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
 msgstr "Anslutningen släpptes av servern innan sessionen kunde etableras."
 
-#: vncviewer/CConn.cxx:262
+#: vncviewer/CConn.cxx:258
 #, c-format
 msgid "Authentication failed: %s"
 msgstr "Autentisering misslyckades: %s"
 
-#: vncviewer/CConn.cxx:263
+#: vncviewer/CConn.cxx:259
 #, c-format
 msgid ""
 "Failed to authenticate with the server. Reason given by the server:\n"
@@ -114,31 +111,22 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:335
-#, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "SetDesktopSize misslyckades: %d"
-
-#: vncviewer/CConn.cxx:408
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "Ogiltig SetColourMapEntries från server!"
-
-#: vncviewer/CConn.cxx:516
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Bandbredd %d kbit/s - byter till kvalitet %d"
 
-#: vncviewer/CConn.cxx:538
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "Bandbredd %d kbit/s – fullfärg är nu aktiverat"
 
-#: vncviewer/CConn.cxx:541
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "Bandbredd %d kbit/s – fullfärg är nu avaktiverat"
 
-#: vncviewer/CConn.cxx:567
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Använder pixelformat %s"
@@ -151,136 +139,125 @@ msgstr "Ogiltig geometri angiven!"
 msgid "Reducing window size to fit on current monitor"
 msgstr "Reducerar fönsterstorleken till att passa på den aktuella bildskärmen"
 
-#: vncviewer/DesktopWindow.cxx:646
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
 msgstr "Justerar fönsterstorleken för att undvika fullskärm av misstag"
 
-#: vncviewer/DesktopWindow.cxx:694
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Tryck %s för att öppna sammanhangsmenyn"
 
-#: vncviewer/DesktopWindow.cxx:1094 vncviewer/DesktopWindow.cxx:1102
-#: vncviewer/DesktopWindow.cxx:1122
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Misslyckades med att fånga tangentbordet"
 
-#: vncviewer/DesktopWindow.cxx:1411
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
 msgstr "Ogiltig skärmlayout beräknad för storleksförändrings-begäran!"
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "Felaktigt tillstånd för 3-knappsemulering"
 
-#: vncviewer/KeyboardWin32.cxx:242
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "Ingen scancode för utökad virtuell tangent 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:244
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "Ingen scancode för virtuell tangent 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:250
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "Felaktig skanningskod 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:262
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "Ingen symbol för utökad virtuell tangent 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:264
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "Ingen symbol för virtuell tangent 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:423
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
 msgid "Failed to update keyboard LED state: %lu"
 msgstr "Misslyckades att uppdatera tillståndet för tangentbords-LED: %lu"
 
-#: vncviewer/KeyboardX11.cxx:104
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "Ingen symbol för tangentkod %d (i nuvarande tillstånd)"
 
-#: vncviewer/KeyboardX11.cxx:129
+#: vncviewer/KeyboardX11.cxx:148
 #, c-format
 msgid "Failed to get keyboard LED state: %d"
 msgstr "Misslyckades att hämta tillståndet för tangentbords-LED: %d"
 
-#: vncviewer/KeyboardX11.cxx:174
+#: vncviewer/KeyboardX11.cxx:193
 msgid "Failed to update keyboard LED state"
 msgstr "Misslyckades att uppdatera tillståndet för tangentbords-LED"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:100
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "Misslyckades att hämta systemets bildskärmskonfiguration"
 
-#: vncviewer/MonitorIndicesParameter.cxx:79
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "Ogiltig konfiguration angiven för %s"
-
-#: vncviewer/MonitorIndicesParameter.cxx:86
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "Bildskärmsindex %d finns inte"
 
-#: vncviewer/MonitorIndicesParameter.cxx:162
-#: vncviewer/MonitorIndicesParameter.cxx:182
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "Felaktigt skärmindex ”%s”"
-
-#: vncviewer/MonitorIndicesParameter.cxx:170
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "Oväntat tecken ”%c”"
-
-#: vncviewer/OptionsDialog.cxx:64
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
 msgid "TigerVNC options"
 msgstr "TigerVNC alternativ"
 
-#: vncviewer/OptionsDialog.cxx:97 vncviewer/ServerDialog.cxx:107
-#: vncviewer/vncviewer.cxx:397
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: vncviewer/OptionsDialog.cxx:102 vncviewer/vncviewer.cxx:396
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "Ok"
 
-#: vncviewer/OptionsDialog.cxx:514
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "Kompression"
 
-#: vncviewer/OptionsDialog.cxx:530
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "Automatiskt val"
 
-#: vncviewer/OptionsDialog.cxx:541
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "Föredragen kodning"
 
-#: vncviewer/OptionsDialog.cxx:602
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "Färgnivå"
 
-#: vncviewer/OptionsDialog.cxx:614
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "Fullständig"
 
-#: vncviewer/OptionsDialog.cxx:621
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "Medium"
 
-#: vncviewer/OptionsDialog.cxx:628
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "Låg"
 
@@ -288,166 +265,177 @@ msgstr "Låg"
 msgid "Very low"
 msgstr "Mycket låg"
 
-#: vncviewer/OptionsDialog.cxx:657
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "Anpassad komprimeringsnivå:"
 
-#: vncviewer/OptionsDialog.cxx:664
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "kvalitet (0=snabb, 9=bäst)"
 
-#: vncviewer/OptionsDialog.cxx:671
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "Tillåt JPEG-komprimering:"
 
-#: vncviewer/OptionsDialog.cxx:678
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "kvalitet (0=dålig, 9=bäst)"
 
-#: vncviewer/OptionsDialog.cxx:689
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "Säkerhet"
 
-#: vncviewer/OptionsDialog.cxx:703
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "Kryptering"
 
-#: vncviewer/OptionsDialog.cxx:715 vncviewer/OptionsDialog.cxx:782
-#: vncviewer/OptionsDialog.cxx:905
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "Ingen"
 
-#: vncviewer/OptionsDialog.cxx:722
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "TLS med anonyma certifikat"
 
-#: vncviewer/OptionsDialog.cxx:728
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "TLS med X509-certifikat"
 
-#: vncviewer/OptionsDialog.cxx:735
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "Sökväg till CA-certifikat för X509"
 
-#: vncviewer/OptionsDialog.cxx:742
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "Sökväg till CRL-fil för X509"
 
-#: vncviewer/OptionsDialog.cxx:770
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "Autentisering"
 
-#: vncviewer/OptionsDialog.cxx:788
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "Standard-VNC (osäkert utan kryptering)"
 
-#: vncviewer/OptionsDialog.cxx:794
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "Användarnamn och lösenord (osäkert utan kryptering)"
 
-#: vncviewer/OptionsDialog.cxx:822
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "Inmatning"
 
-#: vncviewer/OptionsDialog.cxx:835
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "Endast visning (ignorera mus och tangentbord)"
 
-#: vncviewer/OptionsDialog.cxx:842
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "Mus"
 
-#: vncviewer/OptionsDialog.cxx:854
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "Emulera mittenknapp på musen"
 
-#: vncviewer/OptionsDialog.cxx:860
+#: vncviewer/OptionsDialog.cxx:880
 msgid "Show local cursor when not provided by server"
 msgstr "Visa den lokala markören när den inte tillhandahålls av servern"
 
-#: vncviewer/OptionsDialog.cxx:865
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
 msgid "Cursor type"
 msgstr "Markörtyp"
 
-#: vncviewer/OptionsDialog.cxx:867
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
 msgid "Dot"
 msgstr "Punkt"
 
-#: vncviewer/OptionsDialog.cxx:868
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
 msgid "System"
 msgstr "System"
 
-#: vncviewer/OptionsDialog.cxx:888
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "Tangentbord"
 
-#: vncviewer/OptionsDialog.cxx:900
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
 msgstr "Skicka systemtangenter direkt till servern (fullskärm)"
 
-#: vncviewer/OptionsDialog.cxx:903
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "Menytangent"
 
-#: vncviewer/OptionsDialog.cxx:926
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "Urklipp"
 
-#: vncviewer/OptionsDialog.cxx:938
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "Acceptera urklipp från server"
 
-#: vncviewer/OptionsDialog.cxx:946
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "Sätt även primär markering"
 
-#: vncviewer/OptionsDialog.cxx:953
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "Skicka urklipp till server"
 
-#: vncviewer/OptionsDialog.cxx:961
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "Skicka primär markering som urklipp"
 
-#: vncviewer/OptionsDialog.cxx:982
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "Display"
 
-#: vncviewer/OptionsDialog.cxx:996
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "Visningsläge"
 
-#: vncviewer/OptionsDialog.cxx:1009
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "Fönster"
 
-#: vncviewer/OptionsDialog.cxx:1017
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "Helskärm på nuvarande bildskärm"
 
-#: vncviewer/OptionsDialog.cxx:1025
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "Helskärm på alla bildskärmar"
 
-#: vncviewer/OptionsDialog.cxx:1033
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "Helskärm på valda bildskärmar"
 
-#: vncviewer/OptionsDialog.cxx:1062
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
 msgid "Miscellaneous"
 msgstr "Diverse"
 
-#: vncviewer/OptionsDialog.cxx:1070
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "Delad (koppla ej från andra visare)"
 
-#: vncviewer/OptionsDialog.cxx:1076
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "Be att få återansluta vid anslutningsfel"
-
-#: vncviewer/ServerDialog.cxx:63
-msgid "VNC viewer: Connection details"
-msgstr "VNC visare: Anslutningsdetaljer"
 
 #: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
@@ -492,7 +480,7 @@ msgstr "TigerVNC-konfiguration (*.tigervnc)"
 msgid "Select a TigerVNC configuration file"
 msgstr "Välj en TigerVNC-konfigurationsfil"
 
-#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:517
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -512,7 +500,7 @@ msgstr "Spara TigerVNC-konfigurationen i en fil"
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "%s finns redan.  Vill du skriva över den?"
 
-#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:394
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "Nej"
 
@@ -553,169 +541,170 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:351 vncviewer/ServerDialog.cxx:429
-#: vncviewer/vncviewer.cxx:580
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
 msgid "Could not determine VNC state directory path"
 msgstr "Kunde inte bestämma VNC-tillståndskatalogsökväg"
 
-#: vncviewer/ServerDialog.cxx:363 vncviewer/ServerDialog.cxx:437
-#: vncviewer/parameters.cxx:671 vncviewer/parameters.cxx:752
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
 msgid "Could not open \"%s\""
 msgstr "Kunde inte öppna \"%s\""
 
-#: vncviewer/ServerDialog.cxx:378 vncviewer/ServerDialog.cxx:387
-#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:773
-#: vncviewer/parameters.cxx:807 vncviewer/parameters.cxx:837
-#: vncviewer/parameters.cxx:844
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
 msgid "Failed to read line %d in file \"%s\""
 msgstr "Misslyckades med att läsa rad %d i fil \"%s\""
 
-#: vncviewer/ServerDialog.cxx:390 vncviewer/parameters.cxx:776
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "Raden är för lång"
 
-#: vncviewer/UserDialog.cxx:123
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "Öppning av lösenordsfilen misslyckades"
 
-#: vncviewer/UserDialog.cxx:143
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "VNC-autentisering"
 
-#: vncviewer/UserDialog.cxx:150
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "Denna anslutning är säker"
 
-#: vncviewer/UserDialog.cxx:154
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "Denna anslutning är inte säker"
 
-#: vncviewer/UserDialog.cxx:176
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "Användarnamn:"
 
-#: vncviewer/UserDialog.cxx:189
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "Lösenord:"
 
-#: vncviewer/UserDialog.cxx:197
+#: vncviewer/UserDialog.cxx:204
 msgid "Keep password for reconnect"
 msgstr "Behåll lösenordet för att återansluta"
 
-#: vncviewer/Viewport.cxx:695
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
 msgid "Disconn&ect"
 msgstr "Koppla &ifrån"
 
-#: vncviewer/Viewport.cxx:698
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "&Fullskärm"
 
-#: vncviewer/Viewport.cxx:701
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "M&inimera"
 
-#: vncviewer/Viewport.cxx:703
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "Anpassa &fönster till session"
 
-#: vncviewer/Viewport.cxx:708
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:711
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:717
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "Skicka %s"
 
-#: vncviewer/Viewport.cxx:724
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Skicka Ctrl-Alt-&Del"
 
-#: vncviewer/Viewport.cxx:727
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "&Uppdatera skärm"
 
-#: vncviewer/Viewport.cxx:730
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&Inställningar..."
 
-#: vncviewer/Viewport.cxx:732
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "&Information om anslutningen..."
 
-#: vncviewer/Viewport.cxx:734
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "Om &TigerVNC-visaren..."
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:830
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "VNC anslutningsinformation"
 
-#: vncviewer/Win32TouchHandler.cxx:48
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "Fönstret har registrerats för beröring istället för gester"
 
-#: vncviewer/Win32TouchHandler.cxx:83
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "Misslyckades med att sätta gestkonfigurationen (fel 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:95
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "Misslyckades att få gestinformation (fel 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:360
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr "Felaktig musknapp %d, måste vara ett nummer mellan 1 och 7."
 
-#: vncviewer/Win32TouchHandler.cxx:425
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
 msgstr "Ej hanterad tangent 0x%x — kan inte generera en tangentbordshändelse."
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:107
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
 msgstr "Kan inte få X inmatning 2 händelsemask för fönster 0x%08lx"
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr "Fönster 0x%08lx har ingen X inmatning 2 händelsemask"
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:114
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr "Fönster 0x%08lx har mer än en X inmatning 2 händelsemask"
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "Misslyckades med att fånga enhet %i"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-msgid "TigerVNC Viewer"
-msgstr "VNC-visare"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -723,100 +712,127 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr "Anslut till en VNC-server och visa ett fjärrskrivbord"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
-msgstr "Virtual Network Computing (VNC) är ett system för fjärrskrivbord som gör att man kan se och interagera med en virtuell skrivbordsmiljö som kör på en annan dator i nätverket. Genom att använda VNC kan man köra grafiska program på en fjärrmaskin och skicka bara det som visas från dessa program till den lokala enheten. Detta paket innehåller en klient vilken kommer göra det möjligt att ansluta till andra skrivbord som kör en VNC-server. VNC är plattformsoberoende och stödjer olika operativsystem och arkitekturer både som servrar och klienter."
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+"Virtual Network Computing (VNC) är ett system för fjärrskrivbord som gör att "
+"man kan se och interagera med en virtuell skrivbordsmiljö som kör på en "
+"annan dator i nätverket. Genom att använda VNC kan man köra grafiska program "
+"på en fjärrmaskin och skicka bara det som visas från dessa program till den "
+"lokala enheten. Detta paket innehåller en klient vilken kommer göra det "
+"möjligt att ansluta till andra skrivbord som kör en VNC-server. VNC är "
+"plattformsoberoende och stödjer olika operativsystem och arkitekturer både "
+"som servrar och klienter."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
-msgstr "TigerVNC är en höghastighetsversion av VNC baserat på kodbaserna RealVNC 4 och X.org. TigerVNC startades som ett arbete att utveckla nästa generation av TightVNC på Unix- och Linuxplattformar, men delades av från sitt föräldraprojekt i början av 2009 så att TightVNC kunde fokusera på plattformen Windows. TigerVNC stödjer en variant av Tight-kodning som är kraftigt accelererad genom användning av JPEG-omkodaren från libjpeg-turbo."
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+"TigerVNC är en höghastighetsversion av VNC baserat på kodbaserna RealVNC 4 "
+"och X.org. TigerVNC startades som ett arbete att utveckla nästa generation "
+"av TightVNC på Unix- och Linuxplattformar, men delades av från sitt "
+"föräldraprojekt i början av 2009 så att TightVNC kunde fokusera på "
+"plattformen Windows. TigerVNC stödjer en variant av Tight-kodning som är "
+"kraftigt accelererad genom användning av JPEG-omkodaren från libjpeg-turbo."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC viewer connection to a CentOS machine"
-msgstr "TigerVNC-visningsanslutning till en CentOS-maskin"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC viewer connection to a macOS machine"
-msgstr "TigerVNC-visningsanslutning till en MacOS-maskin"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC viewer connection to a Windows machine"
-msgstr "TigerVNC-visningsanslutning till en Windows-maskin"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
 #. developer_name tag deprecated with Appstream 1.0
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
-#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:48
 msgid "The TigerVNC team"
 msgstr "TigerVNC-teamet"
 
-#: vncviewer/parameters.cxx:319 vncviewer/parameters.cxx:344
-#: vncviewer/parameters.cxx:361 vncviewer/parameters.cxx:401
-#: vncviewer/parameters.cxx:421
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "Namnet på parametern är för stort"
 
-#: vncviewer/parameters.cxx:323 vncviewer/parameters.cxx:328
-#: vncviewer/parameters.cxx:379
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "Parametern är för stor"
 
-#: vncviewer/parameters.cxx:386 vncviewer/parameters.cxx:712
-#: vncviewer/parameters.cxx:822
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "Ogiltigt format eller för stort värde"
 
-#: vncviewer/parameters.cxx:440 vncviewer/parameters.cxx:473
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "Misslyckades med att skapa registernyckel"
 
-#: vncviewer/parameters.cxx:461 vncviewer/parameters.cxx:528
-#: vncviewer/parameters.cxx:571 vncviewer/parameters.cxx:638
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "Misslyckades med att stänga registernyckel"
 
-#: vncviewer/parameters.cxx:479 vncviewer/parameters.cxx:506
-#: vncviewer/parameters.cxx:680 vncviewer/parameters.cxx:692
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "Misslyckades att spara ”%s”: %s"
 
-#: vncviewer/parameters.cxx:489 vncviewer/parameters.cxx:520
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "Misslyckades att ta bort ”%s”: %s"
 
-#: vncviewer/parameters.cxx:544 vncviewer/parameters.cxx:616
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "Misslyckades med att öppna registernyckel"
 
-#: vncviewer/parameters.cxx:561
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "Misslyckades med att läsa serverhistorikpost %d: %s"
 
-#: vncviewer/parameters.cxx:597 vncviewer/parameters.cxx:627
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "Misslyckades med att läsa parametern ”%s”: %s"
 
-#: vncviewer/parameters.cxx:661 vncviewer/parameters.cxx:740
-#: vncviewer/vncviewer.cxx:546
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
 msgid "Could not determine VNC config directory path"
 msgstr "Kunde inte bestämma VNC-konfigurationskatalogsökvägen"
 
-#: vncviewer/parameters.cxx:682 vncviewer/parameters.cxx:694
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "Kunde inte koda parametern"
 
-#: vncviewer/parameters.cxx:785
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "Konfigurationsfilen %s har ogiltigt format"
 
-#: vncviewer/parameters.cxx:809
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "Ogiltigt format"
 
-#: vncviewer/parameters.cxx:846
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "Okänd parameter"
 
@@ -857,23 +873,23 @@ msgid "X Input 2 (or newer) is not available."
 msgstr "X inmatning 2 (eller nyare) är inte tillgänglig."
 
 #: vncviewer/touch.cxx:266
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
-msgstr "X inmatning 2.2 (eller nyare) är inte tillgänglig. Beröringsgester kommer inte stödjas."
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+"X inmatning 2.2 (eller nyare) är inte tillgänglig. Beröringsgester kommer "
+"inte stödjas."
 
-#: vncviewer/vncviewer.cxx:104
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
 "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"TigerVNC visare v%s\n"
-"Byggd på: %s\n"
-"Copyright © 1999-%d TigerVNC-teamet och många andra (se README.rst)\n"
-"Se https://www.tigervnc.org för information om TigerVNC."
 
-#: vncviewer/vncviewer.cxx:158
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -884,15 +900,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:174
-msgid "About TigerVNC Viewer"
-msgstr "Om VNC-visaren"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:195
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "Internt FLTK-fel. Avslutar."
 
-#: vncviewer/vncviewer.cxx:214
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -903,63 +919,59 @@ msgstr ""
 "\n"
 "Försök att återansluta?"
 
-#: vncviewer/vncviewer.cxx:245 vncviewer/vncviewer.cxx:257
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Fel vid start av ny TigerVNC-visare: %s"
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:266
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC viewer will now exit."
-msgstr "Termineringssignal %d har tagits emot. TigerVNC visaren kommer nu att avslutas."
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:391 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC viewer"
-msgstr "TigerVNC-visare"
-
-#: vncviewer/vncviewer.cxx:395
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "Ja"
 
-#: vncviewer/vncviewer.cxx:398
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "Stäng"
 
-#: vncviewer/vncviewer.cxx:403
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "Om"
 
-#: vncviewer/vncviewer.cxx:406
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "Göm"
 
-#: vncviewer/vncviewer.cxx:409
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "Avsluta"
 
-#: vncviewer/vncviewer.cxx:413
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "Tjänster"
 
-#: vncviewer/vncviewer.cxx:414
+#: vncviewer/vncviewer.cxx:413
 msgid "Hide others"
 msgstr "Göm andra"
 
-#: vncviewer/vncviewer.cxx:415
+#: vncviewer/vncviewer.cxx:414
 msgid "Show all"
 msgstr "Visa alla"
 
-#: vncviewer/vncviewer.cxx:424
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "&Arkiv"
 
-#: vncviewer/vncviewer.cxx:427
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "&Ny anslutning"
 
-#: vncviewer/vncviewer.cxx:450
+#: vncviewer/vncviewer.cxx:449
 #, c-format
 msgid ""
 "\n"
@@ -976,24 +988,19 @@ msgstr ""
 "       %s [parametrar] -listen [port]\n"
 "       %s [parametrar] [.tigervnc fil]\n"
 
-#: vncviewer/vncviewer.cxx:465
+#: vncviewer/vncviewer.cxx:464
 #, c-format
 msgid ""
 "\n"
 "Options:\n"
 "\n"
 "  -display Xdisplay  - Specifies the X display for the viewer window\n"
-"  -geometry geometry - Initial position of the main VNC viewer window. See the\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
 "                       man page for details.\n"
 msgstr ""
-"\n"
-"Alternativ:\n"
-"\n"
-"  -display Xdisplay  - Specificerar X-skärm för visningsfönstret\n"
-"  -geometry geometry - Initial position för huvudfönstret för VNC-visning. Se\n"
-"                       manualsidan för detaljer.\n"
 
-#: vncviewer/vncviewer.cxx:472
+#: vncviewer/vncviewer.cxx:471
 #, c-format
 msgid ""
 "\n"
@@ -1010,73 +1017,85 @@ msgstr ""
 "Parameternamn är skiftlägesokänsliga. Parametrarna är:\n"
 "\n"
 
-#: vncviewer/vncviewer.cxx:527
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
-msgstr "FullScreenAllMonitors är föråldrat, sätt FullScreenMode till ”all” istället"
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+"FullScreenAllMonitors är föråldrat, sätt FullScreenMode till ”all” istället"
 
-#: vncviewer/vncviewer.cxx:532
-msgid "DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' instead"
-msgstr "DotWhenNoCursor är utfasad, ställ in AlwaysCursor till 1 och CursorType till \"Dot\" istället"
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+"DotWhenNoCursor är utfasad, ställ in AlwaysCursor till 1 och CursorType till "
+"\"Dot\" istället"
 
-#: vncviewer/vncviewer.cxx:553
-msgid "~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
-msgstr "~/.vnc är utfasad, vänligen konsultera 'man vncviewer' för sökvägar att migrera till."
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+"~/.vnc är utfasad, vänligen konsultera 'man vncviewer' för sökvägar att "
+"migrera till."
 
-#: vncviewer/vncviewer.cxx:557
+#: vncviewer/vncviewer.cxx:556
 #, c-format
-msgid "%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC location."
-msgstr "%%APPDATA%%\\vnc är utfasad, vänligen byt till %%APPDATA%%\\TigerVNC-platsen."
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+"%%APPDATA%%\\vnc är utfasad, vänligen byt till %%APPDATA%%\\TigerVNC-platsen."
 
-#: vncviewer/vncviewer.cxx:562
+#: vncviewer/vncviewer.cxx:561
 #, c-format
 msgid "Could not create VNC config directory \"%s\": %s"
 msgstr "Kunde inte skapa en VNC-konfigurationskatalog: \"%s\": %s"
 
-#: vncviewer/vncviewer.cxx:568
+#: vncviewer/vncviewer.cxx:567
 msgid "Could not determine VNC data directory path"
 msgstr "Kunde inte fastställa sökvägen till VNC-datakatalogen"
 
-#: vncviewer/vncviewer.cxx:574
+#: vncviewer/vncviewer.cxx:573
 #, c-format
 msgid "Could not create VNC data directory \"%s\": %s"
 msgstr "Kunde inte skapa en VNC-datakatalog: \"%s\": %s"
 
-#: vncviewer/vncviewer.cxx:586
+#: vncviewer/vncviewer.cxx:585
 #, c-format
 msgid "Could not create VNC state directory \"%s\": %s"
 msgstr "Kunde inte skapa VNC-tillståndskatalog: \"%s\": %s"
 
-#: vncviewer/vncviewer.cxx:703
+#: vncviewer/vncviewer.cxx:704
 #, c-format
 msgid "%s: Unrecognized option '%s'\n"
 msgstr "%s: Okänt alternativ '%s'\n"
 
-#: vncviewer/vncviewer.cxx:705 vncviewer/vncviewer.cxx:713
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
 #, c-format
 msgid "See '%s --help' for more information.\n"
 msgstr "Se '%s --help' för mer information.\n"
 
-#: vncviewer/vncviewer.cxx:712
+#: vncviewer/vncviewer.cxx:713
 #, c-format
 msgid "%s: Extra argument '%s'\n"
 msgstr "%s: Extra argument '%s'\n"
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:748 vncviewer/vncviewer.cxx:749
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "Parametrar -listen och -via är inkompatibla"
 
-#: vncviewer/vncviewer.cxx:763
+#: vncviewer/vncviewer.cxx:764
 msgid "Unable to listen for incoming connections"
 msgstr "Misslyckades att lyssna efter inkommande anslutningar"
 
-#: vncviewer/vncviewer.cxx:765
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "Lyssnar på port %d"
 
-#: vncviewer/vncviewer.cxx:794
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -1087,7 +1106,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:815
+#: vncviewer/vncviewer.cxx:816
 #, c-format
 msgid ""
 "Failure setting up encrypted tunnel:\n"
@@ -1101,6 +1120,95 @@ msgstr ""
 #: vncviewer/vncviewer.desktop.in.in:4
 msgid "Remote desktop viewer"
 msgstr "Fjärrskrivbordsvisare"
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(serverstandard %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "SetDesktopSize misslyckades: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "Ogiltig SetColourMapEntries från server!"
+
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "Ogiltig konfiguration angiven för %s"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "Felaktigt skärmindex ”%s”"
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "Oväntat tecken ”%c”"
+
+#~ msgid "VNC viewer: Connection details"
+#~ msgstr "VNC visare: Anslutningsdetaljer"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "Om &TigerVNC-visaren..."
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "VNC-visare"
+
+#~ msgid "TigerVNC viewer connection to a CentOS machine"
+#~ msgstr "TigerVNC-visningsanslutning till en CentOS-maskin"
+
+#~ msgid "TigerVNC viewer connection to a macOS machine"
+#~ msgstr "TigerVNC-visningsanslutning till en MacOS-maskin"
+
+#~ msgid "TigerVNC viewer connection to a Windows machine"
+#~ msgstr "TigerVNC-visningsanslutning till en Windows-maskin"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "TigerVNC visare v%s\n"
+#~ "Byggd på: %s\n"
+#~ "Copyright © 1999-%d TigerVNC-teamet och många andra (se README.rst)\n"
+#~ "Se https://www.tigervnc.org för information om TigerVNC."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "Om VNC-visaren"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Fel vid start av ny TigerVNC-visare: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC viewer will now exit."
+#~ msgstr ""
+#~ "Termineringssignal %d har tagits emot. TigerVNC visaren kommer nu att "
+#~ "avslutas."
+
+#~ msgid "TigerVNC viewer"
+#~ msgstr "TigerVNC-visare"
+
+#, c-format
+#~ msgid ""
+#~ "\n"
+#~ "Options:\n"
+#~ "\n"
+#~ "  -display Xdisplay  - Specifies the X display for the viewer window\n"
+#~ "  -geometry geometry - Initial position of the main VNC viewer window. "
+#~ "See the\n"
+#~ "                       man page for details.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Alternativ:\n"
+#~ "\n"
+#~ "  -display Xdisplay  - Specificerar X-skärm för visningsfönstret\n"
+#~ "  -geometry geometry - Initial position för huvudfönstret för VNC-"
+#~ "visning. Se\n"
+#~ "                       manualsidan för detaljer.\n"
 
 #~ msgid "Show dot when no cursor"
 #~ msgstr "Visa punkt när muspekare saknas"

--- a/po/tigervnc.pot
+++ b/po/tigervnc.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2025-01-14 16:15+0100\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,17 +17,17 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: vncviewer/CConn.cxx:102
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr ""
 
-#: vncviewer/CConn.cxx:109
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr ""
 
-#: vncviewer/CConn.cxx:114
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -35,68 +35,63 @@ msgid ""
 "%s"
 msgstr ""
 
-#: vncviewer/CConn.cxx:151
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr ""
 
-#: vncviewer/CConn.cxx:154
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr ""
 
-#: vncviewer/CConn.cxx:158
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr ""
 
-#: vncviewer/CConn.cxx:165
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr ""
 
-#: vncviewer/CConn.cxx:170
-#, c-format
-msgid "(server default %s)"
-msgstr ""
-
-#: vncviewer/CConn.cxx:173
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr ""
 
-#: vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr ""
 
-#: vncviewer/CConn.cxx:181
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr ""
 
-#: vncviewer/CConn.cxx:185
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr ""
 
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr ""
 
-#: vncviewer/CConn.cxx:250 vncviewer/CConn.cxx:252
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
 msgid ""
 "The connection was dropped by the server before the session could be "
 "established."
 msgstr ""
 
-#: vncviewer/CConn.cxx:262
+#: vncviewer/CConn.cxx:258
 #, c-format
 msgid "Authentication failed: %s"
 msgstr ""
 
-#: vncviewer/CConn.cxx:263
+#: vncviewer/CConn.cxx:259
 #, c-format
 msgid ""
 "Failed to authenticate with the server. Reason given by the server:\n"
@@ -104,31 +99,22 @@ msgid ""
 "%s"
 msgstr ""
 
-#: vncviewer/CConn.cxx:335
-#, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr ""
-
-#: vncviewer/CConn.cxx:408
-msgid "Invalid SetColourMapEntries from server!"
-msgstr ""
-
-#: vncviewer/CConn.cxx:516
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr ""
 
-#: vncviewer/CConn.cxx:538
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr ""
 
-#: vncviewer/CConn.cxx:541
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr ""
 
-#: vncviewer/CConn.cxx:567
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr ""
@@ -141,136 +127,125 @@ msgstr ""
 msgid "Reducing window size to fit on current monitor"
 msgstr ""
 
-#: vncviewer/DesktopWindow.cxx:646
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
 msgstr ""
 
-#: vncviewer/DesktopWindow.cxx:694
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr ""
 
-#: vncviewer/DesktopWindow.cxx:1094 vncviewer/DesktopWindow.cxx:1102
-#: vncviewer/DesktopWindow.cxx:1122
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr ""
 
-#: vncviewer/DesktopWindow.cxx:1411
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
 msgstr ""
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr ""
 
-#: vncviewer/KeyboardWin32.cxx:242
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr ""
 
-#: vncviewer/KeyboardWin32.cxx:244
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr ""
 
-#: vncviewer/KeyboardWin32.cxx:250
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr ""
 
-#: vncviewer/KeyboardWin32.cxx:262
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr ""
 
-#: vncviewer/KeyboardWin32.cxx:264
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr ""
 
-#: vncviewer/KeyboardWin32.cxx:423
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
 msgid "Failed to update keyboard LED state: %lu"
 msgstr ""
 
-#: vncviewer/KeyboardX11.cxx:104
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr ""
 
-#: vncviewer/KeyboardX11.cxx:129
+#: vncviewer/KeyboardX11.cxx:148
 #, c-format
 msgid "Failed to get keyboard LED state: %d"
 msgstr ""
 
-#: vncviewer/KeyboardX11.cxx:174
+#: vncviewer/KeyboardX11.cxx:193
 msgid "Failed to update keyboard LED state"
 msgstr ""
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:100
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr ""
 
-#: vncviewer/MonitorIndicesParameter.cxx:79
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr ""
-
-#: vncviewer/MonitorIndicesParameter.cxx:86
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr ""
 
-#: vncviewer/MonitorIndicesParameter.cxx:162
-#: vncviewer/MonitorIndicesParameter.cxx:182
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr ""
-
-#: vncviewer/MonitorIndicesParameter.cxx:170
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr ""
-
-#: vncviewer/OptionsDialog.cxx:64
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
 msgid "TigerVNC options"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:97 vncviewer/ServerDialog.cxx:107
-#: vncviewer/vncviewer.cxx:397
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:102 vncviewer/vncviewer.cxx:396
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:514
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:530
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:541
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:602
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:614
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:621
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:628
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr ""
 
@@ -278,165 +253,176 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:657
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:664
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:671
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:678
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:689
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:703
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:715 vncviewer/OptionsDialog.cxx:782
-#: vncviewer/OptionsDialog.cxx:905
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:722
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:728
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:735
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:742
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:770
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:788
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:794
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:822
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:835
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:842
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:854
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:860
+#: vncviewer/OptionsDialog.cxx:880
 msgid "Show local cursor when not provided by server"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:865
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
 msgid "Cursor type"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:867
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
 msgid "Dot"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:868
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
 msgid "System"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:888
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:900
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:903
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:926
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:938
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:946
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:953
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:961
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:982
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:996
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:1009
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:1017
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:1025
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:1033
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:1062
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
 msgid "Miscellaneous"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:1070
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:1076
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
-msgstr ""
-
-#: vncviewer/ServerDialog.cxx:63
-msgid "VNC viewer: Connection details"
 msgstr ""
 
 #: vncviewer/ServerDialog.cxx:73
@@ -479,7 +465,7 @@ msgstr ""
 msgid "Select a TigerVNC configuration file"
 msgstr ""
 
-#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:517
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -496,7 +482,7 @@ msgstr ""
 msgid "%s already exists. Do you want to overwrite?"
 msgstr ""
 
-#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:394
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr ""
 
@@ -528,168 +514,169 @@ msgid ""
 "%s"
 msgstr ""
 
-#: vncviewer/ServerDialog.cxx:351 vncviewer/ServerDialog.cxx:429
-#: vncviewer/vncviewer.cxx:580
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
 msgid "Could not determine VNC state directory path"
 msgstr ""
 
-#: vncviewer/ServerDialog.cxx:363 vncviewer/ServerDialog.cxx:437
-#: vncviewer/parameters.cxx:671 vncviewer/parameters.cxx:752
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
 msgid "Could not open \"%s\""
 msgstr ""
 
-#: vncviewer/ServerDialog.cxx:378 vncviewer/ServerDialog.cxx:387
-#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:773
-#: vncviewer/parameters.cxx:807 vncviewer/parameters.cxx:837
-#: vncviewer/parameters.cxx:844
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
 msgid "Failed to read line %d in file \"%s\""
 msgstr ""
 
-#: vncviewer/ServerDialog.cxx:390 vncviewer/parameters.cxx:776
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr ""
 
-#: vncviewer/UserDialog.cxx:123
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr ""
 
-#: vncviewer/UserDialog.cxx:143
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr ""
 
-#: vncviewer/UserDialog.cxx:150
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr ""
 
-#: vncviewer/UserDialog.cxx:154
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr ""
 
-#: vncviewer/UserDialog.cxx:176
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr ""
 
-#: vncviewer/UserDialog.cxx:189
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr ""
 
-#: vncviewer/UserDialog.cxx:197
+#: vncviewer/UserDialog.cxx:204
 msgid "Keep password for reconnect"
 msgstr ""
 
-#: vncviewer/Viewport.cxx:695
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
 msgid "Disconn&ect"
 msgstr ""
 
-#: vncviewer/Viewport.cxx:698
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr ""
 
-#: vncviewer/Viewport.cxx:701
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr ""
 
-#: vncviewer/Viewport.cxx:703
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr ""
 
-#: vncviewer/Viewport.cxx:708
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr ""
 
-#: vncviewer/Viewport.cxx:711
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr ""
 
-#: vncviewer/Viewport.cxx:717
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr ""
 
-#: vncviewer/Viewport.cxx:724
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr ""
 
-#: vncviewer/Viewport.cxx:727
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr ""
 
-#: vncviewer/Viewport.cxx:730
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr ""
 
-#: vncviewer/Viewport.cxx:732
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr ""
 
-#: vncviewer/Viewport.cxx:734
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
+msgid "About &TigerVNC..."
 msgstr ""
 
-#: vncviewer/Viewport.cxx:830
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr ""
 
-#: vncviewer/Win32TouchHandler.cxx:48
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr ""
 
-#: vncviewer/Win32TouchHandler.cxx:83
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr ""
 
-#: vncviewer/Win32TouchHandler.cxx:95
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr ""
 
-#: vncviewer/Win32TouchHandler.cxx:360
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr ""
 
-#: vncviewer/Win32TouchHandler.cxx:425
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
 msgstr ""
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:107
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
 msgstr ""
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr ""
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:114
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr ""
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-msgid "TigerVNC Viewer"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
 msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
@@ -720,92 +707,91 @@ msgid ""
 msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC viewer connection to a CentOS machine"
+msgid "TigerVNC connection to a CentOS machine"
 msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC viewer connection to a macOS machine"
+msgid "TigerVNC connection to a macOS machine"
 msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC viewer connection to a Windows machine"
+msgid "TigerVNC connection to a Windows machine"
 msgstr ""
 
 #. developer_name tag deprecated with Appstream 1.0
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
-#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:48
 msgid "The TigerVNC team"
 msgstr ""
 
-#: vncviewer/parameters.cxx:319 vncviewer/parameters.cxx:344
-#: vncviewer/parameters.cxx:361 vncviewer/parameters.cxx:401
-#: vncviewer/parameters.cxx:421
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr ""
 
-#: vncviewer/parameters.cxx:323 vncviewer/parameters.cxx:328
-#: vncviewer/parameters.cxx:379
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr ""
 
-#: vncviewer/parameters.cxx:386 vncviewer/parameters.cxx:712
-#: vncviewer/parameters.cxx:822
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr ""
 
-#: vncviewer/parameters.cxx:440 vncviewer/parameters.cxx:473
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr ""
 
-#: vncviewer/parameters.cxx:461 vncviewer/parameters.cxx:528
-#: vncviewer/parameters.cxx:571 vncviewer/parameters.cxx:638
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr ""
 
-#: vncviewer/parameters.cxx:479 vncviewer/parameters.cxx:506
-#: vncviewer/parameters.cxx:680 vncviewer/parameters.cxx:692
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr ""
 
-#: vncviewer/parameters.cxx:489 vncviewer/parameters.cxx:520
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr ""
 
-#: vncviewer/parameters.cxx:544 vncviewer/parameters.cxx:616
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr ""
 
-#: vncviewer/parameters.cxx:561
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr ""
 
-#: vncviewer/parameters.cxx:597 vncviewer/parameters.cxx:627
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr ""
 
-#: vncviewer/parameters.cxx:661 vncviewer/parameters.cxx:740
-#: vncviewer/vncviewer.cxx:546
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
 msgid "Could not determine VNC config directory path"
 msgstr ""
 
-#: vncviewer/parameters.cxx:682 vncviewer/parameters.cxx:694
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr ""
 
-#: vncviewer/parameters.cxx:785
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr ""
 
-#: vncviewer/parameters.cxx:809
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr ""
 
-#: vncviewer/parameters.cxx:846
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr ""
 
@@ -851,16 +837,16 @@ msgid ""
 "supported."
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:104
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
 "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:158
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -868,15 +854,15 @@ msgid ""
 "%s"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:174
-msgid "About TigerVNC Viewer"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:195
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:214
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -884,63 +870,59 @@ msgid ""
 "Attempt to reconnect?"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:245 vncviewer/vncviewer.cxx:257
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
+msgid "Error starting new connection: %s"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:266
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC viewer will now exit."
+msgid "Termination signal %d has been received. TigerVNC will now exit."
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:391 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC viewer"
-msgstr ""
-
-#: vncviewer/vncviewer.cxx:395
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:398
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:403
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:406
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:409
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:413
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:414
+#: vncviewer/vncviewer.cxx:413
 msgid "Hide others"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:415
+#: vncviewer/vncviewer.cxx:414
 msgid "Show all"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:424
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:427
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:450
+#: vncviewer/vncviewer.cxx:449
 #, c-format
 msgid ""
 "\n"
@@ -951,19 +933,19 @@ msgid ""
 "       %s [parameters] [.tigervnc file]\n"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:465
+#: vncviewer/vncviewer.cxx:464
 #, c-format
 msgid ""
 "\n"
 "Options:\n"
 "\n"
 "  -display Xdisplay  - Specifies the X display for the viewer window\n"
-"  -geometry geometry - Initial position of the main VNC viewer window. See "
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
 "the\n"
 "                       man page for details.\n"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:472
+#: vncviewer/vncviewer.cxx:471
 #, c-format
 msgid ""
 "\n"
@@ -974,79 +956,79 @@ msgid ""
 "\n"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:527
+#: vncviewer/vncviewer.cxx:526
 msgid ""
 "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:532
+#: vncviewer/vncviewer.cxx:531
 msgid ""
 "DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
 "instead"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:553
+#: vncviewer/vncviewer.cxx:552
 msgid ""
 "~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:557
+#: vncviewer/vncviewer.cxx:556
 #, c-format
 msgid ""
 "%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
 "location."
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:562
+#: vncviewer/vncviewer.cxx:561
 #, c-format
 msgid "Could not create VNC config directory \"%s\": %s"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:568
+#: vncviewer/vncviewer.cxx:567
 msgid "Could not determine VNC data directory path"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:574
+#: vncviewer/vncviewer.cxx:573
 #, c-format
 msgid "Could not create VNC data directory \"%s\": %s"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:586
+#: vncviewer/vncviewer.cxx:585
 #, c-format
 msgid "Could not create VNC state directory \"%s\": %s"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:703
+#: vncviewer/vncviewer.cxx:704
 #, c-format
 msgid "%s: Unrecognized option '%s'\n"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:705 vncviewer/vncviewer.cxx:713
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
 #, c-format
 msgid "See '%s --help' for more information.\n"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:712
+#: vncviewer/vncviewer.cxx:713
 #, c-format
 msgid "%s: Extra argument '%s'\n"
 msgstr ""
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:748 vncviewer/vncviewer.cxx:749
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:763
+#: vncviewer/vncviewer.cxx:764
 msgid "Unable to listen for incoming connections"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:765
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:794
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -1054,7 +1036,7 @@ msgid ""
 "%s"
 msgstr ""
 
-#: vncviewer/vncviewer.cxx:815
+#: vncviewer/vncviewer.cxx:816
 #, c-format
 msgid ""
 "Failure setting up encrypted tunnel:\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.12.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2022-12-15 16:35+0100\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2023-09-08 22:51+0200\n"
 "Last-Translator: Volkan Gezer <volkangezer@gmail.com>\n"
 "Language-Team: Turkish <gnome-turk@gnome.org>\n"
@@ -30,7 +30,7 @@ msgstr "Bağlı olunan soket: %s"
 msgid "Connected to host %s port %d"
 msgstr "%s ana makinesinin, %d bağlantı noktasına bağlı"
 
-#: vncviewer/CConn.cxx:114
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -41,364 +41,421 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:159
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Masaüstü adı: %.80s"
 
-#: vncviewer/CConn.cxx:164
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Ana makine: %.80s bağlantı noktası: %d"
 
-#: vncviewer/CConn.cxx:169
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Boyut: %d x %d"
 
-#: vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Piksel biçimi: %s"
 
-#: vncviewer/CConn.cxx:184
-#, c-format
-msgid "(server default %s)"
-msgstr "(sunucu varsayılanı %s)"
-
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "İstenen kodlama: %s"
 
-#: vncviewer/CConn.cxx:194
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Son kullanılan kodlama: %s"
 
-#: vncviewer/CConn.cxx:199
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Hat hızı tahmini: %d kbit/s"
 
-#: vncviewer/CConn.cxx:204
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Protokol sürümü: %d.%d"
 
-#: vncviewer/CConn.cxx:209
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Güvenlik yöntemi: %s"
 
-#: vncviewer/CConn.cxx:270 vncviewer/CConn.cxx:272
-msgid "The connection was dropped by the server before the session could be established."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
 msgstr "Oturum kurulmadan bağlantı sunucu tarafından kesildi."
 
-#: vncviewer/CConn.cxx:332
+#: vncviewer/CConn.cxx:258
 #, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "SetDesktopSize başarısız: %d"
+msgid "Authentication failed: %s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:404
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "Sunucudan gelen geçersiz SetColourMapEntries!"
+#: vncviewer/CConn.cxx:259
+#, c-format
+msgid ""
+"Failed to authenticate with the server. Reason given by the server:\n"
+"\n"
+"%s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:512
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Verim %d kbit/s - %d kalitesine değiştiriliyor"
 
-#: vncviewer/CConn.cxx:534
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "Verim %d kbit/s - tam renkli artık etkin"
 
-#: vncviewer/CConn.cxx:537
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "Verim %d kbit/s - tam renkli artık devre dışı"
 
-#: vncviewer/CConn.cxx:563
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "%s piksel biçimi kullanılıyor"
 
-#: vncviewer/DesktopWindow.cxx:145
+#: vncviewer/DesktopWindow.cxx:146
 msgid "Invalid geometry specified!"
 msgstr "Geçersiz geometri belirtildi!"
 
-#: vncviewer/DesktopWindow.cxx:166
+#: vncviewer/DesktopWindow.cxx:167
 msgid "Reducing window size to fit on current monitor"
 msgstr "Geçerli monitöre sığması için pencere boyutu azaltılıyor"
 
-#: vncviewer/DesktopWindow.cxx:648
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
 msgstr "Yanlışlıkla tam ekran isteğini önlemek için pencere boyutu ayarlanıyor"
 
-#: vncviewer/DesktopWindow.cxx:696
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Bağlam menüsünü açmak için %s tuşuna basın"
 
-#: vncviewer/DesktopWindow.cxx:1083 vncviewer/DesktopWindow.cxx:1091
-#: vncviewer/DesktopWindow.cxx:1111
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Klavye yakalanamadı"
 
-#: vncviewer/DesktopWindow.cxx:1401
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
 msgstr "Yeniden boyutlandırma isteği için geçersiz ekran düzeni hesaplandı!"
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "3 düğme emülasyonu için geçersiz durum"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:105
+#: vncviewer/KeyboardWin32.cxx:243
+#, c-format
+msgid "No scan code for extended virtual key 0x%02x"
+msgstr "Genişletilmiş sanal tuş 0x%02x için hiçbir tarama kodu yok"
+
+#: vncviewer/KeyboardWin32.cxx:245
+#, c-format
+msgid "No scan code for virtual key 0x%02x"
+msgstr "Sanal tuş 0x%02x için tarama kodu yok"
+
+#: vncviewer/KeyboardWin32.cxx:251
+#, c-format
+msgid "Invalid scan code 0x%02x"
+msgstr "Geçersiz tarama kodu 0x%02x"
+
+#: vncviewer/KeyboardWin32.cxx:263
+#, c-format
+msgid "No symbol for extended virtual key 0x%02x"
+msgstr "Genişletilmiş sanal tuş 0x%02x için simge yok"
+
+#: vncviewer/KeyboardWin32.cxx:265
+#, c-format
+msgid "No symbol for virtual key 0x%02x"
+msgstr "Sanal tuş 0x%02x için simge yok"
+
+#: vncviewer/KeyboardWin32.cxx:424
+#, c-format
+msgid "Failed to update keyboard LED state: %lu"
+msgstr "Klavye LED durumu güncellenemedi: %lu"
+
+#: vncviewer/KeyboardX11.cxx:123
+#, c-format
+msgid "No symbol for key code %d (in the current state)"
+msgstr "Tuş kodu %d için simge yok (mevcut durumda)"
+
+#: vncviewer/KeyboardX11.cxx:148
+#, c-format
+msgid "Failed to get keyboard LED state: %d"
+msgstr "Klavye LED durumu alınamadı: %d"
+
+#: vncviewer/KeyboardX11.cxx:193
+msgid "Failed to update keyboard LED state"
+msgstr "Klavye LED durumu güncellenemedi"
+
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "Sistem monitörü yapılandırması alınamadı"
 
-#: vncviewer/MonitorIndicesParameter.cxx:83
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "%s için geçersiz yapılandırma belirtildi"
-
-#: vncviewer/MonitorIndicesParameter.cxx:91
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "%d monitör dizini mevcut değil"
 
-#: vncviewer/MonitorIndicesParameter.cxx:169
-#: vncviewer/MonitorIndicesParameter.cxx:189
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "Geçersiz monitör dizini '%s'"
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
+msgid "TigerVNC options"
+msgstr ""
 
-#: vncviewer/MonitorIndicesParameter.cxx:177
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "Beklenmeyen karakter '%c'"
-
-#: vncviewer/OptionsDialog.cxx:63
-msgid "VNC Viewer: Connection Options"
-msgstr "VNC Görüntüleyici: Bağlantı Seçenekleri"
-
-#: vncviewer/OptionsDialog.cxx:89 vncviewer/ServerDialog.cxx:108
-#: vncviewer/vncviewer.cxx:417
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "İptal"
 
-#: vncviewer/OptionsDialog.cxx:94 vncviewer/vncviewer.cxx:416
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "Tamam"
 
-#: vncviewer/OptionsDialog.cxx:484
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "Sıkıştırma"
 
-#: vncviewer/OptionsDialog.cxx:501
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "Otomatik seç"
 
-#: vncviewer/OptionsDialog.cxx:516
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "Tercih edilen kodlama"
 
-#: vncviewer/OptionsDialog.cxx:574
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "Renk seviyesi"
 
-#: vncviewer/OptionsDialog.cxx:585
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "Tam dolu"
 
-#: vncviewer/OptionsDialog.cxx:592
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "Orta"
 
-#: vncviewer/OptionsDialog.cxx:599
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "Düşük"
 
-#: vncviewer/OptionsDialog.cxx:606
+#: vncviewer/OptionsDialog.cxx:635
 msgid "Very low"
 msgstr "Çok düşük"
 
-#: vncviewer/OptionsDialog.cxx:624
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "Özel sıkıştırma seviyesi:"
 
-#: vncviewer/OptionsDialog.cxx:630
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "kalite (0=hızlı, 9=en iyi)"
 
-#: vncviewer/OptionsDialog.cxx:637
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "JPEG sıkıştırmasına izin ver:"
 
-#: vncviewer/OptionsDialog.cxx:643
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "kalite (0=düşük, 9=yüksek)"
 
-#: vncviewer/OptionsDialog.cxx:654
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "Güvenlik"
 
-#: vncviewer/OptionsDialog.cxx:676
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "Şifreleme"
 
-#: vncviewer/OptionsDialog.cxx:687 vncviewer/OptionsDialog.cxx:750
-#: vncviewer/OptionsDialog.cxx:854
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "Yok"
 
-#: vncviewer/OptionsDialog.cxx:694
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "Adsız sertifikalı  TLS"
 
-#: vncviewer/OptionsDialog.cxx:700
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "X509 sertifikalı TLS"
 
-#: vncviewer/OptionsDialog.cxx:707
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "X509 CA sertifikası yolu"
 
-#: vncviewer/OptionsDialog.cxx:714
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "X509  CRL  dosyası  yolu"
 
-#: vncviewer/OptionsDialog.cxx:739
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "Doğrulama"
 
-#: vncviewer/OptionsDialog.cxx:756
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "Standart VNC (şifreleme olmadan güvensiz)"
 
-#: vncviewer/OptionsDialog.cxx:762
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "Kullanıcı adı ve şifre (şifreleme olmadan güvensiz)"
 
-#: vncviewer/OptionsDialog.cxx:781
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "Girdi"
 
-#: vncviewer/OptionsDialog.cxx:794
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "Yalnızca görüntüleme (fare ve klavyeyi yoksay)"
 
-#: vncviewer/OptionsDialog.cxx:801
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "Fare"
 
-#: vncviewer/OptionsDialog.cxx:815
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "Orta fare düğmesini taklit et"
 
-#: vncviewer/OptionsDialog.cxx:821
-msgid "Show dot when no cursor"
-msgstr "İmleç yokken nokta göster"
+#: vncviewer/OptionsDialog.cxx:880
+msgid "Show local cursor when not provided by server"
+msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:835
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
+msgid "Cursor type"
+msgstr ""
+
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
+msgid "Dot"
+msgstr ""
+
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
+msgid "System"
+msgstr ""
+
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "Tuş takımı"
 
-#: vncviewer/OptionsDialog.cxx:849
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
 msgstr "Sistem tuşlarını doğrudan sunucuya aktar (tam ekran)"
 
-#: vncviewer/OptionsDialog.cxx:852
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "Menü tuşu"
 
-#: vncviewer/OptionsDialog.cxx:871
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "Pano"
 
-#: vncviewer/OptionsDialog.cxx:885
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "Sunucudan panoyu kabul et"
 
-#: vncviewer/OptionsDialog.cxx:893
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "Birincil seçim olarak da ayarla"
 
-#: vncviewer/OptionsDialog.cxx:900
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "Panodan sunucuya gönder"
 
-#: vncviewer/OptionsDialog.cxx:908
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "Birincil seçimi pano olarak gönder"
 
-#: vncviewer/OptionsDialog.cxx:927
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "Görüntü"
 
-#: vncviewer/OptionsDialog.cxx:941
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "Ekran kipi"
 
-#: vncviewer/OptionsDialog.cxx:956
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "Pencereli"
 
-#: vncviewer/OptionsDialog.cxx:964
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "Mevcut monitörde tam ekran"
 
-#: vncviewer/OptionsDialog.cxx:972
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "Tüm monitörlerde tam ekranı etkinleştir"
 
-#: vncviewer/OptionsDialog.cxx:980
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "Seçilen monitör(ler)de tam ekranı etkinleştir"
 
-#: vncviewer/OptionsDialog.cxx:1007
-msgid "Misc."
-msgstr "Çeşitli"
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
+msgid "Miscellaneous"
+msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:1015
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "Paylaşılan (diğer görüntüleyenlerin bağlantısını kesme)"
 
-#: vncviewer/OptionsDialog.cxx:1021
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "Bağlantı hatalarında yeniden bağlanmayı iste"
 
-#: vncviewer/ServerDialog.cxx:58
-msgid "VNC Viewer: Connection Details"
-msgstr "VNC Görüntüleyici: Bağlantı Bilgileri"
-
-#: vncviewer/ServerDialog.cxx:65 vncviewer/ServerDialog.cxx:70
+#: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
 msgstr "VNC sunucusu:"
 
-#: vncviewer/ServerDialog.cxx:81
+#: vncviewer/ServerDialog.cxx:80
 msgid "Options..."
 msgstr "Seçenekler..."
 
-#: vncviewer/ServerDialog.cxx:86
+#: vncviewer/ServerDialog.cxx:84
 msgid "Load..."
 msgstr "Yükle..."
 
-#: vncviewer/ServerDialog.cxx:91
-msgid "Save As..."
-msgstr "Farklı Kaydet..."
+#: vncviewer/ServerDialog.cxx:88
+msgid "Save as..."
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:103
+#: vncviewer/ServerDialog.cxx:102
 msgid "About..."
 msgstr "Hakkında..."
 
-#: vncviewer/ServerDialog.cxx:113
+#: vncviewer/ServerDialog.cxx:111
 msgid "Connect"
 msgstr "Bağlan"
 
-#: vncviewer/ServerDialog.cxx:145
+#: vncviewer/ServerDialog.cxx:147
 #, c-format
 msgid ""
 "Unable to load the server history:\n"
@@ -409,15 +466,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:173 vncviewer/ServerDialog.cxx:212
+#: vncviewer/ServerDialog.cxx:176 vncviewer/ServerDialog.cxx:216
 msgid "TigerVNC configuration (*.tigervnc)"
 msgstr "TigerVNC yapılandırması (*.tigervnc)"
 
-#: vncviewer/ServerDialog.cxx:174
+#: vncviewer/ServerDialog.cxx:177
 msgid "Select a TigerVNC configuration file"
 msgstr "TigerVNC yapılandırma dosyasını seçin"
 
-#: vncviewer/ServerDialog.cxx:196 vncviewer/vncviewer.cxx:552
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -428,24 +485,24 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:213
+#: vncviewer/ServerDialog.cxx:217
 msgid "Save the TigerVNC configuration to file"
 msgstr "TigerVNC yapılandırmasını dosyaya kaydedin"
 
-#: vncviewer/ServerDialog.cxx:239
+#: vncviewer/ServerDialog.cxx:243
 #, c-format
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "%s zaten mevcut. Üzerine yazmak istiyor musunuz?"
 
-#: vncviewer/ServerDialog.cxx:240 vncviewer/vncviewer.cxx:414
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "Hayır"
 
-#: vncviewer/ServerDialog.cxx:240
+#: vncviewer/ServerDialog.cxx:244
 msgid "Overwrite"
 msgstr "Üzerine yaz"
 
-#: vncviewer/ServerDialog.cxx:256
+#: vncviewer/ServerDialog.cxx:260
 #, c-format
 msgid ""
 "Unable to save the specified configuration file:\n"
@@ -456,7 +513,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:290
+#: vncviewer/ServerDialog.cxx:294
 #, c-format
 msgid ""
 "Unable to save the default configuration:\n"
@@ -467,7 +524,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:303
+#: vncviewer/ServerDialog.cxx:306
 #, c-format
 msgid ""
 "Unable to save the server history:\n"
@@ -478,230 +535,170 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:320 vncviewer/ServerDialog.cxx:387
-#: vncviewer/parameters.cxx:635 vncviewer/parameters.cxx:740
-#: vncviewer/vncviewer.cxx:459
-msgid "Could not obtain the home directory path"
-msgstr "VNC ana dizini edinilemedi"
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
+msgid "Could not determine VNC state directory path"
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:333 vncviewer/ServerDialog.cxx:396
-#: vncviewer/parameters.cxx:646 vncviewer/parameters.cxx:753
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
-msgid "Could not open \"%s\": %s"
-msgstr "\"%s\" açılamadı: %s"
+msgid "Could not open \"%s\""
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:348 vncviewer/ServerDialog.cxx:356
-#: vncviewer/parameters.cxx:767 vncviewer/parameters.cxx:773
-#: vncviewer/parameters.cxx:804 vncviewer/parameters.cxx:833
-#: vncviewer/parameters.cxx:839
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
-msgid "Failed to read line %d in file %s: %s"
-msgstr "%d satırını %s dosyasından okumak başarısız: %s"
+msgid "Failed to read line %d in file \"%s\""
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:357 vncviewer/parameters.cxx:774
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "Satır çok uzun"
 
-#: vncviewer/UserDialog.cxx:98
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "Parola dosyası açılamadı"
 
-#: vncviewer/UserDialog.cxx:118
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "VNC doğrulaması"
 
-#: vncviewer/UserDialog.cxx:125
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "Bu bağlantı güvenlidir"
 
-#: vncviewer/UserDialog.cxx:129
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "Bu bağlantı güvenli değil"
 
-#: vncviewer/UserDialog.cxx:146
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "Kullanıcı adı:"
 
-#: vncviewer/UserDialog.cxx:159
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "Şifre:"
 
-#: vncviewer/UserDialog.cxx:198
-msgid "Authentication cancelled"
-msgstr "Doğrulama iptal edildi"
+#: vncviewer/UserDialog.cxx:204
+msgid "Keep password for reconnect"
+msgstr ""
 
-#: vncviewer/Viewport.cxx:391
-#, c-format
-msgid "Failed to update keyboard LED state: %lu"
-msgstr "Klavye LED durumu güncellenemedi: %lu"
-
-#: vncviewer/Viewport.cxx:397 vncviewer/Viewport.cxx:403
-#, c-format
-msgid "Failed to update keyboard LED state: %d"
-msgstr "Klavye LED durumu güncellenemedi: %d"
-
-#: vncviewer/Viewport.cxx:433
-msgid "Failed to update keyboard LED state"
-msgstr "Klavye LED durumu güncellenemedi"
-
-#: vncviewer/Viewport.cxx:460 vncviewer/Viewport.cxx:468
-#: vncviewer/Viewport.cxx:485
-#, c-format
-msgid "Failed to get keyboard LED state: %d"
-msgstr "Klavye LED durumu alınamadı: %d"
-
-#: vncviewer/Viewport.cxx:849
-msgid "No key code specified on key press"
-msgstr "Tuşa basıldığında tuş kodu belirtilmedi"
-
-#: vncviewer/Viewport.cxx:1008
-#, c-format
-msgid "No scan code for extended virtual key 0x%02x"
-msgstr "Genişletilmiş sanal tuş 0x%02x için hiçbir tarama kodu yok"
-
-#: vncviewer/Viewport.cxx:1010
-#, c-format
-msgid "No scan code for virtual key 0x%02x"
-msgstr "Sanal tuş 0x%02x için tarama kodu yok"
-
-#: vncviewer/Viewport.cxx:1016
-#, c-format
-msgid "Invalid scan code 0x%02x"
-msgstr "Geçersiz tarama kodu 0x%02x"
-
-#: vncviewer/Viewport.cxx:1046
-#, c-format
-msgid "No symbol for extended virtual key 0x%02x"
-msgstr "Genişletilmiş sanal tuş 0x%02x için simge yok"
-
-#: vncviewer/Viewport.cxx:1048
-#, c-format
-msgid "No symbol for virtual key 0x%02x"
-msgstr "Sanal tuş 0x%02x için simge yok"
-
-#: vncviewer/Viewport.cxx:1154
-#, c-format
-msgid "No symbol for key code 0x%02x (in the current state)"
-msgstr "Tuş kodu 0x%02x için simge yok (mevcut durumda)"
-
-#: vncviewer/Viewport.cxx:1187
-#, c-format
-msgid "No symbol for key code %d (in the current state)"
-msgstr "Tuş kodu %d için simge yok (mevcut durumda)"
-
-#: vncviewer/Viewport.cxx:1247
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
-msgid "Dis&connect"
-msgstr "Bağlantıyı &Kes"
+msgid "Disconn&ect"
+msgstr ""
 
-#: vncviewer/Viewport.cxx:1250
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "&Tam Ekran"
 
-#: vncviewer/Viewport.cxx:1253
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "K&üçült"
 
-#: vncviewer/Viewport.cxx:1255
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "Pencereyi &oturuma tekrar boyutlandır"
 
-#: vncviewer/Viewport.cxx:1260
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:1263
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:1269
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "%s gönder"
 
-#: vncviewer/Viewport.cxx:1275
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Ctrl-Alt-Del &Gönder"
 
-#: vncviewer/Viewport.cxx:1278
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "Ekranı &yenile"
 
-#: vncviewer/Viewport.cxx:1281
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "&Seçenekler..."
 
-#: vncviewer/Viewport.cxx:1283
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "Bağlantı &bilgisi..."
 
-#: vncviewer/Viewport.cxx:1285
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "TigerVNC görüntüleyici &hakkında..."
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:1374
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "VNC Bağlantı bilgisi"
 
-#: vncviewer/Win32TouchHandler.cxx:47
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "Pencere, hareketler yerine dokunma için kaydedildi"
 
-#: vncviewer/Win32TouchHandler.cxx:81
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "Hareket yapılandırması ayarlanamadı (hata 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:93
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "Hareket bilgileri alınamadı (hata 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:358
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr "Geçersiz fare düğmesi %d, 1 ile 7 arasında bir sayı olmalıdır."
 
-#: vncviewer/Win32TouchHandler.cxx:423
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
 msgstr "İşlenmeyen anahtar 0x%x - klavye olayı oluşturulamıyor."
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:107
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
 msgstr "0x%08lx penceresi için X Giriş 2 olay maskesi alınamıyor"
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr "Pencere 0x%08lx'te X Girişi 2 olay maskesi yok"
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:114
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr "Pencere 0x%08lx'te birden fazla X Girişi 2 olay maskesi var"
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "Başarısızlık yakalama cihazı %i"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-#: vncviewer/vncviewer.cxx:406 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC Viewer"
-msgstr "TigerVNC Görüntüleyici"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -709,95 +706,127 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr "VNC sunucusuna bağlanın ve uzak masaüstünü görüntüleyin"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
-msgstr "Sanal Ağ Bilgi İşlem (VNC), ağdaki başka bir bilgisayarda çalışan sanal masaüstü ortamını görüntülemenize ve etkileşimde bulunmanıza olanak tanıyan bir uzak görüntüleme sistemidir. VNC'yi kullanarak uzaktaki bir makinede grafik uygulamaları çalıştırabilir ve bu uygulamaların yalnızca ekranını yerel cihazınıza gönderebilirsiniz. Bu paket, VNC sunucusu çalıştıran diğer masaüstlerine bağlanmanızı sağlayacak bir istemci içerir. VNC platformdan bağımsızdır ve hem sunucu hem de istemci olarak çeşitli işletim sistemlerini ve mimarileri destekler."
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+"Sanal Ağ Bilgi İşlem (VNC), ağdaki başka bir bilgisayarda çalışan sanal "
+"masaüstü ortamını görüntülemenize ve etkileşimde bulunmanıza olanak tanıyan "
+"bir uzak görüntüleme sistemidir. VNC'yi kullanarak uzaktaki bir makinede "
+"grafik uygulamaları çalıştırabilir ve bu uygulamaların yalnızca ekranını "
+"yerel cihazınıza gönderebilirsiniz. Bu paket, VNC sunucusu çalıştıran diğer "
+"masaüstlerine bağlanmanızı sağlayacak bir istemci içerir. VNC platformdan "
+"bağımsızdır ve hem sunucu hem de istemci olarak çeşitli işletim sistemlerini "
+"ve mimarileri destekler."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
-msgstr "TigerVNC, RealVNC 4 ve X.org kod tabanlarını temel alan yüksek hızlı bir VNC sürümüdür. TigerVNC, TightVNC'nin Unix ve Linux platformlarında yeni nesil geliştirme çalışması olarak başladı, ancak TightVNC'nin Windows platformlarına odaklanabilmesi için 2009'un başlarında ana projesinden ayrıldı. TigerVNC, libjpeg-turbo JPEG codec bileşeninin kullanımıyla büyük ölçüde hızlandırılan bir Sıkı kodlama çeşidini destekler."
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+"TigerVNC, RealVNC 4 ve X.org kod tabanlarını temel alan yüksek hızlı bir VNC "
+"sürümüdür. TigerVNC, TightVNC'nin Unix ve Linux platformlarında yeni nesil "
+"geliştirme çalışması olarak başladı, ancak TightVNC'nin Windows "
+"platformlarına odaklanabilmesi için 2009'un başlarında ana projesinden "
+"ayrıldı. TigerVNC, libjpeg-turbo JPEG codec bileşeninin kullanımıyla büyük "
+"ölçüde hızlandırılan bir Sıkı kodlama çeşidini destekler."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC Viewer connection to a CentOS machine"
-msgstr "TigerVNC Görüntüleyici, CentOS makinesine bağlantı"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC Viewer connection to a macOS machine"
-msgstr "TigerVNC Görüntüleyici, macOS makinesine bağlantı"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC Viewer connection to a Windows machine"
-msgstr "TigerVNC Görüntüleyici, Windows makinesine bağlantı"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
-#: vncviewer/parameters.cxx:308 vncviewer/parameters.cxx:333
-#: vncviewer/parameters.cxx:350 vncviewer/parameters.cxx:390
-#: vncviewer/parameters.cxx:410
+#. developer_name tag deprecated with Appstream 1.0
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
+msgid "The TigerVNC team"
+msgstr ""
+
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "Parametrenin adı çok büyük"
 
-#: vncviewer/parameters.cxx:312 vncviewer/parameters.cxx:317
-#: vncviewer/parameters.cxx:368
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "Parametre çok büyük"
 
-#: vncviewer/parameters.cxx:375 vncviewer/parameters.cxx:696
-#: vncviewer/parameters.cxx:818
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "Geçersiz biçim veya çok büyük değer"
 
-#: vncviewer/parameters.cxx:429 vncviewer/parameters.cxx:460
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "Kayıt defteri anahtarı oluşturulamadı"
 
-#: vncviewer/parameters.cxx:448 vncviewer/parameters.cxx:503
-#: vncviewer/parameters.cxx:545 vncviewer/parameters.cxx:612
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "Kayıt defteri anahtarı kapatılamadı"
 
-#: vncviewer/parameters.cxx:466 vncviewer/parameters.cxx:483
-#: vncviewer/parameters.cxx:654 vncviewer/parameters.cxx:664
-#: vncviewer/parameters.cxx:675
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "\"%s\" kaydedilemedi: %s"
 
-#: vncviewer/parameters.cxx:479 vncviewer/parameters.cxx:567
-#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:714
-msgid "Unknown parameter type"
-msgstr "Bilinmeyen parametre türü"
-
-#: vncviewer/parameters.cxx:496
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "\"%s\" kaldırılamadı: %s"
 
-#: vncviewer/parameters.cxx:518 vncviewer/parameters.cxx:590
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "Kayıt defteri anahtarı açılamadı"
 
-#: vncviewer/parameters.cxx:535
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "%d sunucu geçmişi girişi okunamadı: %s"
 
-#: vncviewer/parameters.cxx:571 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "\"%s\" parametresi okunamadı: %s"
 
-#: vncviewer/parameters.cxx:655 vncviewer/parameters.cxx:666
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
+msgid "Could not determine VNC config directory path"
+msgstr ""
+
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "Parametre kodlanamadı"
 
-#: vncviewer/parameters.cxx:783
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "Yapılandırma dosyası %s geçersiz bir biçimde"
 
-#: vncviewer/parameters.cxx:805
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "Geçersiz biçim"
 
-#: vncviewer/parameters.cxx:840
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "Bilinmeyen parametre"
 
@@ -821,40 +850,40 @@ msgstr "Dokunma işleyicisi oluşturulamadı: %s"
 msgid "Couldn't attach event handler to window (error 0x%x)"
 msgstr "Olay işleyicisi pencereye eklenemedi (hata 0x%x)"
 
-#: vncviewer/touch.cxx:212
+#: vncviewer/touch.cxx:215
 msgid "Failed to get event data for X Input event"
 msgstr "X Giriş etkinliği için etkinlik verileri alınamadı"
 
-#: vncviewer/touch.cxx:225
+#: vncviewer/touch.cxx:228
 msgid "X Input event for unknown window"
 msgstr "Bilinmeyen pencere için X Giriş olayı"
 
-#: vncviewer/touch.cxx:251
+#: vncviewer/touch.cxx:254
 msgid "X Input extension not available."
 msgstr "X Giriş uzantısı mevcut değil."
 
-#: vncviewer/touch.cxx:258
+#: vncviewer/touch.cxx:261
 msgid "X Input 2 (or newer) is not available."
 msgstr "X Giriş 2 (veya daha yenisi) mevcut değil."
 
-#: vncviewer/touch.cxx:263
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
-msgstr "X Giriş 2.2 (veya daha yenisi) mevcut değil. Dokunma hareketleri desteklenmeyecektir."
+#: vncviewer/touch.cxx:266
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+"X Giriş 2.2 (veya daha yenisi) mevcut değil. Dokunma hareketleri "
+"desteklenmeyecektir."
 
-#: vncviewer/vncviewer.cxx:107
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC Viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
-"Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+"Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"TigerVNC Görüntüleyici v%s\n"
-"Derlenme: %s\n"
-"Telif Hakkı (C) 1999-%d TigerVNC Takımı ve diğer birçok kişi (bkz. README.rst)\n"
-"TigerVNC hakkında bilgi için http://www.tigervnc.org adresine bakın."
 
-#: vncviewer/vncviewer.cxx:161
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -865,15 +894,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:177
-msgid "About TigerVNC Viewer"
-msgstr "TigerVNC Görüntüleyici Hakkında"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:198
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "Dahili FLTK hatası. Çıkışıyor."
 
-#: vncviewer/vncviewer.cxx:217
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -884,79 +913,167 @@ msgstr ""
 "\n"
 "Yeniden bağlanma denensin mi?"
 
-#: vncviewer/vncviewer.cxx:248 vncviewer/vncviewer.cxx:260
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Yeni TigerVNC Görüntüleyici başlatılırken hata oluştu: %s"
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:269
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC Viewer will now exit."
-msgstr "Sonlandırma sinyali %d alındı. TigerVNC Görüntüleyici çıkacak."
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:415
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "Evet"
 
-#: vncviewer/vncviewer.cxx:418
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "Kapat"
 
-#: vncviewer/vncviewer.cxx:423
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "Hakkında"
 
-#: vncviewer/vncviewer.cxx:426
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "Gizle"
 
-#: vncviewer/vncviewer.cxx:429
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "Çık"
 
-#: vncviewer/vncviewer.cxx:433
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "Hizmetler"
 
-#: vncviewer/vncviewer.cxx:434
-msgid "Hide Others"
-msgstr "Diğerlerini Gizle"
+#: vncviewer/vncviewer.cxx:413
+msgid "Hide others"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:435
-msgid "Show All"
-msgstr "Tümü Göster"
+#: vncviewer/vncviewer.cxx:414
+msgid "Show all"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:444
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "&Dosya"
 
-#: vncviewer/vncviewer.cxx:447
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "&Yeni Bağlantı"
 
-#: vncviewer/vncviewer.cxx:463
+#: vncviewer/vncviewer.cxx:449
 #, c-format
-msgid "Could not create VNC home directory: %s"
-msgstr "VNC ana dizini oluşturulamadı: %s"
+msgid ""
+"\n"
+"Usage: %s [parameters] [host][:displayNum]\n"
+"       %s [parameters] [host][::port]\n"
+"       %s [parameters] [unix socket]\n"
+"       %s [parameters] -listen [port]\n"
+"       %s [parameters] [.tigervnc file]\n"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:562
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
-msgstr "FullScreenAllMonitors artık eski, bunun yerine FullScreenMode seçeneğini 'all' yapın"
+#: vncviewer/vncviewer.cxx:464
+#, c-format
+msgid ""
+"\n"
+"Options:\n"
+"\n"
+"  -display Xdisplay  - Specifies the X display for the viewer window\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
+"                       man page for details.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:471
+#, c-format
+msgid ""
+"\n"
+"Parameters can be turned on with -<param> or off with -<param>=0\n"
+"Parameters which take a value can be specified as -<param> <value>\n"
+"Other valid forms are <param>=<value> -<param>=<value> --<param>=<value>\n"
+"Parameter names are case-insensitive.  The parameters are:\n"
+"\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+"FullScreenAllMonitors artık eski, bunun yerine FullScreenMode seçeneğini "
+"'all' yapın"
+
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:556
+#, c-format
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:561
+#, c-format
+msgid "Could not create VNC config directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:567
+msgid "Could not determine VNC data directory path"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:573
+#, c-format
+msgid "Could not create VNC data directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:585
+#, c-format
+msgid "Could not create VNC state directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:704
+#, c-format
+msgid "%s: Unrecognized option '%s'\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
+#, c-format
+msgid "See '%s --help' for more information.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:713
+#, c-format
+msgid "%s: Extra argument '%s'\n"
+msgstr ""
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:768 vncviewer/vncviewer.cxx:769
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "-listen ve -via parametreleri uyumsuzdur"
 
-#: vncviewer/vncviewer.cxx:783
+#: vncviewer/vncviewer.cxx:764
+msgid "Unable to listen for incoming connections"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "%d bağlantı noktasında dinleniyor"
 
-#: vncviewer/vncviewer.cxx:816
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -967,6 +1084,138 @@ msgstr ""
 "\n"
 "%s"
 
+#: vncviewer/vncviewer.cxx:816
+#, c-format
+msgid ""
+"Failure setting up encrypted tunnel:\n"
+"\n"
+"%s"
+msgstr ""
+
 #: vncviewer/vncviewer.desktop.in.in:4
-msgid "Remote Desktop Viewer"
-msgstr "Uzak Masaüstü Görüntüleyici"
+msgid "Remote desktop viewer"
+msgstr ""
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(sunucu varsayılanı %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "SetDesktopSize başarısız: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "Sunucudan gelen geçersiz SetColourMapEntries!"
+
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "%s için geçersiz yapılandırma belirtildi"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "Geçersiz monitör dizini '%s'"
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "Beklenmeyen karakter '%c'"
+
+#~ msgid "VNC Viewer: Connection Options"
+#~ msgstr "VNC Görüntüleyici: Bağlantı Seçenekleri"
+
+#~ msgid "Show dot when no cursor"
+#~ msgstr "İmleç yokken nokta göster"
+
+#~ msgid "Misc."
+#~ msgstr "Çeşitli"
+
+#~ msgid "VNC Viewer: Connection Details"
+#~ msgstr "VNC Görüntüleyici: Bağlantı Bilgileri"
+
+#~ msgid "Save As..."
+#~ msgstr "Farklı Kaydet..."
+
+#~ msgid "Could not obtain the home directory path"
+#~ msgstr "VNC ana dizini edinilemedi"
+
+#, c-format
+#~ msgid "Could not open \"%s\": %s"
+#~ msgstr "\"%s\" açılamadı: %s"
+
+#, c-format
+#~ msgid "Failed to read line %d in file %s: %s"
+#~ msgstr "%d satırını %s dosyasından okumak başarısız: %s"
+
+#~ msgid "Authentication cancelled"
+#~ msgstr "Doğrulama iptal edildi"
+
+#, c-format
+#~ msgid "Failed to update keyboard LED state: %d"
+#~ msgstr "Klavye LED durumu güncellenemedi: %d"
+
+#~ msgid "No key code specified on key press"
+#~ msgstr "Tuşa basıldığında tuş kodu belirtilmedi"
+
+#, c-format
+#~ msgid "No symbol for key code 0x%02x (in the current state)"
+#~ msgstr "Tuş kodu 0x%02x için simge yok (mevcut durumda)"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "Dis&connect"
+#~ msgstr "Bağlantıyı &Kes"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "TigerVNC görüntüleyici &hakkında..."
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "TigerVNC Görüntüleyici"
+
+#~ msgid "TigerVNC Viewer connection to a CentOS machine"
+#~ msgstr "TigerVNC Görüntüleyici, CentOS makinesine bağlantı"
+
+#~ msgid "TigerVNC Viewer connection to a macOS machine"
+#~ msgstr "TigerVNC Görüntüleyici, macOS makinesine bağlantı"
+
+#~ msgid "TigerVNC Viewer connection to a Windows machine"
+#~ msgstr "TigerVNC Görüntüleyici, Windows makinesine bağlantı"
+
+#~ msgid "Unknown parameter type"
+#~ msgstr "Bilinmeyen parametre türü"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC Viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "TigerVNC Görüntüleyici v%s\n"
+#~ "Derlenme: %s\n"
+#~ "Telif Hakkı (C) 1999-%d TigerVNC Takımı ve diğer birçok kişi (bkz. README."
+#~ "rst)\n"
+#~ "TigerVNC hakkında bilgi için http://www.tigervnc.org adresine bakın."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "TigerVNC Görüntüleyici Hakkında"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Yeni TigerVNC Görüntüleyici başlatılırken hata oluştu: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC Viewer will now exit."
+#~ msgstr "Sonlandırma sinyali %d alındı. TigerVNC Görüntüleyici çıkacak."
+
+#~ msgid "Hide Others"
+#~ msgstr "Diğerlerini Gizle"
+
+#~ msgid "Show All"
+#~ msgstr "Tümü Göster"
+
+#, c-format
+#~ msgid "Could not create VNC home directory: %s"
+#~ msgstr "VNC ana dizini oluşturulamadı: %s"
+
+#~ msgid "Remote Desktop Viewer"
+#~ msgstr "Uzak Masaüstü Görüntüleyici"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.14.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2025-01-14 16:15+0100\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2025-01-21 19:30+0200\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <trans-uk@lists.fedoraproject.org>\n"
@@ -16,20 +16,21 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Bugs: Report translation errors to the Language-Team address.\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Lokalize 23.04.3\n"
 
-#: vncviewer/CConn.cxx:102
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "З’єднано з сокетом %s"
 
-#: vncviewer/CConn.cxx:109
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "З’єднано з вузлом %s, порт %d"
 
-#: vncviewer/CConn.cxx:114
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -40,66 +41,65 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:151
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Назва робочої станції: %.80s"
 
-#: vncviewer/CConn.cxx:154
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Вузол: %.80s порт: %d"
 
-#: vncviewer/CConn.cxx:158
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Розмір: %d x %d"
 
-#: vncviewer/CConn.cxx:165
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Формат у пікселях: %s"
 
-#: vncviewer/CConn.cxx:170
-#, c-format
-msgid "(server default %s)"
-msgstr "(типовий для сервера %s)"
-
-#: vncviewer/CConn.cxx:173
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Запит щодо кодування: %s"
 
-#: vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Останнє використане кодування: %s"
 
-#: vncviewer/CConn.cxx:181
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Оцінка швидкості лінії: %d кбіт/с"
 
-#: vncviewer/CConn.cxx:185
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Версія протоколу: %d.%d"
 
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Метод захисту: %s"
 
-#: vncviewer/CConn.cxx:250 vncviewer/CConn.cxx:252
-msgid "The connection was dropped by the server before the session could be established."
-msgstr "З'єднання було розірвано сервером до того, як виникла можливість розпочати сеанс."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
+msgstr ""
+"З'єднання було розірвано сервером до того, як виникла можливість розпочати "
+"сеанс."
 
-#: vncviewer/CConn.cxx:262
+#: vncviewer/CConn.cxx:258
 #, c-format
 msgid "Authentication failed: %s"
 msgstr "Розпізнавання не пройдено: %s"
 
-#: vncviewer/CConn.cxx:263
+#: vncviewer/CConn.cxx:259
 #, c-format
 msgid ""
 "Failed to authenticate with the server. Reason given by the server:\n"
@@ -110,31 +110,22 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:335
-#, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "Помилка SetDesktopSize: %d"
-
-#: vncviewer/CConn.cxx:408
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "Некоректне значення SetColourMapEntries від сервера!"
-
-#: vncviewer/CConn.cxx:516
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Пропускна здатність %d кбіт/с — змінюємо якість на %d"
 
-#: vncviewer/CConn.cxx:538
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "Пропускна здатність %d кбіт/с — увімкнено повноцінні кольори"
 
-#: vncviewer/CConn.cxx:541
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "Пропускна здатність %d кбіт/с — вимкнено повноцінні кольори"
 
-#: vncviewer/CConn.cxx:567
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Використовуємо формат у пікселях %s"
@@ -147,136 +138,129 @@ msgstr "Вказано некоректні геометричні параме�
 msgid "Reducing window size to fit on current monitor"
 msgstr "Зменшуємо розмір вікна, щоб умістити його на поточному моніторі"
 
-#: vncviewer/DesktopWindow.cxx:646
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
-msgstr "Коригувати розміри вікна, щоб уникнути випадкового запиту щодо переходу у повноекранний режим"
+msgstr ""
+"Коригувати розміри вікна, щоб уникнути випадкового запиту щодо переходу у "
+"повноекранний режим"
 
-#: vncviewer/DesktopWindow.cxx:694
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Натисніть %s, щоб відкрити контекстне меню"
 
-#: vncviewer/DesktopWindow.cxx:1094 vncviewer/DesktopWindow.cxx:1102
-#: vncviewer/DesktopWindow.cxx:1122
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Помилка під час спроби перехопити клавіатуру"
 
-#: vncviewer/DesktopWindow.cxx:1411
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
-msgstr "Результати обчислення компонування вікна для запиту щодо зміни розмірів є некоректними!"
+msgstr ""
+"Результати обчислення компонування вікна для запиту щодо зміни розмірів є "
+"некоректними!"
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "Некоректний стан для емуляції 3 кнопок"
 
-#: vncviewer/KeyboardWin32.cxx:242
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "Немає коду сканування для віртуальної клавіші розширення 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:244
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "Немає коду сканування для віртуальної клавіші 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:250
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "Некоректний код сканування 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:262
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "Немає символу для віртуальної клавіші розширення 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:264
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "Немає символу для віртуальної клавіші 0x%02x"
 
-#: vncviewer/KeyboardWin32.cxx:423
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
 msgid "Failed to update keyboard LED state: %lu"
 msgstr "Не вдалося оновити стан лампочки клавіатури: %lu"
 
-#: vncviewer/KeyboardX11.cxx:104
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "Немає символу для клавіші з кодом %d (у поточному стані)"
 
-#: vncviewer/KeyboardX11.cxx:129
+#: vncviewer/KeyboardX11.cxx:148
 #, c-format
 msgid "Failed to get keyboard LED state: %d"
 msgstr "Не вдалося отримати стан лампочки клавіатури: %d"
 
-#: vncviewer/KeyboardX11.cxx:174
+#: vncviewer/KeyboardX11.cxx:193
 msgid "Failed to update keyboard LED state"
 msgstr "Не вдалося оновити стан лампочки клавіатури"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:100
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "Не вдалося отримати налаштування монітора з боку системи"
 
-#: vncviewer/MonitorIndicesParameter.cxx:79
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "Вказано некоректні налаштування для %s"
-
-#: vncviewer/MonitorIndicesParameter.cxx:86
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "Монітора із індексом %d не існує"
 
-#: vncviewer/MonitorIndicesParameter.cxx:162
-#: vncviewer/MonitorIndicesParameter.cxx:182
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "Некоректний індекс монітора, «%s»"
-
-#: vncviewer/MonitorIndicesParameter.cxx:170
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "Неочікуваний символ «%c»"
-
-#: vncviewer/OptionsDialog.cxx:64
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
 msgid "TigerVNC options"
 msgstr "Параметри TigerVNC"
 
-#: vncviewer/OptionsDialog.cxx:97 vncviewer/ServerDialog.cxx:107
-#: vncviewer/vncviewer.cxx:397
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: vncviewer/OptionsDialog.cxx:102 vncviewer/vncviewer.cxx:396
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "Гаразд"
 
-#: vncviewer/OptionsDialog.cxx:514
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "Стискання"
 
-#: vncviewer/OptionsDialog.cxx:530
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "Автовибір"
 
-#: vncviewer/OptionsDialog.cxx:541
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "Бажане кодування"
 
-#: vncviewer/OptionsDialog.cxx:602
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "Рівень відтворення кольору"
 
-#: vncviewer/OptionsDialog.cxx:614
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "Повний"
 
-#: vncviewer/OptionsDialog.cxx:621
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "Середній"
 
-#: vncviewer/OptionsDialog.cxx:628
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "Низький"
 
@@ -284,166 +268,179 @@ msgstr "Низький"
 msgid "Very low"
 msgstr "Дуже низький"
 
-#: vncviewer/OptionsDialog.cxx:657
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "Нетиповий рівень стискання:"
 
-#: vncviewer/OptionsDialog.cxx:664
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "рівень (0=швидко, 9=найкраще)"
 
-#: vncviewer/OptionsDialog.cxx:671
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "Дозволити стискання JPEG:"
 
-#: vncviewer/OptionsDialog.cxx:678
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "якість (0=найгірша, 9=найкраща)"
 
-#: vncviewer/OptionsDialog.cxx:689
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "Захист"
 
-#: vncviewer/OptionsDialog.cxx:703
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "Шифрування"
 
-#: vncviewer/OptionsDialog.cxx:715 vncviewer/OptionsDialog.cxx:782
-#: vncviewer/OptionsDialog.cxx:905
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "Немає"
 
-#: vncviewer/OptionsDialog.cxx:722
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "TLS із анонімними сертифікатами"
 
-#: vncviewer/OptionsDialog.cxx:728
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "TLS з сертифікатами X509"
 
-#: vncviewer/OptionsDialog.cxx:735
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "Шлях до сертифіката CA X509"
 
-#: vncviewer/OptionsDialog.cxx:742
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "Шлях до файла CRL X509"
 
-#: vncviewer/OptionsDialog.cxx:770
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "Розпізнавання"
 
-#: vncviewer/OptionsDialog.cxx:788
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "Стандартний VNC (без захисту і шифрування)"
 
-#: vncviewer/OptionsDialog.cxx:794
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "Ім’я користувача і пароль (без захисту і шифрування)"
 
-#: vncviewer/OptionsDialog.cxx:822
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "Введення"
 
-#: vncviewer/OptionsDialog.cxx:835
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "Лише перегляд (ігнорувати сигнали від миші і клавіатури)"
 
-#: vncviewer/OptionsDialog.cxx:842
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "Миша"
 
-#: vncviewer/OptionsDialog.cxx:854
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "Емулювати середню кнопку миші"
 
-#: vncviewer/OptionsDialog.cxx:860
+#: vncviewer/OptionsDialog.cxx:880
 msgid "Show local cursor when not provided by server"
 msgstr "Показувати локальний курсор, якщо його не надано сервером"
 
-#: vncviewer/OptionsDialog.cxx:865
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
 msgid "Cursor type"
 msgstr "Тип курсора"
 
-#: vncviewer/OptionsDialog.cxx:867
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
 msgid "Dot"
 msgstr "Крапка"
 
-#: vncviewer/OptionsDialog.cxx:868
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
 msgid "System"
 msgstr "Системний"
 
-#: vncviewer/OptionsDialog.cxx:888
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "Клавіатура"
 
-#: vncviewer/OptionsDialog.cxx:900
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
-msgstr "Передавати натискання системних клавіш безпосередньо до сервера (повноекранний режим)"
+msgstr ""
+"Передавати натискання системних клавіш безпосередньо до сервера "
+"(повноекранний режим)"
 
-#: vncviewer/OptionsDialog.cxx:903
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "Клавіша меню"
 
-#: vncviewer/OptionsDialog.cxx:926
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "Буфер обміну"
 
-#: vncviewer/OptionsDialog.cxx:938
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "Приймати вміст буфера з сервера"
 
-#: vncviewer/OptionsDialog.cxx:946
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "Також встановити основне позначене"
 
-#: vncviewer/OptionsDialog.cxx:953
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "Надіслати вміст буфера обміну до сервера"
 
-#: vncviewer/OptionsDialog.cxx:961
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "Надіслати основне позначене як буфер обміну"
 
-#: vncviewer/OptionsDialog.cxx:982
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "Дисплей"
 
-#: vncviewer/OptionsDialog.cxx:996
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "Режим показу"
 
-#: vncviewer/OptionsDialog.cxx:1009
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "У вікні"
 
-#: vncviewer/OptionsDialog.cxx:1017
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "Повноекранний режим на поточному моніторі"
 
-#: vncviewer/OptionsDialog.cxx:1025
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "Повноекранний режимі на усіх моніторах"
 
-#: vncviewer/OptionsDialog.cxx:1033
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "Повноекранний режим на позначених моніторах"
 
-#: vncviewer/OptionsDialog.cxx:1062
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
 msgid "Miscellaneous"
 msgstr "Інше"
 
-#: vncviewer/OptionsDialog.cxx:1070
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "Спільний (не від’єднувати інші засоби перегляду)"
 
-#: vncviewer/OptionsDialog.cxx:1076
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "Питати про повторне з'єднання при помилка з'єднання"
-
-#: vncviewer/ServerDialog.cxx:63
-msgid "VNC viewer: Connection details"
-msgstr "Засіб перегляду VNC: подробиці з’єднання"
 
 #: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
@@ -488,7 +485,7 @@ msgstr "налаштування TigerVNC (*.tigervnc)"
 msgid "Select a TigerVNC configuration file"
 msgstr "Виберіть файл налаштувань TigerVNC"
 
-#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:517
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -508,7 +505,7 @@ msgstr "Зберегти налаштування TigerVNC до файла"
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "%s вже існує. Перезаписати?"
 
-#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:394
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "Ні"
 
@@ -549,169 +546,171 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:351 vncviewer/ServerDialog.cxx:429
-#: vncviewer/vncviewer.cxx:580
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
 msgid "Could not determine VNC state directory path"
 msgstr "Не вдалося визначити каталог стану VNC"
 
-#: vncviewer/ServerDialog.cxx:363 vncviewer/ServerDialog.cxx:437
-#: vncviewer/parameters.cxx:671 vncviewer/parameters.cxx:752
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
 msgid "Could not open \"%s\""
 msgstr "Не вдалося відкрити «%s»"
 
-#: vncviewer/ServerDialog.cxx:378 vncviewer/ServerDialog.cxx:387
-#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:773
-#: vncviewer/parameters.cxx:807 vncviewer/parameters.cxx:837
-#: vncviewer/parameters.cxx:844
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
 msgid "Failed to read line %d in file \"%s\""
 msgstr "Не вдалося прочитати рядок %d у файлі «%s»"
 
-#: vncviewer/ServerDialog.cxx:390 vncviewer/parameters.cxx:776
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "Занадто довгий рядок"
 
-#: vncviewer/UserDialog.cxx:123
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "Спроба відкриття файла паролів зазнала невдачі"
 
-#: vncviewer/UserDialog.cxx:143
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "Розпізнавання VNC"
 
-#: vncviewer/UserDialog.cxx:150
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "Це з'єднання є безпечним"
 
-#: vncviewer/UserDialog.cxx:154
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "Це з'єднання не є безпечним"
 
-#: vncviewer/UserDialog.cxx:176
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "Користувач:"
 
-#: vncviewer/UserDialog.cxx:189
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "Пароль:"
 
-#: vncviewer/UserDialog.cxx:197
+#: vncviewer/UserDialog.cxx:204
 msgid "Keep password for reconnect"
 msgstr "Зберігати пароль для повторного з'єднання"
 
-#: vncviewer/Viewport.cxx:695
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
 msgid "Disconn&ect"
 msgstr "Від'єд&натися"
 
-#: vncviewer/Viewport.cxx:698
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "&На весь екран"
 
-#: vncviewer/Viewport.cxx:701
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "М&інімізувати"
 
-#: vncviewer/Viewport.cxx:703
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "Змінити &розміри вікна відповідно до сеансу"
 
-#: vncviewer/Viewport.cxx:708
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:711
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:717
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "Надіслати %s"
 
-#: vncviewer/Viewport.cxx:724
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "На&діслати Ctrl-Alt-Del"
 
-#: vncviewer/Viewport.cxx:727
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "&Оновити вміст екрана"
 
-#: vncviewer/Viewport.cxx:730
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "П&араметри…"
 
-#: vncviewer/Viewport.cxx:732
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "Дані щодо з’&єднання…"
 
-#: vncviewer/Viewport.cxx:734
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "Про &засіб перегляду TigerVNC…"
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:830
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "Дані щодо з’єднання VNC"
 
-#: vncviewer/Win32TouchHandler.cxx:48
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "Вікно зареєстровано для сенсорних дій, а не для жестів"
 
-#: vncviewer/Win32TouchHandler.cxx:83
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "Не вдалося встановити налаштування жестів (помилка 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:95
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "Не вдалося отримати відомості щодо жестів (помилка 0x%x)"
 
-#: vncviewer/Win32TouchHandler.cxx:360
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr "Некоректна кнопка миші, %d, номер кнопки має бути числом від 1 до 7."
 
-#: vncviewer/Win32TouchHandler.cxx:425
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
-msgstr "Непридатна до обробки клавіша 0x%x — не вдалося створити подію клавіатури."
+msgstr ""
+"Непридатна до обробки клавіша 0x%x — не вдалося створити подію клавіатури."
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:107
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
 msgstr "Не вдалося отримати маску події X Input 2 для вікна 0x%08lx"
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr "У вікна 0x%08lx немає маски подій X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:114
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr "У вікна 0x%08lx є декілька масок подій X Input 2"
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "Помилка під час спроби захопити пристрій %i"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-msgid "TigerVNC Viewer"
-msgstr "Засіб перегляду TigerVNC"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -719,100 +718,130 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr "З'єднання із сервером VNC і показ віддаленої стільниці"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
-msgstr "Віртуальна мережева взаємодія комп'ютерів (Virtual Network Computing або VNC) є системою віддаленої стільниці, за допомогою якої ви можете переглядати та взаємодіяти із віртуальним стільничним середовищем, яке запущено на іншому комп'ютері у мережі. За допомогою VNC ви можете запускати програми із графічним інтерфейсом на віддаленому комп'ютері і отримувати лише зображення з цих програм на вашому локальному пристрої. У цьому пакунку міститься клієнтська частина, за допомогою якої ви можете з'єднуватися з іншими стільничними середовищами, де запущено сервер VNC. Протокол VNC є незалежним від платформи, у ньому передбачено підтримку різних операційних систем та апаратних архітектур, як на сервері, так і на клієнті."
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+"Віртуальна мережева взаємодія комп'ютерів (Virtual Network Computing або "
+"VNC) є системою віддаленої стільниці, за допомогою якої ви можете "
+"переглядати та взаємодіяти із віртуальним стільничним середовищем, яке "
+"запущено на іншому комп'ютері у мережі. За допомогою VNC ви можете запускати "
+"програми із графічним інтерфейсом на віддаленому комп'ютері і отримувати "
+"лише зображення з цих програм на вашому локальному пристрої. У цьому пакунку "
+"міститься клієнтська частина, за допомогою якої ви можете з'єднуватися з "
+"іншими стільничними середовищами, де запущено сервер VNC. Протокол VNC є "
+"незалежним від платформи, у ньому передбачено підтримку різних операційних "
+"систем та апаратних архітектур, як на сервері, так і на клієнті."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
-msgstr "TigerVNC — високошвидкісна версія VNC на основі програмного коду RealVNC 4 та X.org. Роботу над TigerVNC було розпочато у межах побудови наступного покоління для TightVNC на платформах Unix та Linux, але програма відокремилася від батьківського проєкту на початку 2009 року, коли проєкт TightVNC зосередився на платформах Windows. У TigerVNC передбачено підтримку варіанта кодування Tight, який значно пришвидшено використанням кодека JPEG libjpeg-turbo."
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+"TigerVNC — високошвидкісна версія VNC на основі програмного коду RealVNC 4 "
+"та X.org. Роботу над TigerVNC було розпочато у межах побудови наступного "
+"покоління для TightVNC на платформах Unix та Linux, але програма "
+"відокремилася від батьківського проєкту на початку 2009 року, коли проєкт "
+"TightVNC зосередився на платформах Windows. У TigerVNC передбачено підтримку "
+"варіанта кодування Tight, який значно пришвидшено використанням кодека JPEG "
+"libjpeg-turbo."
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC viewer connection to a CentOS machine"
-msgstr "З'єднання Переглядача TigerVNC зі комп'ютером, де працює CentOS"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC viewer connection to a macOS machine"
-msgstr "З'єднання Переглядача TigerVNC із комп'ютером, де працює macOS"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC viewer connection to a Windows machine"
-msgstr "З'єднання Переглядача TigerVNC із комп'ютером, де працює Windows"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
 #. developer_name tag deprecated with Appstream 1.0
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
-#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:48
 msgid "The TigerVNC team"
 msgstr "Команда TigerVNC"
 
-#: vncviewer/parameters.cxx:319 vncviewer/parameters.cxx:344
-#: vncviewer/parameters.cxx:361 vncviewer/parameters.cxx:401
-#: vncviewer/parameters.cxx:421
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "Назва параметра є надто довгою"
 
-#: vncviewer/parameters.cxx:323 vncviewer/parameters.cxx:328
-#: vncviewer/parameters.cxx:379
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "Параметр є надто великим"
 
-#: vncviewer/parameters.cxx:386 vncviewer/parameters.cxx:712
-#: vncviewer/parameters.cxx:822
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "Некоректне форматування або надто велике значення"
 
-#: vncviewer/parameters.cxx:440 vncviewer/parameters.cxx:473
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "Не вдалося створити ключ реєстру"
 
-#: vncviewer/parameters.cxx:461 vncviewer/parameters.cxx:528
-#: vncviewer/parameters.cxx:571 vncviewer/parameters.cxx:638
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "Не вдалося закрити ключ реєстру"
 
-#: vncviewer/parameters.cxx:479 vncviewer/parameters.cxx:506
-#: vncviewer/parameters.cxx:680 vncviewer/parameters.cxx:692
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "Не вдалося зберегти «%s»: %s"
 
-#: vncviewer/parameters.cxx:489 vncviewer/parameters.cxx:520
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "Не вдалося вилучити «%s»: %s"
 
-#: vncviewer/parameters.cxx:544 vncviewer/parameters.cxx:616
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "Не вдалося відкрити ключ реєстру"
 
-#: vncviewer/parameters.cxx:561
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "Не вдалося прочитати запис журналу сервера %d: %s"
 
-#: vncviewer/parameters.cxx:597 vncviewer/parameters.cxx:627
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "Не вдалося прочитати параметр «%s»: %s"
 
-#: vncviewer/parameters.cxx:661 vncviewer/parameters.cxx:740
-#: vncviewer/vncviewer.cxx:546
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
 msgid "Could not determine VNC config directory path"
 msgstr "Не вдалося визначити шлях до каталогу налаштувань VNC"
 
-#: vncviewer/parameters.cxx:682 vncviewer/parameters.cxx:694
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "Не вдалося закодувати параметр"
 
-#: vncviewer/parameters.cxx:785
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "Файл налаштувань %s збережено у некоректному форматі"
 
-#: vncviewer/parameters.cxx:809
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "Некоректне форматування"
 
-#: vncviewer/parameters.cxx:846
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "Невідомий параметр"
 
@@ -853,23 +882,23 @@ msgid "X Input 2 (or newer) is not available."
 msgstr "Немає доступу до X Input 2 (або новішої версії)."
 
 #: vncviewer/touch.cxx:266
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
-msgstr "Немає доступу до X Input 2.2 (або новішої версії). Ви не зможете скористатися підтримкою сенсорних жестів."
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+"Немає доступу до X Input 2.2 (або новішої версії). Ви не зможете "
+"скористатися підтримкою сенсорних жестів."
 
-#: vncviewer/vncviewer.cxx:104
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
 "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"Засіб перегляду TigerVNC, v%s\n"
-"Зібрано: %s\n"
-"Авторські права належать команді TigerVNC та багатьом іншим (див. файл README.rst), 1999–%d\n"
-"Докладніший опис TigerVNC можна знайти на https://www.tigervnc.org."
 
-#: vncviewer/vncviewer.cxx:158
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -880,15 +909,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:174
-msgid "About TigerVNC Viewer"
-msgstr "Про засіб перегляду TigerVNC"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:195
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "Внутрішня помилка FLTK. Завершуємо роботу."
 
-#: vncviewer/vncviewer.cxx:214
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -899,63 +928,59 @@ msgstr ""
 "\n"
 "Спробувати встановити з'єднання ще раз?"
 
-#: vncviewer/vncviewer.cxx:245 vncviewer/vncviewer.cxx:257
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Помилка під час спроби запуску нового засобу перегляду TigerVNC: %s"
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:266
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC viewer will now exit."
-msgstr "Отримано сигнал переривання %d. Зараз засіб перегляду TigerVNC завершить роботу."
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:391 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC viewer"
-msgstr "Засіб перегляду TigerVNC"
-
-#: vncviewer/vncviewer.cxx:395
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "Так"
 
-#: vncviewer/vncviewer.cxx:398
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "Закрити"
 
-#: vncviewer/vncviewer.cxx:403
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "Про програму"
 
-#: vncviewer/vncviewer.cxx:406
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "Сховати"
 
-#: vncviewer/vncviewer.cxx:409
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "Вийти"
 
-#: vncviewer/vncviewer.cxx:413
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "Служби"
 
-#: vncviewer/vncviewer.cxx:414
+#: vncviewer/vncviewer.cxx:413
 msgid "Hide others"
 msgstr "Сховати решту"
 
-#: vncviewer/vncviewer.cxx:415
+#: vncviewer/vncviewer.cxx:414
 msgid "Show all"
 msgstr "Показати всі"
 
-#: vncviewer/vncviewer.cxx:424
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "&Файл"
 
-#: vncviewer/vncviewer.cxx:427
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "&Створити з'єднання"
 
-#: vncviewer/vncviewer.cxx:450
+#: vncviewer/vncviewer.cxx:449
 #, c-format
 msgid ""
 "\n"
@@ -972,24 +997,19 @@ msgstr ""
 "       %s [параметри] -listen [порт]\n"
 "       %s [параметри] [файл .tigervnc]\n"
 
-#: vncviewer/vncviewer.cxx:465
+#: vncviewer/vncviewer.cxx:464
 #, c-format
 msgid ""
 "\n"
 "Options:\n"
 "\n"
 "  -display Xdisplay  - Specifies the X display for the viewer window\n"
-"  -geometry geometry - Initial position of the main VNC viewer window. See the\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
 "                       man page for details.\n"
 msgstr ""
-"\n"
-"Параметри:\n"
-"\n"
-"  -display дисплейX  - визначити дисплей X для показу вікна переглядача\n"
-"  -geometry геометрія - початкова позиція головного вікна переглядача VNC.\n"
-"                       Див. сторінку man, щоб дізнатися більше.\n"
 
-#: vncviewer/vncviewer.cxx:472
+#: vncviewer/vncviewer.cxx:471
 #, c-format
 msgid ""
 "\n"
@@ -1000,79 +1020,95 @@ msgid ""
 "\n"
 msgstr ""
 "\n"
-"Параметри можна увімкнути за допомогою -<парам> або вимкнути за допомогою -<парам>=0\n"
+"Параметри можна увімкнути за допомогою -<парам> або вимкнути за допомогою -"
+"<парам>=0\n"
 "Параметри, які приймають значення можна вказати у формі -<парам> <значення>\n"
-"Інші коректні форми — <парам>=<значення> -<парам>=<значення> --<парам>=<значення>\n"
+"Інші коректні форми — <парам>=<значення> -<парам>=<значення> --"
+"<парам>=<значення>\n"
 "Назви параметрів слід вказувати з врахуванням регістру символів. Параметри:\n"
 "\n"
 
-#: vncviewer/vncviewer.cxx:527
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
-msgstr "FullScreenAllMonitors вважається застарілим, замість нього слід встановити для FullScreenMode значення «all»"
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+"FullScreenAllMonitors вважається застарілим, замість нього слід встановити "
+"для FullScreenMode значення «all»"
 
-#: vncviewer/vncviewer.cxx:532
-msgid "DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' instead"
-msgstr "DotWhenNoCursor з застарілим, натомість встановіть для AlwaysCursor значення 1, а для CursorType значення 'Dot'"
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+"DotWhenNoCursor з застарілим, натомість встановіть для AlwaysCursor значення "
+"1, а для CursorType значення 'Dot'"
 
-#: vncviewer/vncviewer.cxx:553
-msgid "~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
-msgstr "~/.vnc вважається застарілим, будь ласка, ознайомтеся із «man vncviewer», щоб дізнатися більше про перенесення даних."
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+"~/.vnc вважається застарілим, будь ласка, ознайомтеся із «man vncviewer», "
+"щоб дізнатися більше про перенесення даних."
 
-#: vncviewer/vncviewer.cxx:557
+#: vncviewer/vncviewer.cxx:556
 #, c-format
-msgid "%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC location."
-msgstr "%%APPDATA%%\\vnc вважається застарілим, будь ласка, переходьте на %%APPDATA%%\\TigerVNC."
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+"%%APPDATA%%\\vnc вважається застарілим, будь ласка, переходьте на %%APPDATA%%"
+"\\TigerVNC."
 
-#: vncviewer/vncviewer.cxx:562
+#: vncviewer/vncviewer.cxx:561
 #, c-format
 msgid "Could not create VNC config directory \"%s\": %s"
 msgstr "Не вдалося створити каталог налаштувань VNC «%s»: %s"
 
-#: vncviewer/vncviewer.cxx:568
+#: vncviewer/vncviewer.cxx:567
 msgid "Could not determine VNC data directory path"
 msgstr "Не вдалося визначити шлях до каталогу даних VNC"
 
-#: vncviewer/vncviewer.cxx:574
+#: vncviewer/vncviewer.cxx:573
 #, c-format
 msgid "Could not create VNC data directory \"%s\": %s"
 msgstr "Не вдалося створити каталог даних VNC «%s»: %s"
 
-#: vncviewer/vncviewer.cxx:586
+#: vncviewer/vncviewer.cxx:585
 #, c-format
 msgid "Could not create VNC state directory \"%s\": %s"
 msgstr "Не вдалося створити каталог стану VNC «%s»: %s"
 
-#: vncviewer/vncviewer.cxx:703
+#: vncviewer/vncviewer.cxx:704
 #, c-format
 msgid "%s: Unrecognized option '%s'\n"
 msgstr "%s: невідомий параметр «%s»\n"
 
-#: vncviewer/vncviewer.cxx:705 vncviewer/vncviewer.cxx:713
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
 #, c-format
 msgid "See '%s --help' for more information.\n"
 msgstr "Див. «%s --help», щоб дізнатися більше.\n"
 
-#: vncviewer/vncviewer.cxx:712
+#: vncviewer/vncviewer.cxx:713
 #, c-format
 msgid "%s: Extra argument '%s'\n"
 msgstr "%s: зайвий аргумент «%s»\n"
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:748 vncviewer/vncviewer.cxx:749
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "Параметри -listen і -via є несумісними"
 
-#: vncviewer/vncviewer.cxx:763
+#: vncviewer/vncviewer.cxx:764
 msgid "Unable to listen for incoming connections"
 msgstr "Не вдалося виконати стеження за вхідними з'єднаннями"
 
-#: vncviewer/vncviewer.cxx:765
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "Очікуємо на дані на порту %d"
 
-#: vncviewer/vncviewer.cxx:794
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -1083,7 +1119,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:815
+#: vncviewer/vncviewer.cxx:816
 #, c-format
 msgid ""
 "Failure setting up encrypted tunnel:\n"
@@ -1097,6 +1133,96 @@ msgstr ""
 #: vncviewer/vncviewer.desktop.in.in:4
 msgid "Remote desktop viewer"
 msgstr "Засіб перегляду віддаленої стільниці"
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(типовий для сервера %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "Помилка SetDesktopSize: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "Некоректне значення SetColourMapEntries від сервера!"
+
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "Вказано некоректні налаштування для %s"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "Некоректний індекс монітора, «%s»"
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "Неочікуваний символ «%c»"
+
+#~ msgid "VNC viewer: Connection details"
+#~ msgstr "Засіб перегляду VNC: подробиці з’єднання"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "Про &засіб перегляду TigerVNC…"
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "Засіб перегляду TigerVNC"
+
+#~ msgid "TigerVNC viewer connection to a CentOS machine"
+#~ msgstr "З'єднання Переглядача TigerVNC зі комп'ютером, де працює CentOS"
+
+#~ msgid "TigerVNC viewer connection to a macOS machine"
+#~ msgstr "З'єднання Переглядача TigerVNC із комп'ютером, де працює macOS"
+
+#~ msgid "TigerVNC viewer connection to a Windows machine"
+#~ msgstr "З'єднання Переглядача TigerVNC із комп'ютером, де працює Windows"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "Засіб перегляду TigerVNC, v%s\n"
+#~ "Зібрано: %s\n"
+#~ "Авторські права належать команді TigerVNC та багатьом іншим (див. файл "
+#~ "README.rst), 1999–%d\n"
+#~ "Докладніший опис TigerVNC можна знайти на https://www.tigervnc.org."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "Про засіб перегляду TigerVNC"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Помилка під час спроби запуску нового засобу перегляду TigerVNC: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC viewer will now exit."
+#~ msgstr ""
+#~ "Отримано сигнал переривання %d. Зараз засіб перегляду TigerVNC завершить "
+#~ "роботу."
+
+#~ msgid "TigerVNC viewer"
+#~ msgstr "Засіб перегляду TigerVNC"
+
+#, c-format
+#~ msgid ""
+#~ "\n"
+#~ "Options:\n"
+#~ "\n"
+#~ "  -display Xdisplay  - Specifies the X display for the viewer window\n"
+#~ "  -geometry geometry - Initial position of the main VNC viewer window. "
+#~ "See the\n"
+#~ "                       man page for details.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Параметри:\n"
+#~ "\n"
+#~ "  -display дисплейX  - визначити дисплей X для показу вікна переглядача\n"
+#~ "  -geometry геометрія - початкова позиція головного вікна переглядача "
+#~ "VNC.\n"
+#~ "                       Див. сторінку man, щоб дізнатися більше.\n"
 
 #~ msgid "Show dot when no cursor"
 #~ msgstr "Показувати крапку, якщо немає курсора"
@@ -1122,7 +1248,8 @@ msgstr "Засіб перегляду віддаленої стільниці"
 #~ msgstr "Інше"
 
 #~ msgid "Failed to get monitor name because X11 RandR could not be found"
-#~ msgstr "Не вдалося отримати назву монітора, оскільки не вдалося знайти RandR X11"
+#~ msgstr ""
+#~ "Не вдалося отримати назву монітора, оскільки не вдалося знайти RandR X11"
 
 #~ msgid "Failed to get information about CRTC %d"
 #~ msgstr "Не вдалося отримати відомості щодо CRTC %d"
@@ -1177,20 +1304,29 @@ msgstr "Засіб перегляду віддаленої стільниці"
 #~ msgid "The parameter %s was too large to read from the registry"
 #~ msgstr "Параметр %s є надто довгим для читання з реєстру"
 
-#~ msgid "Failed to write configuration file, can't obtain home directory path."
-#~ msgstr "Не вдалося записати файл налаштувань, оскільки не вдалося визначити шлях до домашнього каталогу."
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Не вдалося записати файл налаштувань, оскільки не вдалося визначити шлях "
+#~ "до домашнього каталогу."
 
 #~ msgid "Failed to write configuration file, can't open %s: %s"
-#~ msgstr "Не вдалося записати файл налаштувань, оскільки не вдалося відкрити %s: %s"
+#~ msgstr ""
+#~ "Не вдалося записати файл налаштувань, оскільки не вдалося відкрити %s: %s"
 
 #~ msgid "Failed to read configuration file, can't obtain home directory path."
-#~ msgstr "Не вдалося прочитати файл налаштувань, оскільки не вдалося визначити шлях до домашнього каталогу."
+#~ msgstr ""
+#~ "Не вдалося прочитати файл налаштувань, оскільки не вдалося визначити шлях "
+#~ "до домашнього каталогу."
 
 #~ msgid "Unknown parameter %s on line %d in file %s"
 #~ msgstr "Невідомий параметр %s у рядку %d файла %s"
 
-#~ msgid "Could not create VNC home directory: can't obtain home directory path."
-#~ msgstr "Не вдалося створити домашній каталог VNC: не вдалося отримати шлях до домашнього каталогу."
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
+#~ msgstr ""
+#~ "Не вдалося створити домашній каталог VNC: не вдалося отримати шлях до "
+#~ "домашнього каталогу."
 
 #~ msgid "tigervnc"
 #~ msgstr "tigervnc"
@@ -1244,7 +1380,8 @@ msgstr "Засіб перегляду віддаленої стільниці"
 #~ msgstr "Передбачено підтримку лише дисплеїв з True Color"
 
 #~ msgid "Using default colormap and visual, TrueColor, depth %d."
-#~ msgstr "Використовуємо типову карту кольорів і відтворення, TrueColor, глибина %d."
+#~ msgstr ""
+#~ "Використовуємо типову карту кольорів і відтворення, TrueColor, глибина %d."
 
 #~ msgid "Unknown encoding %d"
 #~ msgstr "Невідоме кодування %d"
@@ -1261,32 +1398,68 @@ msgstr "Засіб перегляду віддаленої стільниці"
 #~ msgid "CleanupSignalHandler called"
 #~ msgstr "Викликано CleanupSignalHandler"
 
-#~ msgid "Could not convert the parameter-name %s to wchar_t* when reading from the Registry, the buffersize is to small."
-#~ msgstr "Не вдалося перетворити назву параметра %s на wchar_t* під час читання даних з реєстру. Розмір буфера є надто малим."
+#~ msgid ""
+#~ "Could not convert the parameter-name %s to wchar_t* when reading from the "
+#~ "Registry, the buffersize is to small."
+#~ msgstr ""
+#~ "Не вдалося перетворити назву параметра %s на wchar_t* під час читання "
+#~ "даних з реєстру. Розмір буфера є надто малим."
 
-#~ msgid "Could not convert the parameter-name %s to wchar_t* when writing to the Registry, the buffersize is to small."
-#~ msgstr "Не вдалося перетворити назву параметра %s на wchar_t* під час запису даних до реєстру. Розмір буфера є надто малим."
+#~ msgid ""
+#~ "Could not convert the parameter-name %s to wchar_t* when writing to the "
+#~ "Registry, the buffersize is to small."
+#~ msgstr ""
+#~ "Не вдалося перетворити назву параметра %s на wchar_t* під час запису "
+#~ "даних до реєстру. Розмір буфера є надто малим."
 
-#~ msgid "Could not convert the parameter-value %s to wchar_t* when writing to the Registry, the buffersize is to small."
-#~ msgstr "Не вдалося перетворити значення параметра %s на wchar_t* під час запису даних до реєстру. Розмір буфера є надто малим."
+#~ msgid ""
+#~ "Could not convert the parameter-value %s to wchar_t* when writing to the "
+#~ "Registry, the buffersize is to small."
+#~ msgstr ""
+#~ "Не вдалося перетворити значення параметра %s на wchar_t* під час запису "
+#~ "даних до реєстру. Розмір буфера є надто малим."
 
-#~ msgid "Could not convert the parameter-value for %s to utf8 char* when reading from the Registry, the buffer dest is to small."
-#~ msgstr "Не вдалося перетворити значення параметра %s на utf8 char* під час читання з реєстру. Буфер призначення є надто малим."
+#~ msgid ""
+#~ "Could not convert the parameter-value for %s to utf8 char* when reading "
+#~ "from the Registry, the buffer dest is to small."
+#~ msgstr ""
+#~ "Не вдалося перетворити значення параметра %s на utf8 char* під час "
+#~ "читання з реєстру. Буфер призначення є надто малим."
 
-#~ msgid "Could not read the line(%d) in the configuration file,the buffersize is to small."
-#~ msgstr "Не вдалося прочитати рядок %d у файлі налаштувань. Розмір буфера є надто малим."
+#~ msgid ""
+#~ "Could not read the line(%d) in the configuration file,the buffersize is "
+#~ "to small."
+#~ msgstr ""
+#~ "Не вдалося прочитати рядок %d у файлі налаштувань. Розмір буфера є надто "
+#~ "малим."
 
-#~ msgid "Decoding: The size of the buffer dest is to small, it needs to be 1 byte bigger."
-#~ msgstr "Декодування: розмір буфера призначення є надто малим. Його слід збільшити на 1 байт."
+#~ msgid ""
+#~ "Decoding: The size of the buffer dest is to small, it needs to be 1 byte "
+#~ "bigger."
+#~ msgstr ""
+#~ "Декодування: розмір буфера призначення є надто малим. Його слід збільшити "
+#~ "на 1 байт."
 
-#~ msgid "Encoding backslash: The size of the buffer dest is to small, it needs to be more than %d bytes bigger."
-#~ msgstr "Кодування зворотної похилої риски: розмір буфера призначення є надто малим. Його слід збільшити на понад %d байтів."
+#~ msgid ""
+#~ "Encoding backslash: The size of the buffer dest is to small, it needs to "
+#~ "be more than %d bytes bigger."
+#~ msgstr ""
+#~ "Кодування зворотної похилої риски: розмір буфера призначення є надто "
+#~ "малим. Його слід збільшити на понад %d байтів."
 
-#~ msgid "Encoding escape sequence: The size of the buffer dest is to small, it needs to be more than %d bytes bigger."
-#~ msgstr "Кодування екранованої послідовності: розмір буфера призначення є надто малим. Його слід збільшити на понад %d байтів."
+#~ msgid ""
+#~ "Encoding escape sequence: The size of the buffer dest is to small, it "
+#~ "needs to be more than %d bytes bigger."
+#~ msgstr ""
+#~ "Кодування екранованої послідовності: розмір буфера призначення є надто "
+#~ "малим. Його слід збільшити на понад %d байтів."
 
-#~ msgid "Encoding normal character: The size of the buffer dest is to small, it needs to be more than %d bytes bigger."
-#~ msgstr "Кодування звичайного символу: розмір буфера призначення є надто малим. Його слід збільшити на понад %d байтів."
+#~ msgid ""
+#~ "Encoding normal character: The size of the buffer dest is to small, it "
+#~ "needs to be more than %d bytes bigger."
+#~ msgstr ""
+#~ "Кодування звичайного символу: розмір буфера призначення є надто малим. "
+#~ "Його слід збільшити на понад %d байтів."
 
 #~ msgid "Error(%d) closing key:  Software\\TigerVNC\\vncviewer"
 #~ msgstr "Помилка (%d) закриття ключа:  Software\\TigerVNC\\vncviewer"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,727 +7,1276 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.8.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2018-06-13 14:22+0000\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2018-07-04 14:52+0700\n"
 "Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
 "Language-Team: Vietnamese <translation-team-vi@lists.sourceforge.net>\n"
 "Language: vi\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Gtranslator 2.91.7\n"
 
-#: vncviewer/CConn.cxx:116
+#: vncviewer/CConn.cxx:103
 #, c-format
-msgid "connected to socket %s"
-msgstr "đã kết nối đến ổ cắm mạng %s"
+msgid "Connected to socket %s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:123
+#: vncviewer/CConn.cxx:110
 #, c-format
-msgid "connected to host %s port %d"
-msgstr "đã kết nối đến máy %s cổng %d"
+msgid "Connected to host %s port %d"
+msgstr ""
 
-#: vncviewer/CConn.cxx:184
+#: vncviewer/CConn.cxx:115
+#, c-format
+msgid ""
+"Failed to connect to \"%s\":\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "Tên máy tính: %.80s"
 
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "Máy: %.80s cổng: %d"
 
-#: vncviewer/CConn.cxx:194
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "Cỡ: %d x %d"
 
-#: vncviewer/CConn.cxx:202
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "Định dạng điểm ảnh: %s"
 
-#: vncviewer/CConn.cxx:209
-#, c-format
-msgid "(server default %s)"
-msgstr "(máy chủ mặc định %s)"
-
-#: vncviewer/CConn.cxx:214
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "Bộ mã đã yêu cầu: %s"
 
-#: vncviewer/CConn.cxx:219
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "Bảng mã dùng lần cuối: %s"
 
-#: vncviewer/CConn.cxx:224
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "Ước tính tốc độ đường dây: %d kbit/s"
 
-#: vncviewer/CConn.cxx:229
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "Phiên bản giao thức: %d.%d"
 
-#: vncviewer/CConn.cxx:234
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "Phương thức bảo mật: %s"
 
-#: vncviewer/CConn.cxx:358
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
+msgstr ""
+
+#: vncviewer/CConn.cxx:258
 #, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "SetDesktopSize gặp lỗi: %d"
+msgid "Authentication failed: %s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:428
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "SetColourMapEntries từ máy phục vụ không hợp lệ!"
+#: vncviewer/CConn.cxx:259
+#, c-format
+msgid ""
+"Failed to authenticate with the server. Reason given by the server:\n"
+"\n"
+"%s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:479
-msgid "Enabling continuous updates"
-msgstr "Đang bật cập nhật liên tục"
-
-#: vncviewer/CConn.cxx:556
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "Băng thông %d kbit/s - đổi thành chất lượng %d"
 
-#: vncviewer/CConn.cxx:578
+#: vncviewer/CConn.cxx:521
 #, c-format
-msgid "Throughput %d kbit/s - full color is now %s"
-msgstr "Băng thông %d kbit/s - màu đầy đủ giờ là %s"
+msgid "Throughput %d kbit/s - full color is now enabled"
+msgstr ""
 
-#: vncviewer/CConn.cxx:580
-msgid "disabled"
-msgstr "tắt"
-
-#: vncviewer/CConn.cxx:580
-msgid "enabled"
-msgstr "bật"
-
-#: vncviewer/CConn.cxx:590
+#: vncviewer/CConn.cxx:524
 #, c-format
-msgid "Using %s encoding"
-msgstr "Đang dùng bảng mã %s"
+msgid "Throughput %d kbit/s - full color is now disabled"
+msgstr ""
 
-#: vncviewer/CConn.cxx:637
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "Đang dùng định dạng điểm ảnh %s"
 
-#: vncviewer/DesktopWindow.cxx:122
+#: vncviewer/DesktopWindow.cxx:146
 msgid "Invalid geometry specified!"
 msgstr "Hình dạng đã cho không hợp lệ!"
 
-#: vncviewer/DesktopWindow.cxx:451
-msgid "Adjusting window size to avoid accidental full screen request"
-msgstr "Chỉnh cỡ cửa sổ để tránh yêu cầu toàm màn hình ngẫu nhiên"
+#: vncviewer/DesktopWindow.cxx:167
+msgid "Reducing window size to fit on current monitor"
+msgstr ""
 
-#: vncviewer/DesktopWindow.cxx:495
+#: vncviewer/DesktopWindow.cxx:681
+msgid "Adjusting window size to avoid accidental full-screen request"
+msgstr ""
+
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "Nhấn vào %s to open the context menu để mở trình đơn ngữ cảnh"
 
-#: vncviewer/DesktopWindow.cxx:794 vncviewer/DesktopWindow.cxx:802
-#: vncviewer/DesktopWindow.cxx:822
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "Gặp lỗi khi điều khiển bàn phím"
 
-#: vncviewer/DesktopWindow.cxx:896
-msgid "Failure grabbing mouse"
-msgstr "Gặp lỗi khi điều khiển chuột"
-
-#: vncviewer/DesktopWindow.cxx:1120
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
 msgstr "Bố cục màn hình đã tính toán không hợp lệ cho yêu cầu đổi cỡ!"
 
-#: vncviewer/OptionsDialog.cxx:57
-msgid "VNC Viewer: Connection Options"
-msgstr "Bộ xem VNC: Các tùy chọn kết nối"
-
-#: vncviewer/OptionsDialog.cxx:83 vncviewer/ServerDialog.cxx:91
-#: vncviewer/vncviewer.cxx:282
-msgid "Cancel"
-msgstr "Thôi"
-
-#: vncviewer/OptionsDialog.cxx:88 vncviewer/vncviewer.cxx:281
-msgid "OK"
-msgstr "Đồng ý"
-
-#: vncviewer/OptionsDialog.cxx:423
-msgid "Compression"
-msgstr "Nén"
-
-#: vncviewer/OptionsDialog.cxx:439
-msgid "Auto select"
-msgstr "Chọn tự động"
-
-#: vncviewer/OptionsDialog.cxx:451
-msgid "Preferred encoding"
-msgstr "Bảng mã ưa thích"
-
-#: vncviewer/OptionsDialog.cxx:499
-msgid "Color level"
-msgstr "Mức màu"
-
-#: vncviewer/OptionsDialog.cxx:510
-msgid "Full (all available colors)"
-msgstr "Đầy đủ (mọi màu sẵn có)"
-
-#: vncviewer/OptionsDialog.cxx:517
-msgid "Medium (256 colors)"
-msgstr "Trung bình (256 màu)"
-
-#: vncviewer/OptionsDialog.cxx:524
-msgid "Low (64 colors)"
-msgstr "Thấp (64 màu)"
-
-#: vncviewer/OptionsDialog.cxx:531
-msgid "Very low (8 colors)"
-msgstr "Rất thấp (8 màu)"
-
-#: vncviewer/OptionsDialog.cxx:548
-msgid "Custom compression level:"
-msgstr "Mức nén tự chọn:"
-
-#: vncviewer/OptionsDialog.cxx:554
-msgid "level (1=fast, 6=best [4-6 are rarely useful])"
-msgstr "mức độ (1=nhanh, 6=tốt nhất [4-6 là hữu dụng hơn cả])"
-
-#: vncviewer/OptionsDialog.cxx:561
-msgid "Allow JPEG compression:"
-msgstr "Cho phép nén JPEG:"
-
-#: vncviewer/OptionsDialog.cxx:567
-msgid "quality (0=poor, 9=best)"
-msgstr "Chất lượng (0=kém, 9=tốt nhất)"
-
-#: vncviewer/OptionsDialog.cxx:578
-msgid "Security"
-msgstr "Bảo mật"
-
-#: vncviewer/OptionsDialog.cxx:593
-msgid "Encryption"
-msgstr "Mã hóa"
-
-#: vncviewer/OptionsDialog.cxx:604 vncviewer/OptionsDialog.cxx:657
-#: vncviewer/OptionsDialog.cxx:737
-msgid "None"
-msgstr "Không có gì"
-
-#: vncviewer/OptionsDialog.cxx:610
-msgid "TLS with anonymous certificates"
-msgstr "TLS với chứng nhận nặc danh"
-
-#: vncviewer/OptionsDialog.cxx:616
-msgid "TLS with X509 certificates"
-msgstr "TLS với chứng nhận X509"
-
-#: vncviewer/OptionsDialog.cxx:623
-msgid "Path to X509 CA certificate"
-msgstr "Đường dẫn chứng nhận CA X509"
-
-#: vncviewer/OptionsDialog.cxx:630
-msgid "Path to X509 CRL file"
-msgstr "Đường dẫn đến tập tin CRL X509"
-
-#: vncviewer/OptionsDialog.cxx:646
-msgid "Authentication"
-msgstr "Xác thực"
-
-#: vncviewer/OptionsDialog.cxx:663
-msgid "Standard VNC (insecure without encryption)"
-msgstr "VNC tiêu chuẩn (không bảo mật, không mã hóa)"
-
-#: vncviewer/OptionsDialog.cxx:669
-msgid "Username and password (insecure without encryption)"
-msgstr "Tài khoản và mật khẩu (không bảo mật, không mã hóa)"
-
-#: vncviewer/OptionsDialog.cxx:688
-msgid "Input"
-msgstr "Đầu vào"
-
-#: vncviewer/OptionsDialog.cxx:696
-msgid "View only (ignore mouse and keyboard)"
-msgstr "Chỉ xem (không bắt chuột và bàn phím)"
-
-#: vncviewer/OptionsDialog.cxx:702
-msgid "Accept clipboard from server"
-msgstr "Chấp nhận clipboard từ máy chủ"
-
-#: vncviewer/OptionsDialog.cxx:710
-msgid "Also set primary selection"
-msgstr "Cũng đặt chọn chính"
-
-#: vncviewer/OptionsDialog.cxx:717
-msgid "Send clipboard to server"
-msgstr "Gửi clipboard đến máy chủ"
-
-#: vncviewer/OptionsDialog.cxx:725
-msgid "Send primary selection as clipboard"
-msgstr "Gửi chọn chính là clipboard"
-
-#: vncviewer/OptionsDialog.cxx:732
-msgid "Pass system keys directly to server (full screen)"
-msgstr "Gửi các phím hệ thống trực tiếp đến máy phục vụ (toàn màn hình)"
-
-#: vncviewer/OptionsDialog.cxx:735
-msgid "Menu key"
-msgstr "Phím trình đơn"
-
-#: vncviewer/OptionsDialog.cxx:751
-msgid "Screen"
-msgstr "Màn hình"
-
-#: vncviewer/OptionsDialog.cxx:759
-msgid "Resize remote session on connect"
-msgstr "Đổi cỡ phiên máy từ xa khi kết nối"
-
-#: vncviewer/OptionsDialog.cxx:772
-msgid "Resize remote session to the local window"
-msgstr "Đổi cỡ phiên thành cửa sổ nội bộ"
-
-#: vncviewer/OptionsDialog.cxx:778
-msgid "Full-screen mode"
-msgstr "Chế độ toàn màn hình"
-
-#: vncviewer/OptionsDialog.cxx:784
-msgid "Enable full-screen mode over all monitors"
-msgstr "Bật chế độ toàn màn hình qua tất cả các màn hình"
-
-#: vncviewer/OptionsDialog.cxx:793
-msgid "Misc."
-msgstr "Linh tinh"
-
-#: vncviewer/OptionsDialog.cxx:801
-msgid "Shared (don't disconnect other viewers)"
-msgstr "Đã chia sẻ (đừng ngắt kết nối các bộ xem khác)"
-
-#: vncviewer/OptionsDialog.cxx:807
-msgid "Show dot when no cursor"
-msgstr "Hiển thị chấm khi không có con trỏ"
-
-#: vncviewer/ServerDialog.cxx:42
-msgid "VNC Viewer: Connection Details"
-msgstr "Phần mềm xem VNC: Chi tiết kết nối"
-
-#: vncviewer/ServerDialog.cxx:49 vncviewer/ServerDialog.cxx:54
-msgid "VNC server:"
-msgstr "Máy phục vụ VNC:"
-
-#: vncviewer/ServerDialog.cxx:64
-msgid "Options..."
-msgstr "Tùy chọn…"
-
-#: vncviewer/ServerDialog.cxx:69
-msgid "Load..."
-msgstr "Tải…"
-
-#: vncviewer/ServerDialog.cxx:74
-msgid "Save As..."
-msgstr "Lưu thành…"
-
-#: vncviewer/ServerDialog.cxx:86
-msgid "About..."
-msgstr "Giới thiệu…"
-
-#: vncviewer/ServerDialog.cxx:96
-msgid "Connect"
-msgstr "Kết nối"
-
-#: vncviewer/ServerDialog.cxx:137 vncviewer/ServerDialog.cxx:171
-msgid "TigerVNC configuration (*.tigervnc)"
-msgstr "Cấu hình TigerVNC (*.tigervnc)"
-
-#: vncviewer/ServerDialog.cxx:138
-msgid "Select a TigerVNC configuration file"
-msgstr "Chọn một tập tin cấu hình TigerVNC"
-
-#: vncviewer/ServerDialog.cxx:172
-msgid "Save the TigerVNC configuration to file"
-msgstr "Lưu cấu hình TigerVNC vào tập tin"
-
-#: vncviewer/ServerDialog.cxx:197
-#, c-format
-msgid "%s already exists. Do you want to overwrite?"
-msgstr "%s đã sẵn có. Bạn có muốn ghi đè không?"
-
-#: vncviewer/ServerDialog.cxx:198 vncviewer/vncviewer.cxx:279
-msgid "No"
-msgstr "Không"
-
-#: vncviewer/ServerDialog.cxx:198
-msgid "Overwrite"
-msgstr "Ghi đè"
-
-#: vncviewer/UserDialog.cxx:85
-msgid "Opening password file failed"
-msgstr "Gặp lỗi khi mở tập tin mật khẩu"
-
-#: vncviewer/UserDialog.cxx:105
-msgid "VNC authentication"
-msgstr "Xác thực VNC"
-
-#: vncviewer/UserDialog.cxx:112
-msgid "This connection is secure"
-msgstr "Kết nối này là an toàn"
-
-#: vncviewer/UserDialog.cxx:116
-msgid "This connection is not secure"
-msgstr "Kết nối này là không an toàn"
-
-#: vncviewer/UserDialog.cxx:133
-msgid "Username:"
-msgstr "Tài khoản:"
-
-#: vncviewer/UserDialog.cxx:140
-msgid "Password:"
-msgstr "Mật khẩu:"
-
-#: vncviewer/UserDialog.cxx:179
-msgid "Authentication cancelled"
-msgstr "Xác thực bị hủy bỏ"
-
-#: vncviewer/Viewport.cxx:377
-#, c-format
-msgid "Failed to update keyboard LED state: %lu"
-msgstr "Gặp lỗi khi cập nhật trạng thái LED bàn phím: %lu"
-
-#: vncviewer/Viewport.cxx:383 vncviewer/Viewport.cxx:389
-#, c-format
-msgid "Failed to update keyboard LED state: %d"
-msgstr "Gặp lỗi khi cập nhật trạng thái LED bàn phím: %d"
-
-#: vncviewer/Viewport.cxx:419
-msgid "Failed to update keyboard LED state"
-msgstr "Gặp lỗi khi cập nhật trạng thái LED bàn phím"
-
-#: vncviewer/Viewport.cxx:446 vncviewer/Viewport.cxx:454
-#: vncviewer/Viewport.cxx:471
-#, c-format
-msgid "Failed to get keyboard LED state: %d"
-msgstr "Gặp lỗi khi lấy trạng thái LED bàn phím: %d"
-
-#: vncviewer/Viewport.cxx:817
-msgid "No key code specified on key press"
-msgstr "Không có mã mô tả cho phím bấm"
-
-#: vncviewer/Viewport.cxx:959
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
+msgid "Invalid state for 3 button emulation"
+msgstr ""
+
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "Không có mã quét cho phím ảo mở rộng 0x%02x"
 
-#: vncviewer/Viewport.cxx:961
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "Không có mã quét cho phím ảo 0x%02x"
 
-#: vncviewer/Viewport.cxx:967
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "Mã quét không hợp lệ 0x%02x"
 
-#: vncviewer/Viewport.cxx:997
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "Không có ký hiệu cho phím ảo mở rộng 0x%02x"
 
-#: vncviewer/Viewport.cxx:999
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "Không có ký hiệu cho phím ảo 0x%02x"
 
-#: vncviewer/Viewport.cxx:1086
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
-msgid "No symbol for key code 0x%02x (in the current state)"
-msgstr "Không có ký hiệu cho mã phím 0x%02x (trong trạng thái hiện tại)"
+msgid "Failed to update keyboard LED state: %lu"
+msgstr "Gặp lỗi khi cập nhật trạng thái LED bàn phím: %lu"
 
-#: vncviewer/Viewport.cxx:1119
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "Không có ký hiệu cho mã phím %d (trong trạng thái hiện tại)"
 
-#: vncviewer/Viewport.cxx:1170
-msgctxt "ContextMenu|"
-msgid "E&xit viewer"
-msgstr "T&hoát khỏi bộ xem"
+#: vncviewer/KeyboardX11.cxx:148
+#, c-format
+msgid "Failed to get keyboard LED state: %d"
+msgstr "Gặp lỗi khi lấy trạng thái LED bàn phím: %d"
 
-#: vncviewer/Viewport.cxx:1173
+#: vncviewer/KeyboardX11.cxx:193
+msgid "Failed to update keyboard LED state"
+msgstr "Gặp lỗi khi cập nhật trạng thái LED bàn phím"
+
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
+msgid "Failed to get system monitor configuration"
+msgstr ""
+
+#: vncviewer/MonitorIndicesParameter.cxx:73
+#, c-format
+msgid "Monitor index %d does not exist"
+msgstr ""
+
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
+msgid "TigerVNC options"
+msgstr ""
+
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
+msgid "Cancel"
+msgstr "Thôi"
+
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
+msgid "OK"
+msgstr "Đồng ý"
+
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
+msgid "Compression"
+msgstr "Nén"
+
+#: vncviewer/OptionsDialog.cxx:524
+msgid "Auto select"
+msgstr "Chọn tự động"
+
+#: vncviewer/OptionsDialog.cxx:536
+msgid "Preferred encoding"
+msgstr "Bảng mã ưa thích"
+
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
+msgid "Color level"
+msgstr "Mức màu"
+
+#: vncviewer/OptionsDialog.cxx:611
+msgid "Full"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:619
+msgid "Medium"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:627
+msgid "Low"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:635
+msgid "Very low"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:658
+msgid "Custom compression level:"
+msgstr "Mức nén tự chọn:"
+
+#: vncviewer/OptionsDialog.cxx:666
+msgid "level (0=fast, 9=best)"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:674
+msgid "Allow JPEG compression:"
+msgstr "Cho phép nén JPEG:"
+
+#: vncviewer/OptionsDialog.cxx:682
+msgid "quality (0=poor, 9=best)"
+msgstr "Chất lượng (0=kém, 9=tốt nhất)"
+
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
+msgid "Security"
+msgstr "Bảo mật"
+
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
+msgid "Encryption"
+msgstr "Mã hóa"
+
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
+msgid "None"
+msgstr "Không có gì"
+
+#: vncviewer/OptionsDialog.cxx:730
+msgid "TLS with anonymous certificates"
+msgstr "TLS với chứng nhận nặc danh"
+
+#: vncviewer/OptionsDialog.cxx:737
+msgid "TLS with X509 certificates"
+msgstr "TLS với chứng nhận X509"
+
+#: vncviewer/OptionsDialog.cxx:745
+msgid "Path to X509 CA certificate"
+msgstr "Đường dẫn chứng nhận CA X509"
+
+#: vncviewer/OptionsDialog.cxx:753
+msgid "Path to X509 CRL file"
+msgstr "Đường dẫn đến tập tin CRL X509"
+
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
+msgid "Authentication"
+msgstr "Xác thực"
+
+#: vncviewer/OptionsDialog.cxx:802
+msgid "Standard VNC (insecure without encryption)"
+msgstr "VNC tiêu chuẩn (không bảo mật, không mã hóa)"
+
+#: vncviewer/OptionsDialog.cxx:809
+msgid "Username and password (insecure without encryption)"
+msgstr "Tài khoản và mật khẩu (không bảo mật, không mã hóa)"
+
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
+msgid "Input"
+msgstr "Đầu vào"
+
+#: vncviewer/OptionsDialog.cxx:852
+msgid "View only (ignore mouse and keyboard)"
+msgstr "Chỉ xem (không bắt chuột và bàn phím)"
+
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
+msgid "Mouse"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:873
+msgid "Emulate middle mouse button"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:880
+msgid "Show local cursor when not provided by server"
+msgstr ""
+
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
+msgid "Cursor type"
+msgstr ""
+
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
+msgid "Dot"
+msgstr ""
+
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
+msgid "System"
+msgstr ""
+
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
+msgid "Keyboard"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:925
+msgid "Pass system keys directly to server (full screen)"
+msgstr "Gửi các phím hệ thống trực tiếp đến máy phục vụ (toàn màn hình)"
+
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
+msgid "Menu key"
+msgstr "Phím trình đơn"
+
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
+msgid "Clipboard"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:968
+msgid "Accept clipboard from server"
+msgstr "Chấp nhận clipboard từ máy chủ"
+
+#: vncviewer/OptionsDialog.cxx:977
+msgid "Also set primary selection"
+msgstr "Cũng đặt chọn chính"
+
+#: vncviewer/OptionsDialog.cxx:985
+msgid "Send clipboard to server"
+msgstr "Gửi clipboard đến máy chủ"
+
+#: vncviewer/OptionsDialog.cxx:994
+msgid "Send primary selection as clipboard"
+msgstr "Gửi chọn chính là clipboard"
+
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
+msgid "Display"
+msgstr ""
+
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
+msgid "Display mode"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1045
+msgid "Windowed"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1054
+msgid "Full screen on current monitor"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1063
+msgid "Full screen on all monitors"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1072
+msgid "Full screen on selected monitor(s)"
+msgstr ""
+
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
+msgid "Miscellaneous"
+msgstr ""
+
+#: vncviewer/OptionsDialog.cxx:1111
+msgid "Shared (don't disconnect other viewers)"
+msgstr "Đã chia sẻ (đừng ngắt kết nối các bộ xem khác)"
+
+#: vncviewer/OptionsDialog.cxx:1118
+msgid "Ask to reconnect on connection errors"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:73
+msgid "VNC server:"
+msgstr "Máy phục vụ VNC:"
+
+#: vncviewer/ServerDialog.cxx:80
+msgid "Options..."
+msgstr "Tùy chọn…"
+
+#: vncviewer/ServerDialog.cxx:84
+msgid "Load..."
+msgstr "Tải…"
+
+#: vncviewer/ServerDialog.cxx:88
+msgid "Save as..."
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:102
+msgid "About..."
+msgstr "Giới thiệu…"
+
+#: vncviewer/ServerDialog.cxx:111
+msgid "Connect"
+msgstr "Kết nối"
+
+#: vncviewer/ServerDialog.cxx:147
+#, c-format
+msgid ""
+"Unable to load the server history:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:176 vncviewer/ServerDialog.cxx:216
+msgid "TigerVNC configuration (*.tigervnc)"
+msgstr "Cấu hình TigerVNC (*.tigervnc)"
+
+#: vncviewer/ServerDialog.cxx:177
+msgid "Select a TigerVNC configuration file"
+msgstr "Chọn một tập tin cấu hình TigerVNC"
+
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
+#, c-format
+msgid ""
+"Unable to load the specified configuration file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:217
+msgid "Save the TigerVNC configuration to file"
+msgstr "Lưu cấu hình TigerVNC vào tập tin"
+
+#: vncviewer/ServerDialog.cxx:243
+#, c-format
+msgid "%s already exists. Do you want to overwrite?"
+msgstr "%s đã sẵn có. Bạn có muốn ghi đè không?"
+
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
+msgid "No"
+msgstr "Không"
+
+#: vncviewer/ServerDialog.cxx:244
+msgid "Overwrite"
+msgstr "Ghi đè"
+
+#: vncviewer/ServerDialog.cxx:260
+#, c-format
+msgid ""
+"Unable to save the specified configuration file:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:294
+#, c-format
+msgid ""
+"Unable to save the default configuration:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:306
+#, c-format
+msgid ""
+"Unable to save the server history:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
+msgid "Could not determine VNC state directory path"
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
+#, c-format
+msgid "Could not open \"%s\""
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
+#, c-format
+msgid "Failed to read line %d in file \"%s\""
+msgstr ""
+
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
+msgid "Line too long"
+msgstr "Dòng quá dài"
+
+#: vncviewer/UserDialog.cxx:130
+msgid "Opening password file failed"
+msgstr "Gặp lỗi khi mở tập tin mật khẩu"
+
+#: vncviewer/UserDialog.cxx:150
+msgid "VNC authentication"
+msgstr "Xác thực VNC"
+
+#: vncviewer/UserDialog.cxx:157
+msgid "This connection is secure"
+msgstr "Kết nối này là an toàn"
+
+#: vncviewer/UserDialog.cxx:161
+msgid "This connection is not secure"
+msgstr "Kết nối này là không an toàn"
+
+#: vncviewer/UserDialog.cxx:183
+msgid "Username:"
+msgstr "Tài khoản:"
+
+#: vncviewer/UserDialog.cxx:196
+msgid "Password:"
+msgstr "Mật khẩu:"
+
+#: vncviewer/UserDialog.cxx:204
+msgid "Keep password for reconnect"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:749
+msgctxt "ContextMenu|"
+msgid "Disconn&ect"
+msgstr ""
+
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "T&oàn màn hình"
 
-#: vncviewer/Viewport.cxx:1176
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "Thu &nhỏ"
 
-#: vncviewer/Viewport.cxx:1178
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "Đổi cỡ Cửa &sổ sang phiên"
 
-#: vncviewer/Viewport.cxx:1183
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:1186
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:1192
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "Gửi %s"
 
-#: vncviewer/Viewport.cxx:1198
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "Gửi Ctrl-Alt-&Del"
 
-#: vncviewer/Viewport.cxx:1201
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "&Làm mới màn hình"
 
-#: vncviewer/Viewport.cxx:1204
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "Tù&y chọn…"
 
-#: vncviewer/Viewport.cxx:1206
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "Thông t&in về kết nối…"
 
-#: vncviewer/Viewport.cxx:1208
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "Giới thiệu Bộ xem &TigerVNC…"
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:1211
-msgctxt "ContextMenu|"
-msgid "Dismiss &menu"
-msgstr "Thải bỏ &Trình đơn"
-
-#: vncviewer/Viewport.cxx:1300
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "Thông tin kết nối VNC"
 
-#: vncviewer/parameters.cxx:279 vncviewer/parameters.cxx:313
-#, c-format
-msgid "The name of the parameter %s was too large to write to the registry"
-msgstr "Tên của tham số %s là quá lớn để ghi vào đăng ký"
-
-#: vncviewer/parameters.cxx:285 vncviewer/parameters.cxx:292
-#, c-format
-msgid "The parameter %s was too large to write to the registry"
-msgstr "Tham số %s là quá lớn để ghi vào đăng ký"
-
-#: vncviewer/parameters.cxx:298 vncviewer/parameters.cxx:319
-#, c-format
-msgid "Failed to write parameter %s of type %s to the registry: %ld"
-msgstr "Gặp lỗi khi ghi tham số %s của kiểu %s vào sổ đăng ký: %ld"
-
-#: vncviewer/parameters.cxx:334 vncviewer/parameters.cxx:373
-#, c-format
-msgid "The name of the parameter %s was too large to read from the registry"
-msgstr "Tên của tham số %s là quá lớn để đọc từ sổ đăng ký"
-
-#: vncviewer/parameters.cxx:343 vncviewer/parameters.cxx:382
-#, c-format
-msgid "Failed to read parameter %s from the registry: %ld"
-msgstr "Gặp lỗi khi đọc tham số %s từ sổ đăng ký: %ld"
-
-#: vncviewer/parameters.cxx:352
-#, c-format
-msgid "The parameter %s was too large to read from the registry"
-msgstr "Tham số %s là quá lớn để đọc từ sổ đăng ký"
-
-#: vncviewer/parameters.cxx:402
-#, c-format
-msgid "Failed to create registry key: %ld"
-msgstr "Gặp lỗi khi tạo khóa đăng ký: %ld"
-
-#: vncviewer/parameters.cxx:416 vncviewer/parameters.cxx:465
-#: vncviewer/parameters.cxx:527 vncviewer/parameters.cxx:660
-#, c-format
-msgid "Unknown parameter type for parameter %s"
-msgstr "Không hiểu kiểu tham số cho đối số %s"
-
-#: vncviewer/parameters.cxx:423 vncviewer/parameters.cxx:472
-#, c-format
-msgid "Failed to close registry key: %ld"
-msgstr "Gặp lỗi khi đóng khóa đăng ký: %ld"
-
-#: vncviewer/parameters.cxx:439
-#, c-format
-msgid "Failed to open registry key: %ld"
-msgstr "Gặp lỗi khi mở khóa đăng ký: %ld"
-
-#: vncviewer/parameters.cxx:496
-msgid "Failed to write configuration file, can't obtain home directory path."
-msgstr "Gặp lỗi khi ghi tập tin cấu hình, không thể lấy đường dẫn thư mục riêng."
-
-#: vncviewer/parameters.cxx:509
-#, c-format
-msgid "Failed to write configuration file, can't open %s: %s"
-msgstr "Gặp lỗi khi ghi tập tin cấu hình, không thể mở %s: %s"
-
-#: vncviewer/parameters.cxx:554
-msgid "Failed to read configuration file, can't obtain home directory path."
-msgstr "Gặp lỗi khi đọc tập tin cấu hình, không thể lấy đường dẫn thư mục riêng."
-
-#: vncviewer/parameters.cxx:567
-#, c-format
-msgid "Failed to read configuration file, can't open %s: %s"
-msgstr "Gặp lỗi khi đọc tập tin cấu hình, không thể mở %s: %s"
-
-#: vncviewer/parameters.cxx:580 vncviewer/parameters.cxx:585
-#: vncviewer/parameters.cxx:610 vncviewer/parameters.cxx:623
-#: vncviewer/parameters.cxx:639
-#, c-format
-msgid "Failed to read line %d in file %s: %s"
-msgstr "Gặp lỗi khi đọc dòng %d trong tập tin %s: %s"
-
-#: vncviewer/parameters.cxx:586
-msgid "Line too long"
-msgstr "Dòng quá dài"
-
-#: vncviewer/parameters.cxx:593
-#, c-format
-msgid "Configuration file %s is in an invalid format"
-msgstr "Tập tin cấu hình %s ở định dạng không hợp lệ"
-
-#: vncviewer/parameters.cxx:611
-msgid "Invalid format"
-msgstr "Định dạng không hợp lệ"
-
-#: vncviewer/parameters.cxx:624 vncviewer/parameters.cxx:640
-msgid "Invalid format or too large value"
-msgstr "Định dạng không hợp lệ hay giá trị quá lớn"
-
-#: vncviewer/parameters.cxx:667
-#, c-format
-msgid "Unknown parameter %s on line %d in file %s"
-msgstr "Không hiểu tham số %s trên dòng %d ở tập tin %s"
-
-#: vncviewer/vncviewer.cxx:100
-#, c-format
-msgid ""
-"TigerVNC Viewer %d-bit v%s\n"
-"Built on: %s\n"
-"Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
-"See http://www.tigervnc.org for information on TigerVNC."
+#: vncviewer/Win32TouchHandler.cxx:49
+msgid "Window is registered for touch instead of gestures"
 msgstr ""
-"TigerVNC Viewer %d-bít v%s\n"
-"Biên dịch vào: %s\n"
-"Copyright (C) 1999-%d Nhóm TigerVNC và nhiều người khác (xem README.rst)\n"
-"Truy cập http://www.tigervnc.org để biết thêm thông tin về TigerVNC."
 
-#: vncviewer/vncviewer.cxx:127
-msgid "About TigerVNC Viewer"
-msgstr "Giới thiệu về bộ xem TigerVNC"
-
-#: vncviewer/vncviewer.cxx:140
-msgid "Internal FLTK error. Exiting."
-msgstr "Lỗi bên trong FLTK. Nên thoát."
-
-#: vncviewer/vncviewer.cxx:158 vncviewer/vncviewer.cxx:170
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "Gặp lỗi khi khởi chạy bộ xem TigerVNC mới: %s"
+msgid "Failed to set gesture configuration (error 0x%x)"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:179
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC Viewer will now exit."
-msgstr "Đã nhận được tín hiệu kết thúc %d. Bộ xem TigerVNC bây giờ sẽ thoát."
+msgid "Failed to get gesture information (error 0x%x)"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:271 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC Viewer"
-msgstr "Bộ xem TigerVNC"
-
-#: vncviewer/vncviewer.cxx:280
-msgid "Yes"
-msgstr "Có"
-
-#: vncviewer/vncviewer.cxx:283
-msgid "Close"
-msgstr "Đóng"
-
-#: vncviewer/vncviewer.cxx:288
-msgid "About"
-msgstr "Giới thiệu"
-
-#: vncviewer/vncviewer.cxx:291
-msgid "Hide"
-msgstr "Ẩn"
-
-#: vncviewer/vncviewer.cxx:294
-msgid "Quit"
-msgstr "Thoát"
-
-#: vncviewer/vncviewer.cxx:298
-msgid "Services"
-msgstr "Dịch vụ"
-
-#: vncviewer/vncviewer.cxx:299
-msgid "Hide Others"
-msgstr "Ẩn các cái khác"
-
-#: vncviewer/vncviewer.cxx:300
-msgid "Show All"
-msgstr "Hiện tất cả"
-
-#: vncviewer/vncviewer.cxx:309
-msgctxt "SysMenu|"
-msgid "&File"
-msgstr "&Chính"
-
-#: vncviewer/vncviewer.cxx:312
-msgctxt "SysMenu|File|"
-msgid "&New Connection"
-msgstr "Kết nối &mới"
-
-#: vncviewer/vncviewer.cxx:324
-msgid "Could not create VNC home directory: can't obtain home directory path."
-msgstr "Không thể tạo thư mục cá nhân cho VNC: không thể lấy đường dẫn thư mục cá nhân."
-
-#: vncviewer/vncviewer.cxx:329
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
-msgid "Could not create VNC home directory: %s."
-msgstr "Không thể tạo thư mục cá nhân cho VNC: %s."
+msgid "Invalid mouse button %d, must be a number between 1 and 7."
+msgstr ""
 
-#. TRANSLATORS: "Parameters" are command line arguments, or settings
-#. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:581 vncviewer/vncviewer.cxx:583
-msgid "Parameters -listen and -via are incompatible"
-msgstr "Các tham số -listen và -via xung khắc nhau"
-
-#: vncviewer/vncviewer.cxx:598
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
-msgid "Listening on port %d"
-msgstr "Đang nghe trên cổng %d"
+msgid "Unhandled key 0x%x - can't generate keyboard event."
+msgstr ""
 
-#: vncviewer/vncviewer.desktop.in.in:4
-msgid "Remote Desktop Viewer"
-msgstr "Trình xem màn hình từ xa"
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
+#, c-format
+msgid "Unable to get X Input 2 event mask for window 0x%08lx"
+msgstr ""
 
+#: vncviewer/XInputTouchHandler.cxx:105
+#, c-format
+msgid "Window 0x%08lx has no X Input 2 event mask"
+msgstr ""
+
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
+#, c-format
+msgid "Window 0x%08lx has more than one X Input 2 event mask"
+msgstr ""
+
+#: vncviewer/XInputTouchHandler.cxx:144
+#, c-format
+msgid "Failure grabbing device %i"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
 msgid "Connect to VNC server and display remote desktop"
 msgstr "Kết nối đến máy phục vụ VNC và hiển thị màn hình từ xa"
 
-#: vncviewer/vncviewer.desktop.in.in:7
-msgid "tigervnc"
-msgstr "tigervnc"
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
+
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
+
+#. developer_name tag deprecated with Appstream 1.0
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
+msgid "The TigerVNC team"
+msgstr ""
+
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
+msgid "The name of the parameter is too large"
+msgstr ""
+
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
+msgid "The parameter is too large"
+msgstr ""
+
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
+msgid "Invalid format or too large value"
+msgstr "Định dạng không hợp lệ hay giá trị quá lớn"
+
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
+msgid "Failed to create registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
+msgid "Failed to close registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
+#, c-format
+msgid "Failed to save \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
+#, c-format
+msgid "Failed to remove \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
+msgid "Failed to open registry key"
+msgstr ""
+
+#: vncviewer/parameters.cxx:635
+#, c-format
+msgid "Failed to read server history entry %d: %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
+#, c-format
+msgid "Failed to read parameter \"%s\": %s"
+msgstr ""
+
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
+msgid "Could not determine VNC config directory path"
+msgstr ""
+
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
+msgid "Could not encode parameter"
+msgstr ""
+
+#: vncviewer/parameters.cxx:872
+#, c-format
+msgid "Configuration file %s is in an invalid format"
+msgstr "Tập tin cấu hình %s ở định dạng không hợp lệ"
+
+#: vncviewer/parameters.cxx:895
+msgid "Invalid format"
+msgstr "Định dạng không hợp lệ"
+
+#: vncviewer/parameters.cxx:939
+msgid "Unknown parameter"
+msgstr ""
+
+#: vncviewer/touch.cxx:75
+#, c-format
+msgid "Got message (0x%x) for an unhandled window"
+msgstr ""
+
+#: vncviewer/touch.cxx:138 vncviewer/touch.cxx:160
+#, c-format
+msgid "Invalid window 0x%08lx specified for pointer grab"
+msgstr ""
+
+#: vncviewer/touch.cxx:183 vncviewer/touch.cxx:184
+#, c-format
+msgid "Failed to create touch handler: %s"
+msgstr ""
+
+#: vncviewer/touch.cxx:188
+#, c-format
+msgid "Couldn't attach event handler to window (error 0x%x)"
+msgstr ""
+
+#: vncviewer/touch.cxx:215
+msgid "Failed to get event data for X Input event"
+msgstr ""
+
+#: vncviewer/touch.cxx:228
+msgid "X Input event for unknown window"
+msgstr ""
+
+#: vncviewer/touch.cxx:254
+msgid "X Input extension not available."
+msgstr ""
+
+#: vncviewer/touch.cxx:261
+msgid "X Input 2 (or newer) is not available."
+msgstr ""
+
+#: vncviewer/touch.cxx:266
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:103
+#, c-format
+msgid ""
+"TigerVNC v%s\n"
+"Built on: %s\n"
+"Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+"See https://www.tigervnc.org for information on TigerVNC."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:157
+#, c-format
+msgid ""
+"An unexpected error occurred when communicating with the server:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:194
+msgid "Internal FLTK error. Exiting."
+msgstr "Lỗi bên trong FLTK. Nên thoát."
+
+#: vncviewer/vncviewer.cxx:213
+#, c-format
+msgid ""
+"%s\n"
+"\n"
+"Attempt to reconnect?"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
+#, c-format
+msgid "Error starting new connection: %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:265
+#, c-format
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:394
+msgid "Yes"
+msgstr "Có"
+
+#: vncviewer/vncviewer.cxx:397
+msgid "Close"
+msgstr "Đóng"
+
+#: vncviewer/vncviewer.cxx:402
+msgid "About"
+msgstr "Giới thiệu"
+
+#: vncviewer/vncviewer.cxx:405
+msgid "Hide"
+msgstr "Ẩn"
+
+#: vncviewer/vncviewer.cxx:408
+msgid "Quit"
+msgstr "Thoát"
+
+#: vncviewer/vncviewer.cxx:412
+msgid "Services"
+msgstr "Dịch vụ"
+
+#: vncviewer/vncviewer.cxx:413
+msgid "Hide others"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:414
+msgid "Show all"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:423
+msgctxt "SysMenu|"
+msgid "&File"
+msgstr "&Chính"
+
+#: vncviewer/vncviewer.cxx:426
+msgctxt "SysMenu|File|"
+msgid "&New Connection"
+msgstr "Kết nối &mới"
+
+#: vncviewer/vncviewer.cxx:449
+#, c-format
+msgid ""
+"\n"
+"Usage: %s [parameters] [host][:displayNum]\n"
+"       %s [parameters] [host][::port]\n"
+"       %s [parameters] [unix socket]\n"
+"       %s [parameters] -listen [port]\n"
+"       %s [parameters] [.tigervnc file]\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:464
+#, c-format
+msgid ""
+"\n"
+"Options:\n"
+"\n"
+"  -display Xdisplay  - Specifies the X display for the viewer window\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
+"                       man page for details.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:471
+#, c-format
+msgid ""
+"\n"
+"Parameters can be turned on with -<param> or off with -<param>=0\n"
+"Parameters which take a value can be specified as -<param> <value>\n"
+"Other valid forms are <param>=<value> -<param>=<value> --<param>=<value>\n"
+"Parameter names are case-insensitive.  The parameters are:\n"
+"\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:556
+#, c-format
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:561
+#, c-format
+msgid "Could not create VNC config directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:567
+msgid "Could not determine VNC data directory path"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:573
+#, c-format
+msgid "Could not create VNC data directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:585
+#, c-format
+msgid "Could not create VNC state directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:704
+#, c-format
+msgid "%s: Unrecognized option '%s'\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
+#, c-format
+msgid "See '%s --help' for more information.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:713
+#, c-format
+msgid "%s: Extra argument '%s'\n"
+msgstr ""
+
+#. TRANSLATORS: "Parameters" are command line arguments, or settings
+#. from a file or the Windows registry.
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
+msgid "Parameters -listen and -via are incompatible"
+msgstr "Các tham số -listen và -via xung khắc nhau"
+
+#: vncviewer/vncviewer.cxx:764
+msgid "Unable to listen for incoming connections"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:766
+#, c-format
+msgid "Listening on port %d"
+msgstr "Đang nghe trên cổng %d"
+
+#: vncviewer/vncviewer.cxx:795
+#, c-format
+msgid ""
+"Failure waiting for incoming VNC connection:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:816
+#, c-format
+msgid ""
+"Failure setting up encrypted tunnel:\n"
+"\n"
+"%s"
+msgstr ""
+
+#: vncviewer/vncviewer.desktop.in.in:4
+msgid "Remote desktop viewer"
+msgstr ""
+
+#, c-format
+#~ msgid "connected to socket %s"
+#~ msgstr "đã kết nối đến ổ cắm mạng %s"
+
+#, c-format
+#~ msgid "connected to host %s port %d"
+#~ msgstr "đã kết nối đến máy %s cổng %d"
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "(máy chủ mặc định %s)"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "SetDesktopSize gặp lỗi: %d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "SetColourMapEntries từ máy phục vụ không hợp lệ!"
+
+#~ msgid "Enabling continuous updates"
+#~ msgstr "Đang bật cập nhật liên tục"
+
+#, c-format
+#~ msgid "Throughput %d kbit/s - full color is now %s"
+#~ msgstr "Băng thông %d kbit/s - màu đầy đủ giờ là %s"
+
+#~ msgid "disabled"
+#~ msgstr "tắt"
+
+#~ msgid "enabled"
+#~ msgstr "bật"
+
+#, c-format
+#~ msgid "Using %s encoding"
+#~ msgstr "Đang dùng bảng mã %s"
+
+#~ msgid "Adjusting window size to avoid accidental full screen request"
+#~ msgstr "Chỉnh cỡ cửa sổ để tránh yêu cầu toàm màn hình ngẫu nhiên"
+
+#~ msgid "Failure grabbing mouse"
+#~ msgstr "Gặp lỗi khi điều khiển chuột"
+
+#~ msgid "VNC Viewer: Connection Options"
+#~ msgstr "Bộ xem VNC: Các tùy chọn kết nối"
+
+#~ msgid "Full (all available colors)"
+#~ msgstr "Đầy đủ (mọi màu sẵn có)"
+
+#~ msgid "Medium (256 colors)"
+#~ msgstr "Trung bình (256 màu)"
+
+#~ msgid "Low (64 colors)"
+#~ msgstr "Thấp (64 màu)"
+
+#~ msgid "Very low (8 colors)"
+#~ msgstr "Rất thấp (8 màu)"
+
+#~ msgid "level (1=fast, 6=best [4-6 are rarely useful])"
+#~ msgstr "mức độ (1=nhanh, 6=tốt nhất [4-6 là hữu dụng hơn cả])"
+
+#~ msgid "Screen"
+#~ msgstr "Màn hình"
+
+#~ msgid "Resize remote session on connect"
+#~ msgstr "Đổi cỡ phiên máy từ xa khi kết nối"
+
+#~ msgid "Resize remote session to the local window"
+#~ msgstr "Đổi cỡ phiên thành cửa sổ nội bộ"
+
+#~ msgid "Full-screen mode"
+#~ msgstr "Chế độ toàn màn hình"
+
+#~ msgid "Enable full-screen mode over all monitors"
+#~ msgstr "Bật chế độ toàn màn hình qua tất cả các màn hình"
+
+#~ msgid "Misc."
+#~ msgstr "Linh tinh"
+
+#~ msgid "Show dot when no cursor"
+#~ msgstr "Hiển thị chấm khi không có con trỏ"
+
+#~ msgid "VNC Viewer: Connection Details"
+#~ msgstr "Phần mềm xem VNC: Chi tiết kết nối"
+
+#~ msgid "Save As..."
+#~ msgstr "Lưu thành…"
+
+#~ msgid "Authentication cancelled"
+#~ msgstr "Xác thực bị hủy bỏ"
+
+#, c-format
+#~ msgid "Failed to update keyboard LED state: %d"
+#~ msgstr "Gặp lỗi khi cập nhật trạng thái LED bàn phím: %d"
+
+#~ msgid "No key code specified on key press"
+#~ msgstr "Không có mã mô tả cho phím bấm"
+
+#, c-format
+#~ msgid "No symbol for key code 0x%02x (in the current state)"
+#~ msgstr "Không có ký hiệu cho mã phím 0x%02x (trong trạng thái hiện tại)"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "E&xit viewer"
+#~ msgstr "T&hoát khỏi bộ xem"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "Giới thiệu Bộ xem &TigerVNC…"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "Dismiss &menu"
+#~ msgstr "Thải bỏ &Trình đơn"
+
+#, c-format
+#~ msgid "The name of the parameter %s was too large to write to the registry"
+#~ msgstr "Tên của tham số %s là quá lớn để ghi vào đăng ký"
+
+#, c-format
+#~ msgid "The parameter %s was too large to write to the registry"
+#~ msgstr "Tham số %s là quá lớn để ghi vào đăng ký"
+
+#, c-format
+#~ msgid "Failed to write parameter %s of type %s to the registry: %ld"
+#~ msgstr "Gặp lỗi khi ghi tham số %s của kiểu %s vào sổ đăng ký: %ld"
+
+#, c-format
+#~ msgid "The name of the parameter %s was too large to read from the registry"
+#~ msgstr "Tên của tham số %s là quá lớn để đọc từ sổ đăng ký"
+
+#, c-format
+#~ msgid "Failed to read parameter %s from the registry: %ld"
+#~ msgstr "Gặp lỗi khi đọc tham số %s từ sổ đăng ký: %ld"
+
+#, c-format
+#~ msgid "The parameter %s was too large to read from the registry"
+#~ msgstr "Tham số %s là quá lớn để đọc từ sổ đăng ký"
+
+#, c-format
+#~ msgid "Failed to create registry key: %ld"
+#~ msgstr "Gặp lỗi khi tạo khóa đăng ký: %ld"
+
+#, c-format
+#~ msgid "Unknown parameter type for parameter %s"
+#~ msgstr "Không hiểu kiểu tham số cho đối số %s"
+
+#, c-format
+#~ msgid "Failed to close registry key: %ld"
+#~ msgstr "Gặp lỗi khi đóng khóa đăng ký: %ld"
+
+#, c-format
+#~ msgid "Failed to open registry key: %ld"
+#~ msgstr "Gặp lỗi khi mở khóa đăng ký: %ld"
+
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Gặp lỗi khi ghi tập tin cấu hình, không thể lấy đường dẫn thư mục riêng."
+
+#, c-format
+#~ msgid "Failed to write configuration file, can't open %s: %s"
+#~ msgstr "Gặp lỗi khi ghi tập tin cấu hình, không thể mở %s: %s"
+
+#~ msgid "Failed to read configuration file, can't obtain home directory path."
+#~ msgstr ""
+#~ "Gặp lỗi khi đọc tập tin cấu hình, không thể lấy đường dẫn thư mục riêng."
+
+#, c-format
+#~ msgid "Failed to read configuration file, can't open %s: %s"
+#~ msgstr "Gặp lỗi khi đọc tập tin cấu hình, không thể mở %s: %s"
+
+#, c-format
+#~ msgid "Failed to read line %d in file %s: %s"
+#~ msgstr "Gặp lỗi khi đọc dòng %d trong tập tin %s: %s"
+
+#, c-format
+#~ msgid "Unknown parameter %s on line %d in file %s"
+#~ msgstr "Không hiểu tham số %s trên dòng %d ở tập tin %s"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC Viewer %d-bit v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+#~ "See http://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "TigerVNC Viewer %d-bít v%s\n"
+#~ "Biên dịch vào: %s\n"
+#~ "Copyright (C) 1999-%d Nhóm TigerVNC và nhiều người khác (xem README.rst)\n"
+#~ "Truy cập http://www.tigervnc.org để biết thêm thông tin về TigerVNC."
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "Giới thiệu về bộ xem TigerVNC"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "Gặp lỗi khi khởi chạy bộ xem TigerVNC mới: %s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC Viewer will now exit."
+#~ msgstr ""
+#~ "Đã nhận được tín hiệu kết thúc %d. Bộ xem TigerVNC bây giờ sẽ thoát."
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "Bộ xem TigerVNC"
+
+#~ msgid "Hide Others"
+#~ msgstr "Ẩn các cái khác"
+
+#~ msgid "Show All"
+#~ msgstr "Hiện tất cả"
+
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
+#~ msgstr ""
+#~ "Không thể tạo thư mục cá nhân cho VNC: không thể lấy đường dẫn thư mục cá "
+#~ "nhân."
+
+#, c-format
+#~ msgid "Could not create VNC home directory: %s."
+#~ msgstr "Không thể tạo thư mục cá nhân cho VNC: %s."
+
+#~ msgid "Remote Desktop Viewer"
+#~ msgstr "Trình xem màn hình từ xa"
+
+#~ msgid "tigervnc"
+#~ msgstr "tigervnc"
 
 #~ msgid "Not enough memory for framebuffer"
 #~ msgstr "Không đủ bộ nhớ cho bộ đệm khung"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.13.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2024-06-20 15:01+0200\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2024-09-02 12:19+0800\n"
 "Last-Translator: Mingye Wang (Artoria2e5) <arthur200126@gmail.com>\n"
 "Language-Team: Chinese (simplified) <i18n-zh@googlegroups.com>\n"
@@ -21,17 +21,17 @@ msgstr ""
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: Poedit 3.5\n"
 
-#: vncviewer/CConn.cxx:99
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "连接到套接字 %s"
 
-#: vncviewer/CConn.cxx:106
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "已连接到主机 %s 的端口 %d"
 
-#: vncviewer/CConn.cxx:111
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -42,85 +42,86 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:155
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "桌面名称：%.80s"
 
-#: vncviewer/CConn.cxx:160
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "主机：%.80s 端口：%d"
 
-#: vncviewer/CConn.cxx:165
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "尺寸：%d x %d"
 
-#: vncviewer/CConn.cxx:173
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "像素格式：%s"
 
-#: vncviewer/CConn.cxx:180
-#, c-format
-msgid "(server default %s)"
-msgstr "（服务器默认值 %s）"
-
-#: vncviewer/CConn.cxx:185
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "请求的编码：%s"
 
-#: vncviewer/CConn.cxx:190
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "最近使用的编码：%s"
 
-#: vncviewer/CConn.cxx:195
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "线路速度估计值：%d kbit/s"
 
-#: vncviewer/CConn.cxx:200
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "协议版本：%d.%d"
 
-#: vncviewer/CConn.cxx:205
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "安全方式：%s"
 
-#: vncviewer/CConn.cxx:266 vncviewer/CConn.cxx:268
-msgid "The connection was dropped by the server before the session could be established."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
 msgstr "在建立会话之前，服务器已断开连接。"
 
-#: vncviewer/CConn.cxx:326
+#: vncviewer/CConn.cxx:258
 #, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "SetDesktopSize 函数失败：%d"
+msgid "Authentication failed: %s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:399
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "来自服务器的 SetColourMapEntries 信号无效！"
+#: vncviewer/CConn.cxx:259
+#, c-format
+msgid ""
+"Failed to authenticate with the server. Reason given by the server:\n"
+"\n"
+"%s"
+msgstr ""
 
-#: vncviewer/CConn.cxx:507
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "吞吐量 %d kbit/s - 改变质量级别为 %d"
 
-#: vncviewer/CConn.cxx:529
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "吞吐量 %d kbit/s - 现已启用全彩"
 
-#: vncviewer/CConn.cxx:532
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "吞吐量 %d kbit/s - 现已禁用全彩"
 
-#: vncviewer/CConn.cxx:558
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "正在使用像素格式 %s"
@@ -133,273 +134,329 @@ msgstr "指定的几何尺寸无效！"
 msgid "Reducing window size to fit on current monitor"
 msgstr "减小窗口大小以适应当前显示器"
 
-#: vncviewer/DesktopWindow.cxx:648
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
 msgstr "正在调整窗口大小以避免意外的全屏请求"
 
-#: vncviewer/DesktopWindow.cxx:696
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "按下 %s 以打开上下文菜单"
 
-#: vncviewer/DesktopWindow.cxx:1097 vncviewer/DesktopWindow.cxx:1105
-#: vncviewer/DesktopWindow.cxx:1125
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "占用键盘失败"
 
-#: vncviewer/DesktopWindow.cxx:1415
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
 msgstr "大小改变请求计算得到了无效的屏幕布局！"
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "三按钮仿真的状态无效"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:102
+#: vncviewer/KeyboardWin32.cxx:243
+#, c-format
+msgid "No scan code for extended virtual key 0x%02x"
+msgstr "扩展虚拟键 0x%02x 无扫描码"
+
+#: vncviewer/KeyboardWin32.cxx:245
+#, c-format
+msgid "No scan code for virtual key 0x%02x"
+msgstr "虚拟键 0x%02x 无扫描码"
+
+#: vncviewer/KeyboardWin32.cxx:251
+#, c-format
+msgid "Invalid scan code 0x%02x"
+msgstr "无效的键盘扫描码 0x%02x"
+
+#: vncviewer/KeyboardWin32.cxx:263
+#, c-format
+msgid "No symbol for extended virtual key 0x%02x"
+msgstr "扩展虚拟键 0x%02x 无符号"
+
+#: vncviewer/KeyboardWin32.cxx:265
+#, c-format
+msgid "No symbol for virtual key 0x%02x"
+msgstr "虚拟键 0x%02x 无符号"
+
+#: vncviewer/KeyboardWin32.cxx:424
+#, c-format
+msgid "Failed to update keyboard LED state: %lu"
+msgstr "未能更新键盘 LED 状态：%lu"
+
+#: vncviewer/KeyboardX11.cxx:123
+#, c-format
+msgid "No symbol for key code %d (in the current state)"
+msgstr "键位码 %d 无符号（当前状态）"
+
+#: vncviewer/KeyboardX11.cxx:148
+#, c-format
+msgid "Failed to get keyboard LED state: %d"
+msgstr "未能获取键盘 LED 指示灯状态：%d"
+
+#: vncviewer/KeyboardX11.cxx:193
+msgid "Failed to update keyboard LED state"
+msgstr "未能更新键盘 LED 状态"
+
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "未能获取系统显示器配置"
 
-#: vncviewer/MonitorIndicesParameter.cxx:80
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "为 %s 指定的配置无效"
-
-#: vncviewer/MonitorIndicesParameter.cxx:88
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "显示器索引%d不存在"
 
-#: vncviewer/MonitorIndicesParameter.cxx:166
-#: vncviewer/MonitorIndicesParameter.cxx:186
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "显示器索引 '%s' 无效"
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
+msgid "TigerVNC options"
+msgstr ""
 
-#: vncviewer/MonitorIndicesParameter.cxx:174
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "意料之外的字符 '%c'"
-
-#: vncviewer/OptionsDialog.cxx:64
-msgid "TigerVNC Options"
-msgstr "TigerVNC 选项"
-
-#: vncviewer/OptionsDialog.cxx:97 vncviewer/ServerDialog.cxx:102
-#: vncviewer/vncviewer.cxx:395
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "取消"
 
-#: vncviewer/OptionsDialog.cxx:102 vncviewer/vncviewer.cxx:394
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "确定"
 
-#: vncviewer/OptionsDialog.cxx:502
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "压缩"
 
-#: vncviewer/OptionsDialog.cxx:518
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "自动选择"
 
-#: vncviewer/OptionsDialog.cxx:529
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "首选编码"
 
-#: vncviewer/OptionsDialog.cxx:590
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "颜色级别"
 
-#: vncviewer/OptionsDialog.cxx:602
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "全部"
 
-#: vncviewer/OptionsDialog.cxx:609
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "中"
 
-#: vncviewer/OptionsDialog.cxx:616
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "低"
 
-#: vncviewer/OptionsDialog.cxx:623
+#: vncviewer/OptionsDialog.cxx:635
 msgid "Very low"
 msgstr "非常低"
 
-#: vncviewer/OptionsDialog.cxx:645
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "自定义压缩级别："
 
-#: vncviewer/OptionsDialog.cxx:652
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "级别（0=最快，9=最好）"
 
-#: vncviewer/OptionsDialog.cxx:659
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "允许 JPEG 压缩："
 
-#: vncviewer/OptionsDialog.cxx:666
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "质量（0=最差，9=最好）"
 
-#: vncviewer/OptionsDialog.cxx:677
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "安全"
 
-#: vncviewer/OptionsDialog.cxx:691
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "加密"
 
-#: vncviewer/OptionsDialog.cxx:703 vncviewer/OptionsDialog.cxx:770
-#: vncviewer/OptionsDialog.cxx:876
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "无"
 
-#: vncviewer/OptionsDialog.cxx:710
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "带有匿名证书的 TLS"
 
-#: vncviewer/OptionsDialog.cxx:716
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "带有 X509 证书的 TLS"
 
-#: vncviewer/OptionsDialog.cxx:723
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "X509 CA 证书路径"
 
-#: vncviewer/OptionsDialog.cxx:730
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "X509 CRL 文件路径"
 
-#: vncviewer/OptionsDialog.cxx:758
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "认证"
 
-#: vncviewer/OptionsDialog.cxx:776
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "标准 VNC（不安全且无加密）"
 
-#: vncviewer/OptionsDialog.cxx:782
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "用户名及密码（不安全且无加密）"
 
-#: vncviewer/OptionsDialog.cxx:805
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "输入"
 
-#: vncviewer/OptionsDialog.cxx:818
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "仅显示（忽略鼠标及键盘）"
 
-#: vncviewer/OptionsDialog.cxx:825
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "鼠标"
 
-#: vncviewer/OptionsDialog.cxx:837
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "模拟鼠标中键"
 
-#: vncviewer/OptionsDialog.cxx:843
-msgid "Show dot when no cursor"
-msgstr "无光标时显示一个点"
+#: vncviewer/OptionsDialog.cxx:880
+msgid "Show local cursor when not provided by server"
+msgstr ""
 
-#: vncviewer/OptionsDialog.cxx:859
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
+msgid "Cursor type"
+msgstr ""
+
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
+msgid "Dot"
+msgstr ""
+
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
+msgid "System"
+msgstr ""
+
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "键盘"
 
-#: vncviewer/OptionsDialog.cxx:871
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
 msgstr "将系统键位直接传递到服务器（全屏）"
 
-#: vncviewer/OptionsDialog.cxx:874
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "菜单键"
 
-#: vncviewer/OptionsDialog.cxx:895
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "剪贴板"
 
-#: vncviewer/OptionsDialog.cxx:907
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "接受来自服务器的剪切板内容"
 
-#: vncviewer/OptionsDialog.cxx:915
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "同样设定鼠标选择内容"
 
-#: vncviewer/OptionsDialog.cxx:922
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "发送剪切板内容到服务器"
 
-#: vncviewer/OptionsDialog.cxx:930
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "将鼠标选择内容作为剪切板内容发送"
 
-#: vncviewer/OptionsDialog.cxx:951
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "显示"
 
-#: vncviewer/OptionsDialog.cxx:965
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "显示模式"
 
-#: vncviewer/OptionsDialog.cxx:978
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "窗口化"
 
-#: vncviewer/OptionsDialog.cxx:986
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "在当前显示器上全屏显示"
 
-#: vncviewer/OptionsDialog.cxx:994
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "为所有显示器开启全屏模式"
 
-#: vncviewer/OptionsDialog.cxx:1002
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "为选定显示器开启全屏模式"
 
-#: vncviewer/OptionsDialog.cxx:1031
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
 msgid "Miscellaneous"
 msgstr "杂项"
 
-#: vncviewer/OptionsDialog.cxx:1039
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "共享（不要断开其他查看器）"
 
-#: vncviewer/OptionsDialog.cxx:1045
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "连接错误时询问是否重新连接"
 
-#: vncviewer/ServerDialog.cxx:58
-msgid "VNC Viewer: Connection Details"
-msgstr "VNC 查看器：连接细节"
-
-#: vncviewer/ServerDialog.cxx:68
+#: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
 msgstr "VNC 服务器："
 
-#: vncviewer/ServerDialog.cxx:75
+#: vncviewer/ServerDialog.cxx:80
 msgid "Options..."
 msgstr "选项..."
 
-#: vncviewer/ServerDialog.cxx:79
+#: vncviewer/ServerDialog.cxx:84
 msgid "Load..."
 msgstr "载入..."
 
-#: vncviewer/ServerDialog.cxx:83
-msgid "Save As..."
-msgstr "保存为..."
+#: vncviewer/ServerDialog.cxx:88
+msgid "Save as..."
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:97
+#: vncviewer/ServerDialog.cxx:102
 msgid "About..."
 msgstr "关于..."
 
-#: vncviewer/ServerDialog.cxx:106
+#: vncviewer/ServerDialog.cxx:111
 msgid "Connect"
 msgstr "连接"
 
-#: vncviewer/ServerDialog.cxx:143
+#: vncviewer/ServerDialog.cxx:147
 #, c-format
 msgid ""
 "Unable to load the server history:\n"
@@ -410,15 +467,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:172 vncviewer/ServerDialog.cxx:212
+#: vncviewer/ServerDialog.cxx:176 vncviewer/ServerDialog.cxx:216
 msgid "TigerVNC configuration (*.tigervnc)"
 msgstr "TigerVNC 配置（*.tigervnc）"
 
-#: vncviewer/ServerDialog.cxx:173
+#: vncviewer/ServerDialog.cxx:177
 msgid "Select a TigerVNC configuration file"
 msgstr "选择 TigerVNC 配置文件"
 
-#: vncviewer/ServerDialog.cxx:195 vncviewer/vncviewer.cxx:515
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -429,24 +486,24 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:213
+#: vncviewer/ServerDialog.cxx:217
 msgid "Save the TigerVNC configuration to file"
 msgstr "将 TigerVNC 配置保存到文件"
 
-#: vncviewer/ServerDialog.cxx:239
+#: vncviewer/ServerDialog.cxx:243
 #, c-format
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "%s 已经存在。是否要覆盖？"
 
-#: vncviewer/ServerDialog.cxx:240 vncviewer/vncviewer.cxx:392
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "否"
 
-#: vncviewer/ServerDialog.cxx:240
+#: vncviewer/ServerDialog.cxx:244
 msgid "Overwrite"
 msgstr "覆盖"
 
-#: vncviewer/ServerDialog.cxx:256
+#: vncviewer/ServerDialog.cxx:260
 #, c-format
 msgid ""
 "Unable to save the specified configuration file:\n"
@@ -457,7 +514,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:290
+#: vncviewer/ServerDialog.cxx:294
 #, c-format
 msgid ""
 "Unable to save the default configuration:\n"
@@ -468,7 +525,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:303
+#: vncviewer/ServerDialog.cxx:306
 #, c-format
 msgid ""
 "Unable to save the server history:\n"
@@ -479,228 +536,170 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:320 vncviewer/ServerDialog.cxx:386
-msgid "Could not obtain the state directory path"
-msgstr "未能获取状态目录路径"
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
+msgid "Could not determine VNC state directory path"
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:332 vncviewer/ServerDialog.cxx:394
-#: vncviewer/parameters.cxx:644 vncviewer/parameters.cxx:750
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
-msgid "Could not open \"%s\": %s"
-msgstr "未能打开“%s”： %s"
+msgid "Could not open \"%s\""
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:347 vncviewer/ServerDialog.cxx:355
-#: vncviewer/parameters.cxx:764 vncviewer/parameters.cxx:770
-#: vncviewer/parameters.cxx:801 vncviewer/parameters.cxx:830
-#: vncviewer/parameters.cxx:836
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
-msgid "Failed to read line %d in file %s: %s"
-msgstr "未能读取文件 %2$s 的第 %1$d 行：%3$s"
+msgid "Failed to read line %d in file \"%s\""
+msgstr ""
 
-#: vncviewer/ServerDialog.cxx:356 vncviewer/parameters.cxx:771
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "行过长"
 
-#: vncviewer/UserDialog.cxx:99
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "打开密码文件失败"
 
-#: vncviewer/UserDialog.cxx:118
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "VNC 认证"
 
-#: vncviewer/UserDialog.cxx:125
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "此连接是安全的"
 
-#: vncviewer/UserDialog.cxx:129
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "此连接不安全"
 
-#: vncviewer/UserDialog.cxx:151
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "用户名："
 
-#: vncviewer/UserDialog.cxx:164
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "密码："
 
-#: vncviewer/UserDialog.cxx:207
-msgid "Authentication cancelled"
-msgstr "认证已取消"
+#: vncviewer/UserDialog.cxx:204
+msgid "Keep password for reconnect"
+msgstr ""
 
-#: vncviewer/Viewport.cxx:390
-#, c-format
-msgid "Failed to update keyboard LED state: %lu"
-msgstr "未能更新键盘 LED 状态：%lu"
-
-#: vncviewer/Viewport.cxx:396 vncviewer/Viewport.cxx:402
-#, c-format
-msgid "Failed to update keyboard LED state: %d"
-msgstr "未能更新键盘 LED 状态：%d"
-
-#: vncviewer/Viewport.cxx:432
-msgid "Failed to update keyboard LED state"
-msgstr "未能更新键盘 LED 状态"
-
-#: vncviewer/Viewport.cxx:459 vncviewer/Viewport.cxx:467
-#: vncviewer/Viewport.cxx:484
-#, c-format
-msgid "Failed to get keyboard LED state: %d"
-msgstr "未能获取键盘 LED 指示灯状态：%d"
-
-#: vncviewer/Viewport.cxx:839
-msgid "No key code specified on key press"
-msgstr "按下按键时未指定键码"
-
-#: vncviewer/Viewport.cxx:990
-#, c-format
-msgid "No scan code for extended virtual key 0x%02x"
-msgstr "扩展虚拟键 0x%02x 无扫描码"
-
-#: vncviewer/Viewport.cxx:992
-#, c-format
-msgid "No scan code for virtual key 0x%02x"
-msgstr "虚拟键 0x%02x 无扫描码"
-
-#: vncviewer/Viewport.cxx:998
-#, c-format
-msgid "Invalid scan code 0x%02x"
-msgstr "无效的键盘扫描码 0x%02x"
-
-#: vncviewer/Viewport.cxx:1028
-#, c-format
-msgid "No symbol for extended virtual key 0x%02x"
-msgstr "扩展虚拟键 0x%02x 无符号"
-
-#: vncviewer/Viewport.cxx:1030
-#, c-format
-msgid "No symbol for virtual key 0x%02x"
-msgstr "虚拟键 0x%02x 无符号"
-
-#: vncviewer/Viewport.cxx:1136
-#, c-format
-msgid "No symbol for key code 0x%02x (in the current state)"
-msgstr "键位码 0x%02x 无符号（当前状态）"
-
-#: vncviewer/Viewport.cxx:1169
-#, c-format
-msgid "No symbol for key code %d (in the current state)"
-msgstr "键位码 %d 无符号（当前状态）"
-
-#: vncviewer/Viewport.cxx:1229
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
 msgid "Disconn&ect"
 msgstr "断开（&E）"
 
-#: vncviewer/Viewport.cxx:1232
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "全屏(&F)"
 
-#: vncviewer/Viewport.cxx:1235
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "最小化(&Z)"
 
-#: vncviewer/Viewport.cxx:1237
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "改变窗口大小以适应会话(&W)"
 
-#: vncviewer/Viewport.cxx:1242
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:1245
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:1251
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "发送 %s"
 
-#: vncviewer/Viewport.cxx:1257
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "发送 Ctrl-Alt-&Del"
 
-#: vncviewer/Viewport.cxx:1260
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "刷新屏幕(&R)"
 
-#: vncviewer/Viewport.cxx:1263
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "选项...(&O)"
 
-#: vncviewer/Viewport.cxx:1265
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "连接信息...(&I)"
 
-#: vncviewer/Viewport.cxx:1267
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "关于 &TigerVNC 查看器..."
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:1356
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "VNC 连接信息"
 
-#: vncviewer/Win32TouchHandler.cxx:47
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "窗口为触摸而不是手势注册"
 
-#: vncviewer/Win32TouchHandler.cxx:82
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "未能设置手势配置（错误 0x%x）"
 
-#: vncviewer/Win32TouchHandler.cxx:94
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "未能获取手势信息（错误 0x%x）"
 
-#: vncviewer/Win32TouchHandler.cxx:359
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr "无效的鼠标按钮%d，必须是介于 1 和 7 之间的数字。"
 
-#: vncviewer/Win32TouchHandler.cxx:424
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
 msgstr "未处理的键 0x%x - 未能生成键盘事件。"
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:108
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
 msgstr "未能获取窗口 0x%08lx 的 X Input 2 事件掩码"
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr "窗口 0x%08lx 没有 X Input 2 事件掩码"
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:115
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr "窗口 0x%08lx 具有多个 X Input 2 事件掩码"
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "抓取设备 %i 失败"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-#: vncviewer/vncviewer.cxx:389 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC Viewer"
-msgstr "TigerVNC 查看器"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -708,156 +707,177 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr "连接到 VNC 服务器并显示远程桌面"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
-msgstr "虚拟网络计算（VNC）是一种远程显示系统，允许您查看网络上另一台计算机上运行的虚拟桌面环境并与之交互。通过 VNC，您可以在远程计算机上运行图形应用程序，并仅将这些应用程序显示的内容发送到本地设备。此软件包含有一个客户端，通过该客户端，您可以连接到运行 VNC 服务器的其他桌面。VNC 支持各种操作系统和架构作为服务器和客户端。"
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+"虚拟网络计算（VNC）是一种远程显示系统，允许您查看网络上另一台计算机上运行的虚"
+"拟桌面环境并与之交互。通过 VNC，您可以在远程计算机上运行图形应用程序，并仅将"
+"这些应用程序显示的内容发送到本地设备。此软件包含有一个客户端，通过该客户端，"
+"您可以连接到运行 VNC 服务器的其他桌面。VNC 支持各种操作系统和架构作为服务器和"
+"客户端。"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
-msgstr "TigerVNC 是基于 RealVNC 4 和 X.org 代码库的高速 VNC 版本。TigerVNC 最初是 Unix 和 Linux 平台上 TightVNC 的下一代开发工作，但它在 2009 年初从其父项目中分离出来，以便 TightVNC 专注于 Windows 平台。TigerVNC 支持 Tight 编码的一种变体，通过使用 libjpeg-turbo JPEG 编解码器大大加速。"
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+"TigerVNC 是基于 RealVNC 4 和 X.org 代码库的高速 VNC 版本。TigerVNC 最初是 "
+"Unix 和 Linux 平台上 TightVNC 的下一代开发工作，但它在 2009 年初从其父项目中"
+"分离出来，以便 TightVNC 专注于 Windows 平台。TigerVNC 支持 Tight 编码的一种变"
+"体，通过使用 libjpeg-turbo JPEG 编解码器大大加速。"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC Viewer connection to a CentOS machine"
-msgstr "TigerVNC Viewer 连接到 CentOS 机器"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC Viewer connection to a macOS machine"
-msgstr "TigerVNC Viewer 连接到 macOS 机器"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC Viewer connection to a Windows machine"
-msgstr "TigerVNC Viewer 连接到 Windows 机器"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
-#: vncviewer/parameters.cxx:307 vncviewer/parameters.cxx:332
-#: vncviewer/parameters.cxx:349 vncviewer/parameters.cxx:389
-#: vncviewer/parameters.cxx:409
+#. developer_name tag deprecated with Appstream 1.0
+#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
+msgid "The TigerVNC team"
+msgstr ""
+
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "参数名称太大"
 
-#: vncviewer/parameters.cxx:311 vncviewer/parameters.cxx:316
-#: vncviewer/parameters.cxx:367
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "参数太大"
 
-#: vncviewer/parameters.cxx:374 vncviewer/parameters.cxx:694
-#: vncviewer/parameters.cxx:815
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "格式无效或值太大"
 
-#: vncviewer/parameters.cxx:428 vncviewer/parameters.cxx:459
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "创建注册键值失败"
 
-#: vncviewer/parameters.cxx:447 vncviewer/parameters.cxx:502
-#: vncviewer/parameters.cxx:544 vncviewer/parameters.cxx:611
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "关闭注册键值失败"
 
-#: vncviewer/parameters.cxx:465 vncviewer/parameters.cxx:482
-#: vncviewer/parameters.cxx:652 vncviewer/parameters.cxx:662
-#: vncviewer/parameters.cxx:673
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "未能保存 “%s”：%s"
 
-#: vncviewer/parameters.cxx:478 vncviewer/parameters.cxx:566
-#: vncviewer/parameters.cxx:675 vncviewer/parameters.cxx:712
-msgid "Unknown parameter type"
-msgstr "未知参数类型"
-
-#: vncviewer/parameters.cxx:495
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "未能移除 “%s”：%s"
 
-#: vncviewer/parameters.cxx:517 vncviewer/parameters.cxx:589
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "无法打开注册键值"
 
-#: vncviewer/parameters.cxx:534
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "无法读取服务器历史记录条目 %d：%s"
 
-#: vncviewer/parameters.cxx:570 vncviewer/parameters.cxx:600
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "无法读取参数 %s：%s"
 
-#: vncviewer/parameters.cxx:634 vncviewer/parameters.cxx:738
-msgid "Could not obtain the config directory path"
-msgstr "无法获取配置目录路径"
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
+msgid "Could not determine VNC config directory path"
+msgstr ""
 
-#: vncviewer/parameters.cxx:653 vncviewer/parameters.cxx:664
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "无法对参数进行编码"
 
-#: vncviewer/parameters.cxx:780
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "配置文件 %s 的格式无效"
 
-#: vncviewer/parameters.cxx:802
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "格式无效"
 
-#: vncviewer/parameters.cxx:837
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "未知参数"
 
-#: vncviewer/touch.cxx:76
+#: vncviewer/touch.cxx:75
 #, c-format
 msgid "Got message (0x%x) for an unhandled window"
 msgstr "未处理窗口收到了消息（0x%x）"
 
-#: vncviewer/touch.cxx:139 vncviewer/touch.cxx:161
+#: vncviewer/touch.cxx:138 vncviewer/touch.cxx:160
 #, c-format
 msgid "Invalid window 0x%08lx specified for pointer grab"
 msgstr "为指针抓取指定的窗口 0x%08lx 无效"
 
-#: vncviewer/touch.cxx:184 vncviewer/touch.cxx:185
+#: vncviewer/touch.cxx:183 vncviewer/touch.cxx:184
 #, c-format
 msgid "Failed to create touch handler: %s"
 msgstr "未能创建触摸处理程序 %s"
 
-#: vncviewer/touch.cxx:189
+#: vncviewer/touch.cxx:188
 #, c-format
 msgid "Couldn't attach event handler to window (error 0x%x)"
 msgstr "未能将事件处理程序附加到窗口（错误 0x%x）"
 
-#: vncviewer/touch.cxx:216
+#: vncviewer/touch.cxx:215
 msgid "Failed to get event data for X Input event"
 msgstr "未能获取 X Input 事件的事件数据"
 
-#: vncviewer/touch.cxx:229
+#: vncviewer/touch.cxx:228
 msgid "X Input event for unknown window"
 msgstr "未知窗口的 X Input 事件"
 
-#: vncviewer/touch.cxx:255
+#: vncviewer/touch.cxx:254
 msgid "X Input extension not available."
 msgstr "X Input 扩展不可用。"
 
-#: vncviewer/touch.cxx:262
+#: vncviewer/touch.cxx:261
 msgid "X Input 2 (or newer) is not available."
 msgstr "X Input 2（或更高版本）不可用。"
 
-#: vncviewer/touch.cxx:267
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
+#: vncviewer/touch.cxx:266
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
 msgstr "X Input 2.2（或更高版本）不可用。不支持触摸手势。"
 
-#: vncviewer/vncviewer.cxx:104
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC Viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
-"Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+"Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"TigerVNC 查看器 v%s\n"
-"构建于：%s\n"
-"版权所有 1999-%d TigerVNC 团队及众多开发者（参见 README.txt）\n"
-"访问 http://www.tigervnc.org 以获取更多关于 TigerVNC 的信息。"
 
-#: vncviewer/vncviewer.cxx:158
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -868,15 +888,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:174
-msgid "About TigerVNC Viewer"
-msgstr "关于 TigerVNC 查看器"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:195
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "FLTK 内部错误。现在将退出。"
 
-#: vncviewer/vncviewer.cxx:214
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -887,102 +907,165 @@ msgstr ""
 "\n"
 "尝试重新连接？"
 
-#: vncviewer/vncviewer.cxx:245 vncviewer/vncviewer.cxx:257
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "启动 TigerVNC 查看器出错：%s"
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:266
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC Viewer will now exit."
-msgstr "收到终端信号 %d 。TigerVNC 现在将退出。"
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:393
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "是"
 
-#: vncviewer/vncviewer.cxx:396
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "关闭"
 
-#: vncviewer/vncviewer.cxx:401
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "关于"
 
-#: vncviewer/vncviewer.cxx:404
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "隐藏"
 
-#: vncviewer/vncviewer.cxx:407
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "退出"
 
-#: vncviewer/vncviewer.cxx:411
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "服务"
 
-#: vncviewer/vncviewer.cxx:412
-msgid "Hide Others"
-msgstr "隐藏其他"
-
 #: vncviewer/vncviewer.cxx:413
-msgid "Show All"
-msgstr "全部显示"
+msgid "Hide others"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:422
+#: vncviewer/vncviewer.cxx:414
+msgid "Show all"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "文件(&F)"
 
-#: vncviewer/vncviewer.cxx:425
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "新建连接(&N)"
 
-#: vncviewer/vncviewer.cxx:525
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+#: vncviewer/vncviewer.cxx:449
+#, c-format
+msgid ""
+"\n"
+"Usage: %s [parameters] [host][:displayNum]\n"
+"       %s [parameters] [host][::port]\n"
+"       %s [parameters] [unix socket]\n"
+"       %s [parameters] -listen [port]\n"
+"       %s [parameters] [.tigervnc file]\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:464
+#, c-format
+msgid ""
+"\n"
+"Options:\n"
+"\n"
+"  -display Xdisplay  - Specifies the X display for the viewer window\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
+"                       man page for details.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:471
+#, c-format
+msgid ""
+"\n"
+"Parameters can be turned on with -<param> or off with -<param>=0\n"
+"Parameters which take a value can be specified as -<param> <value>\n"
+"Other valid forms are <param>=<value> -<param>=<value> --<param>=<value>\n"
+"Parameter names are case-insensitive.  The parameters are:\n"
+"\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
 msgstr "FullScreenAllMonitors 已弃用，请将 FullScreenMode 改为“all”"
 
-#: vncviewer/vncviewer.cxx:721
-msgid "~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
 msgstr "~/.vnc 已弃用，请查阅 'man vncviewer' 以获取新路径。"
 
-#: vncviewer/vncviewer.cxx:725
+#: vncviewer/vncviewer.cxx:556
 #, c-format
-msgid "%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC location."
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
 msgstr "%%APPDATA%%\\vnc 已弃用，请切换到 %%APPDATA%%\\TigerVNC 位置。"
 
-#: vncviewer/vncviewer.cxx:730
+#: vncviewer/vncviewer.cxx:561
 #, c-format
-msgid "Could not create VNC config directory: %s"
-msgstr "未能创建 VNC 配置目录：%s"
+msgid "Could not create VNC config directory \"%s\": %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:735
-#, c-format
-msgid "Could not create VNC data directory: %s"
-msgstr "未能创建 VNC 数据目录：%s"
+#: vncviewer/vncviewer.cxx:567
+msgid "Could not determine VNC data directory path"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:740
+#: vncviewer/vncviewer.cxx:573
 #, c-format
-msgid "Could not create VNC state directory: %s"
-msgstr "未能创建 VNC 状态目录：%s"
+msgid "Could not create VNC data directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:585
+#, c-format
+msgid "Could not create VNC state directory \"%s\": %s"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:704
+#, c-format
+msgid "%s: Unrecognized option '%s'\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
+#, c-format
+msgid "See '%s --help' for more information.\n"
+msgstr ""
+
+#: vncviewer/vncviewer.cxx:713
+#, c-format
+msgid "%s: Extra argument '%s'\n"
+msgstr ""
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:755 vncviewer/vncviewer.cxx:756
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "-listen 及 -via 参数不兼容"
 
-#: vncviewer/vncviewer.cxx:770
+#: vncviewer/vncviewer.cxx:764
 msgid "Unable to listen for incoming connections"
 msgstr "未能侦听传入连接"
 
-#: vncviewer/vncviewer.cxx:772
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "正在监听端口 %d"
 
-#: vncviewer/vncviewer.cxx:805
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -993,9 +1076,144 @@ msgstr ""
 "\n"
 "%s"
 
+#: vncviewer/vncviewer.cxx:816
+#, c-format
+msgid ""
+"Failure setting up encrypted tunnel:\n"
+"\n"
+"%s"
+msgstr ""
+
 #: vncviewer/vncviewer.desktop.in.in:4
-msgid "Remote Desktop Viewer"
-msgstr "远程桌面查看器"
+msgid "Remote desktop viewer"
+msgstr ""
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "（服务器默认值 %s）"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "SetDesktopSize 函数失败：%d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "来自服务器的 SetColourMapEntries 信号无效！"
+
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "为 %s 指定的配置无效"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "显示器索引 '%s' 无效"
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "意料之外的字符 '%c'"
+
+#~ msgid "TigerVNC Options"
+#~ msgstr "TigerVNC 选项"
+
+#~ msgid "Show dot when no cursor"
+#~ msgstr "无光标时显示一个点"
+
+#~ msgid "VNC Viewer: Connection Details"
+#~ msgstr "VNC 查看器：连接细节"
+
+#~ msgid "Save As..."
+#~ msgstr "保存为..."
+
+#~ msgid "Could not obtain the state directory path"
+#~ msgstr "未能获取状态目录路径"
+
+#, c-format
+#~ msgid "Could not open \"%s\": %s"
+#~ msgstr "未能打开“%s”： %s"
+
+#, c-format
+#~ msgid "Failed to read line %d in file %s: %s"
+#~ msgstr "未能读取文件 %2$s 的第 %1$d 行：%3$s"
+
+#~ msgid "Authentication cancelled"
+#~ msgstr "认证已取消"
+
+#, c-format
+#~ msgid "Failed to update keyboard LED state: %d"
+#~ msgstr "未能更新键盘 LED 状态：%d"
+
+#~ msgid "No key code specified on key press"
+#~ msgstr "按下按键时未指定键码"
+
+#, c-format
+#~ msgid "No symbol for key code 0x%02x (in the current state)"
+#~ msgstr "键位码 0x%02x 无符号（当前状态）"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "关于 &TigerVNC 查看器..."
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "TigerVNC 查看器"
+
+#~ msgid "TigerVNC Viewer connection to a CentOS machine"
+#~ msgstr "TigerVNC Viewer 连接到 CentOS 机器"
+
+#~ msgid "TigerVNC Viewer connection to a macOS machine"
+#~ msgstr "TigerVNC Viewer 连接到 macOS 机器"
+
+#~ msgid "TigerVNC Viewer connection to a Windows machine"
+#~ msgstr "TigerVNC Viewer 连接到 Windows 机器"
+
+#~ msgid "Unknown parameter type"
+#~ msgstr "未知参数类型"
+
+#~ msgid "Could not obtain the config directory path"
+#~ msgstr "无法获取配置目录路径"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC Viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC Team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "TigerVNC 查看器 v%s\n"
+#~ "构建于：%s\n"
+#~ "版权所有 1999-%d TigerVNC 团队及众多开发者（参见 README.txt）\n"
+#~ "访问 http://www.tigervnc.org 以获取更多关于 TigerVNC 的信息。"
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "关于 TigerVNC 查看器"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "启动 TigerVNC 查看器出错：%s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC Viewer will now exit."
+#~ msgstr "收到终端信号 %d 。TigerVNC 现在将退出。"
+
+#~ msgid "Hide Others"
+#~ msgstr "隐藏其他"
+
+#~ msgid "Show All"
+#~ msgstr "全部显示"
+
+#, c-format
+#~ msgid "Could not create VNC config directory: %s"
+#~ msgstr "未能创建 VNC 配置目录：%s"
+
+#, c-format
+#~ msgid "Could not create VNC data directory: %s"
+#~ msgstr "未能创建 VNC 数据目录：%s"
+
+#, c-format
+#~ msgid "Could not create VNC state directory: %s"
+#~ msgstr "未能创建 VNC 状态目录：%s"
+
+#~ msgid "Remote Desktop Viewer"
+#~ msgstr "远程桌面查看器"
 
 #~ msgid "Enabling continuous updates"
 #~ msgstr "已启动持续更新"
@@ -1063,7 +1281,8 @@ msgstr "远程桌面查看器"
 #~ msgid "The parameter %s was too large to read from the registry"
 #~ msgstr "参数 %s 过大，因而无法从注册表读取"
 
-#~ msgid "Failed to write configuration file, can't obtain home directory path."
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
 #~ msgstr "无法写入配置文件，无法获取家目录路径。"
 
 #, c-format
@@ -1077,7 +1296,8 @@ msgstr "远程桌面查看器"
 #~ msgid "Unknown parameter %s on line %d in file %s"
 #~ msgstr "未知参数 %1$s 于文件 %3$s 的第 %2$d 行"
 
-#~ msgid "Could not create VNC home directory: can't obtain home directory path."
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
 #~ msgstr "无法创建 VNC 家目录：无法获取家目录路径。"
 
 #~ msgid "Unknown encoding %d"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tigervnc 1.14.90\n"
 "Report-Msgid-Bugs-To: tigervnc-devel@googlegroups.com\n"
-"POT-Creation-Date: 2025-01-14 16:15+0100\n"
+"POT-Creation-Date: 2025-06-10 08:06+0000\n"
 "PO-Revision-Date: 2025-02-02 00:23+0800\n"
 "Last-Translator: Yi-Jyun Pan <pan93412@gmail.com>\n"
 "Language-Team: Chinese (traditional) <zh-l10n@lists.slat.org>\n"
@@ -19,17 +19,17 @@ msgstr ""
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: Poedit 3.5\n"
 
-#: vncviewer/CConn.cxx:102
+#: vncviewer/CConn.cxx:103
 #, c-format
 msgid "Connected to socket %s"
 msgstr "已連線到 socket %s"
 
-#: vncviewer/CConn.cxx:109
+#: vncviewer/CConn.cxx:110
 #, c-format
 msgid "Connected to host %s port %d"
 msgstr "已連線到主機位址 %s (連線埠 %d)"
 
-#: vncviewer/CConn.cxx:114
+#: vncviewer/CConn.cxx:115
 #, c-format
 msgid ""
 "Failed to connect to \"%s\":\n"
@@ -40,66 +40,63 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:151
+#: vncviewer/CConn.cxx:152
 #, c-format
 msgid "Desktop name: %.80s"
 msgstr "桌面名稱：%.80s"
 
-#: vncviewer/CConn.cxx:154
+#: vncviewer/CConn.cxx:155
 #, c-format
 msgid "Host: %.80s port: %d"
 msgstr "主機名稱：%.80s 連線埠：%d"
 
-#: vncviewer/CConn.cxx:158
+#: vncviewer/CConn.cxx:159
 #, c-format
 msgid "Size: %d x %d"
 msgstr "大小：%d x %d"
 
-#: vncviewer/CConn.cxx:165
+#: vncviewer/CConn.cxx:166
 #, c-format
 msgid "Pixel format: %s"
 msgstr "像素格式：%s"
 
-#: vncviewer/CConn.cxx:170
-#, c-format
-msgid "(server default %s)"
-msgstr "（伺服器預設值：%s）"
-
-#: vncviewer/CConn.cxx:173
+#: vncviewer/CConn.cxx:169
 #, c-format
 msgid "Requested encoding: %s"
 msgstr "請求的編碼方式：%s"
 
-#: vncviewer/CConn.cxx:177
+#: vncviewer/CConn.cxx:173
 #, c-format
 msgid "Last used encoding: %s"
 msgstr "上次使用的編碼方式：%s"
 
-#: vncviewer/CConn.cxx:181
+#: vncviewer/CConn.cxx:177
 #, c-format
 msgid "Line speed estimate: %d kbit/s"
 msgstr "估計線速：%d kbit/秒"
 
-#: vncviewer/CConn.cxx:185
+#: vncviewer/CConn.cxx:181
 #, c-format
 msgid "Protocol version: %d.%d"
 msgstr "協定版本：%d.%d"
 
-#: vncviewer/CConn.cxx:189
+#: vncviewer/CConn.cxx:185
 #, c-format
 msgid "Security method: %s"
 msgstr "安全性方法：%s"
 
-#: vncviewer/CConn.cxx:250 vncviewer/CConn.cxx:252
-msgid "The connection was dropped by the server before the session could be established."
+#: vncviewer/CConn.cxx:246 vncviewer/CConn.cxx:248
+msgid ""
+"The connection was dropped by the server before the session could be "
+"established."
 msgstr "在工作階段能夠建立前，連線就被伺服器丟棄。"
 
-#: vncviewer/CConn.cxx:262
+#: vncviewer/CConn.cxx:258
 #, c-format
 msgid "Authentication failed: %s"
 msgstr "認證失敗：%s"
 
-#: vncviewer/CConn.cxx:263
+#: vncviewer/CConn.cxx:259
 #, c-format
 msgid ""
 "Failed to authenticate with the server. Reason given by the server:\n"
@@ -110,31 +107,22 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/CConn.cxx:335
-#, c-format
-msgid "SetDesktopSize failed: %d"
-msgstr "執行 SetDesktopSize 失敗：%d"
-
-#: vncviewer/CConn.cxx:408
-msgid "Invalid SetColourMapEntries from server!"
-msgstr "伺服器傳來無效的 SetColourMapEntries！"
-
-#: vncviewer/CConn.cxx:516
+#: vncviewer/CConn.cxx:490
 #, c-format
 msgid "Throughput %d kbit/s - changing to quality %d"
 msgstr "輸送量 %d kbit/秒 - 將品質等級變更至 %d"
 
-#: vncviewer/CConn.cxx:538
+#: vncviewer/CConn.cxx:521
 #, c-format
 msgid "Throughput %d kbit/s - full color is now enabled"
 msgstr "輸送量 %d kbit/秒 - 全彩模式現已啟用"
 
-#: vncviewer/CConn.cxx:541
+#: vncviewer/CConn.cxx:524
 #, c-format
 msgid "Throughput %d kbit/s - full color is now disabled"
 msgstr "輸送量 %d kbit/秒 - 全彩模式現已停用"
 
-#: vncviewer/CConn.cxx:567
+#: vncviewer/CConn.cxx:543
 #, c-format
 msgid "Using pixel format %s"
 msgstr "使用像素格式 %s"
@@ -147,136 +135,125 @@ msgstr "指定了無效的幾何大小！"
 msgid "Reducing window size to fit on current monitor"
 msgstr "縮小視窗大小，使之能完全置於目前顯示器中"
 
-#: vncviewer/DesktopWindow.cxx:646
+#: vncviewer/DesktopWindow.cxx:681
 msgid "Adjusting window size to avoid accidental full-screen request"
 msgstr "調整視窗大小，避免產生意外的全螢幕請求"
 
-#: vncviewer/DesktopWindow.cxx:694
+#: vncviewer/DesktopWindow.cxx:712
 #, c-format
 msgid "Press %s to open the context menu"
 msgstr "按下 %s 鍵開啟內容選單"
 
-#: vncviewer/DesktopWindow.cxx:1094 vncviewer/DesktopWindow.cxx:1102
-#: vncviewer/DesktopWindow.cxx:1122
+#: vncviewer/DesktopWindow.cxx:1119 vncviewer/DesktopWindow.cxx:1127
+#: vncviewer/DesktopWindow.cxx:1142
 msgid "Failure grabbing keyboard"
 msgstr "擷取鍵盤失敗"
 
-#: vncviewer/DesktopWindow.cxx:1411
+#: vncviewer/DesktopWindow.cxx:1427
 msgid "Invalid screen layout computed for resize request!"
 msgstr "為縮放請求計算的螢幕版面配置無效！"
 
-#: vncviewer/EmulateMB.cxx:226 vncviewer/EmulateMB.cxx:289
+#: vncviewer/EmulateMB.cxx:227 vncviewer/EmulateMB.cxx:290
 msgid "Invalid state for 3 button emulation"
 msgstr "無效的 3 按鈕模擬狀態"
 
-#: vncviewer/KeyboardWin32.cxx:242
+#: vncviewer/KeyboardWin32.cxx:243
 #, c-format
 msgid "No scan code for extended virtual key 0x%02x"
 msgstr "沒有對應到延伸虛擬代碼 0x%02x 的掃描碼"
 
-#: vncviewer/KeyboardWin32.cxx:244
+#: vncviewer/KeyboardWin32.cxx:245
 #, c-format
 msgid "No scan code for virtual key 0x%02x"
 msgstr "沒有對應到虛擬按鍵 0x%02x 的掃描碼"
 
-#: vncviewer/KeyboardWin32.cxx:250
+#: vncviewer/KeyboardWin32.cxx:251
 #, c-format
 msgid "Invalid scan code 0x%02x"
 msgstr "掃描碼 0x%02x 無效"
 
-#: vncviewer/KeyboardWin32.cxx:262
+#: vncviewer/KeyboardWin32.cxx:263
 #, c-format
 msgid "No symbol for extended virtual key 0x%02x"
 msgstr "沒有對應到延伸虛擬代碼 0x%02x 的符號"
 
-#: vncviewer/KeyboardWin32.cxx:264
+#: vncviewer/KeyboardWin32.cxx:265
 #, c-format
 msgid "No symbol for virtual key 0x%02x"
 msgstr "沒有對應到虛擬按鍵 0x%02x 的符號"
 
-#: vncviewer/KeyboardWin32.cxx:423
+#: vncviewer/KeyboardWin32.cxx:424
 #, c-format
 msgid "Failed to update keyboard LED state: %lu"
 msgstr "更新鍵盤 LED 狀態失敗：%lu"
 
-#: vncviewer/KeyboardX11.cxx:104
+#: vncviewer/KeyboardX11.cxx:123
 #, c-format
 msgid "No symbol for key code %d (in the current state)"
 msgstr "沒有對應到按鍵代碼 %d 的符號 (目前狀態)"
 
-#: vncviewer/KeyboardX11.cxx:129
+#: vncviewer/KeyboardX11.cxx:148
 #, c-format
 msgid "Failed to get keyboard LED state: %d"
 msgstr "取得鍵盤 LED 狀態失敗：%d"
 
-#: vncviewer/KeyboardX11.cxx:174
+#: vncviewer/KeyboardX11.cxx:193
 msgid "Failed to update keyboard LED state"
 msgstr "更新鍵盤 LED 狀態失敗"
 
-#: vncviewer/MonitorIndicesParameter.cxx:52
-#: vncviewer/MonitorIndicesParameter.cxx:100
+#: vncviewer/MonitorIndicesParameter.cxx:53
+#: vncviewer/MonitorIndicesParameter.cxx:85
 msgid "Failed to get system monitor configuration"
 msgstr "無法取得系統顯示器設定"
 
-#: vncviewer/MonitorIndicesParameter.cxx:79
-#, c-format
-msgid "Invalid configuration specified for %s"
-msgstr "為 %s 指定之組態無效"
-
-#: vncviewer/MonitorIndicesParameter.cxx:86
+#: vncviewer/MonitorIndicesParameter.cxx:73
 #, c-format
 msgid "Monitor index %d does not exist"
 msgstr "沒有索引編號是 %d 的顯示器"
 
-#: vncviewer/MonitorIndicesParameter.cxx:162
-#: vncviewer/MonitorIndicesParameter.cxx:182
-#, c-format
-msgid "Invalid monitor index '%s'"
-msgstr "顯示器索引編號「%s」無效"
-
-#: vncviewer/MonitorIndicesParameter.cxx:170
-#, c-format
-msgid "Unexpected character '%c'"
-msgstr "遇到非預期字元「%c」"
-
-#: vncviewer/OptionsDialog.cxx:64
+#. TRANSLATORS: Title of the viewer options dialog window
+#: vncviewer/OptionsDialog.cxx:66
 msgid "TigerVNC options"
 msgstr "TigerVNC 選項"
 
-#: vncviewer/OptionsDialog.cxx:97 vncviewer/ServerDialog.cxx:107
-#: vncviewer/vncviewer.cxx:397
+#. TRANSLATORS: Button that dismisses the dialog without saving
+#: vncviewer/OptionsDialog.cxx:100 vncviewer/ServerDialog.cxx:107
+#: vncviewer/vncviewer.cxx:396
 msgid "Cancel"
 msgstr "取消"
 
-#: vncviewer/OptionsDialog.cxx:102 vncviewer/vncviewer.cxx:396
+#. TRANSLATORS: Button that confirms the dialog and applies changes
+#: vncviewer/OptionsDialog.cxx:106 vncviewer/vncviewer.cxx:395
 msgid "OK"
 msgstr "確認"
 
-#: vncviewer/OptionsDialog.cxx:514
+#. TRANSLATORS: Tab heading for settings controlling image compression
+#: vncviewer/OptionsDialog.cxx:507
 msgid "Compression"
 msgstr "壓縮模式"
 
-#: vncviewer/OptionsDialog.cxx:530
+#: vncviewer/OptionsDialog.cxx:524
 msgid "Auto select"
 msgstr "自動選擇"
 
-#: vncviewer/OptionsDialog.cxx:541
+#: vncviewer/OptionsDialog.cxx:536
 msgid "Preferred encoding"
 msgstr "偏好編碼方式"
 
-#: vncviewer/OptionsDialog.cxx:602
+#. TRANSLATORS: Label for a group of color quality radio buttons
+#: vncviewer/OptionsDialog.cxx:598
 msgid "Color level"
 msgstr "色彩等級"
 
-#: vncviewer/OptionsDialog.cxx:614
+#: vncviewer/OptionsDialog.cxx:611
 msgid "Full"
 msgstr "完整"
 
-#: vncviewer/OptionsDialog.cxx:621
+#: vncviewer/OptionsDialog.cxx:619
 msgid "Medium"
 msgstr "中量"
 
-#: vncviewer/OptionsDialog.cxx:628
+#: vncviewer/OptionsDialog.cxx:627
 msgid "Low"
 msgstr "少量"
 
@@ -284,166 +261,177 @@ msgstr "少量"
 msgid "Very low"
 msgstr "極少"
 
-#: vncviewer/OptionsDialog.cxx:657
+#: vncviewer/OptionsDialog.cxx:658
 msgid "Custom compression level:"
 msgstr "自訂壓縮等級："
 
-#: vncviewer/OptionsDialog.cxx:664
+#: vncviewer/OptionsDialog.cxx:666
 msgid "level (0=fast, 9=best)"
 msgstr "級別 (0=速度最快、9=品質最好)"
 
-#: vncviewer/OptionsDialog.cxx:671
+#: vncviewer/OptionsDialog.cxx:674
 msgid "Allow JPEG compression:"
 msgstr "允許 JPEG 壓縮方式："
 
-#: vncviewer/OptionsDialog.cxx:678
+#: vncviewer/OptionsDialog.cxx:682
 msgid "quality (0=poor, 9=best)"
 msgstr "品質 (0=最低、9=最好)"
 
-#: vncviewer/OptionsDialog.cxx:689
+#. TRANSLATORS: Tab heading for encryption and authentication settings
+#: vncviewer/OptionsDialog.cxx:694
 msgid "Security"
 msgstr "安全性"
 
-#: vncviewer/OptionsDialog.cxx:703
+#. TRANSLATORS: Label for the encryption options section
+#: vncviewer/OptionsDialog.cxx:709
 msgid "Encryption"
 msgstr "加密方式"
 
-#: vncviewer/OptionsDialog.cxx:715 vncviewer/OptionsDialog.cxx:782
-#: vncviewer/OptionsDialog.cxx:905
+#. TRANSLATORS: No menu key configured
+#: vncviewer/OptionsDialog.cxx:722 vncviewer/OptionsDialog.cxx:795
+#: vncviewer/OptionsDialog.cxx:933
 msgid "None"
 msgstr "無"
 
-#: vncviewer/OptionsDialog.cxx:722
+#: vncviewer/OptionsDialog.cxx:730
 msgid "TLS with anonymous certificates"
 msgstr "使用匿名憑證的 TLS"
 
-#: vncviewer/OptionsDialog.cxx:728
+#: vncviewer/OptionsDialog.cxx:737
 msgid "TLS with X509 certificates"
 msgstr "使用 X509 憑證的 TLS"
 
-#: vncviewer/OptionsDialog.cxx:735
+#: vncviewer/OptionsDialog.cxx:745
 msgid "Path to X509 CA certificate"
 msgstr "X509 CA 憑證位置"
 
-#: vncviewer/OptionsDialog.cxx:742
+#: vncviewer/OptionsDialog.cxx:753
 msgid "Path to X509 CRL file"
 msgstr "X509 CRL 檔案位置"
 
-#: vncviewer/OptionsDialog.cxx:770
+#. TRANSLATORS: Label for the authentication options section
+#: vncviewer/OptionsDialog.cxx:782
 msgid "Authentication"
 msgstr "認證方式"
 
-#: vncviewer/OptionsDialog.cxx:788
+#: vncviewer/OptionsDialog.cxx:802
 msgid "Standard VNC (insecure without encryption)"
 msgstr "標準 VNC 認證方式 (若未開啟加密功能則不安全)"
 
-#: vncviewer/OptionsDialog.cxx:794
+#: vncviewer/OptionsDialog.cxx:809
 msgid "Username and password (insecure without encryption)"
 msgstr "使用者與密碼認證方式 (若未開啟加密功能則不安全)"
 
-#: vncviewer/OptionsDialog.cxx:822
+#. TRANSLATORS: Tab heading for keyboard and mouse settings
+#: vncviewer/OptionsDialog.cxx:838
 msgid "Input"
 msgstr "輸入"
 
-#: vncviewer/OptionsDialog.cxx:835
+#: vncviewer/OptionsDialog.cxx:852
 msgid "View only (ignore mouse and keyboard)"
 msgstr "僅供檢視模式 (忽略滑鼠與鍵盤動作)"
 
-#: vncviewer/OptionsDialog.cxx:842
+#. TRANSLATORS: Label for mouse related options
+#: vncviewer/OptionsDialog.cxx:860
 msgid "Mouse"
 msgstr "滑鼠"
 
-#: vncviewer/OptionsDialog.cxx:854
+#: vncviewer/OptionsDialog.cxx:873
 msgid "Emulate middle mouse button"
 msgstr "模擬滑鼠中鍵"
 
-#: vncviewer/OptionsDialog.cxx:860
+#: vncviewer/OptionsDialog.cxx:880
 msgid "Show local cursor when not provided by server"
 msgstr "如果伺服器沒有提供游標，則顯示本機游標"
 
-#: vncviewer/OptionsDialog.cxx:865
+#. TRANSLATORS: Choice of cursor appearance used when showing a local cursor
+#: vncviewer/OptionsDialog.cxx:886
 msgid "Cursor type"
 msgstr "游標類型"
 
-#: vncviewer/OptionsDialog.cxx:867
+#. TRANSLATORS: Simple dot shaped cursor
+#: vncviewer/OptionsDialog.cxx:889
 msgid "Dot"
 msgstr "點狀"
 
-#: vncviewer/OptionsDialog.cxx:868
+#. TRANSLATORS: Use the operating system's default cursor
+#: vncviewer/OptionsDialog.cxx:891
 msgid "System"
 msgstr "系統"
 
-#: vncviewer/OptionsDialog.cxx:888
+#. TRANSLATORS: Label for keyboard related options
+#: vncviewer/OptionsDialog.cxx:912
 msgid "Keyboard"
 msgstr "鍵盤"
 
-#: vncviewer/OptionsDialog.cxx:900
+#: vncviewer/OptionsDialog.cxx:925
 msgid "Pass system keys directly to server (full screen)"
 msgstr "直接將系統鍵傳至伺服器 (全螢幕模式)"
 
-#: vncviewer/OptionsDialog.cxx:903
+#. TRANSLATORS: Choice of key that will pop up the menu while full screen
+#: vncviewer/OptionsDialog.cxx:930
 msgid "Menu key"
 msgstr "選單鍵"
 
-#: vncviewer/OptionsDialog.cxx:926
+#. TRANSLATORS: Label for clipboard related settings
+#: vncviewer/OptionsDialog.cxx:955
 msgid "Clipboard"
 msgstr "剪貼板"
 
-#: vncviewer/OptionsDialog.cxx:938
+#: vncviewer/OptionsDialog.cxx:968
 msgid "Accept clipboard from server"
 msgstr "接受來自伺服器的剪貼簿內容"
 
-#: vncviewer/OptionsDialog.cxx:946
+#: vncviewer/OptionsDialog.cxx:977
 msgid "Also set primary selection"
 msgstr "亦設定主要選區"
 
-#: vncviewer/OptionsDialog.cxx:953
+#: vncviewer/OptionsDialog.cxx:985
 msgid "Send clipboard to server"
 msgstr "將剪貼簿內容傳至伺服器"
 
-#: vncviewer/OptionsDialog.cxx:961
+#: vncviewer/OptionsDialog.cxx:994
 msgid "Send primary selection as clipboard"
 msgstr "將主要選取區塊作為剪貼簿內容傳送"
 
-#: vncviewer/OptionsDialog.cxx:982
+#. TRANSLATORS: Tab heading for display related settings
+#: vncviewer/OptionsDialog.cxx:1016
 msgid "Display"
 msgstr "顯示"
 
-#: vncviewer/OptionsDialog.cxx:996
+#. TRANSLATORS: Label for the screen mode selection section
+#: vncviewer/OptionsDialog.cxx:1031
 msgid "Display mode"
 msgstr "顯示模式"
 
-#: vncviewer/OptionsDialog.cxx:1009
+#: vncviewer/OptionsDialog.cxx:1045
 msgid "Windowed"
 msgstr "視窗模式"
 
-#: vncviewer/OptionsDialog.cxx:1017
+#: vncviewer/OptionsDialog.cxx:1054
 msgid "Full screen on current monitor"
 msgstr "在目前顯示器全螢幕"
 
-#: vncviewer/OptionsDialog.cxx:1025
+#: vncviewer/OptionsDialog.cxx:1063
 msgid "Full screen on all monitors"
 msgstr "在所有顯示器全螢幕"
 
-#: vncviewer/OptionsDialog.cxx:1033
+#: vncviewer/OptionsDialog.cxx:1072
 msgid "Full screen on selected monitor(s)"
 msgstr "在選取顯示器全螢幕"
 
-#: vncviewer/OptionsDialog.cxx:1062
+#. TRANSLATORS: Tab heading for various other settings
+#: vncviewer/OptionsDialog.cxx:1102
 msgid "Miscellaneous"
 msgstr "雜項設定"
 
-#: vncviewer/OptionsDialog.cxx:1070
+#: vncviewer/OptionsDialog.cxx:1111
 msgid "Shared (don't disconnect other viewers)"
 msgstr "共用連線 (不斷開其他檢視器的連線)"
 
-#: vncviewer/OptionsDialog.cxx:1076
+#: vncviewer/OptionsDialog.cxx:1118
 msgid "Ask to reconnect on connection errors"
 msgstr "詢問是否要在連接發生錯誤時重新連線"
-
-#: vncviewer/ServerDialog.cxx:63
-msgid "VNC viewer: Connection details"
-msgstr "VNC 檢視器：連線詳細資訊"
 
 #: vncviewer/ServerDialog.cxx:73
 msgid "VNC server:"
@@ -488,7 +476,7 @@ msgstr "TigerVNC 組態設定 (*.tigervnc)"
 msgid "Select a TigerVNC configuration file"
 msgstr "請選取 TigerVNC 組態設定檔"
 
-#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:517
+#: vncviewer/ServerDialog.cxx:199 vncviewer/vncviewer.cxx:516
 #, c-format
 msgid ""
 "Unable to load the specified configuration file:\n"
@@ -508,7 +496,7 @@ msgstr "將 TigerVNC 組態設定儲存為檔案"
 msgid "%s already exists. Do you want to overwrite?"
 msgstr "%s 已存在，是否覆寫？"
 
-#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:394
+#: vncviewer/ServerDialog.cxx:244 vncviewer/vncviewer.cxx:393
 msgid "No"
 msgstr "否"
 
@@ -549,169 +537,170 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/ServerDialog.cxx:351 vncviewer/ServerDialog.cxx:429
-#: vncviewer/vncviewer.cxx:580
+#: vncviewer/ServerDialog.cxx:352 vncviewer/ServerDialog.cxx:434
+#: vncviewer/vncviewer.cxx:579
 msgid "Could not determine VNC state directory path"
 msgstr "無法決定 VNC 狀態目錄的路徑"
 
-#: vncviewer/ServerDialog.cxx:363 vncviewer/ServerDialog.cxx:437
-#: vncviewer/parameters.cxx:671 vncviewer/parameters.cxx:752
+#: vncviewer/ServerDialog.cxx:365 vncviewer/ServerDialog.cxx:442
+#: vncviewer/parameters.cxx:757 vncviewer/parameters.cxx:837
 #, c-format
 msgid "Could not open \"%s\""
 msgstr "無法開啟「%s」"
 
-#: vncviewer/ServerDialog.cxx:378 vncviewer/ServerDialog.cxx:387
-#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:773
-#: vncviewer/parameters.cxx:807 vncviewer/parameters.cxx:837
-#: vncviewer/parameters.cxx:844
+#: vncviewer/ServerDialog.cxx:380 vncviewer/ServerDialog.cxx:389
+#: vncviewer/parameters.cxx:851 vncviewer/parameters.cxx:858
+#: vncviewer/parameters.cxx:892 vncviewer/parameters.cxx:928
+#: vncviewer/parameters.cxx:936
 #, c-format
 msgid "Failed to read line %d in file \"%s\""
 msgstr "無法讀取「%2$s」檔案的第 %1$d 列"
 
-#: vncviewer/ServerDialog.cxx:390 vncviewer/parameters.cxx:776
+#: vncviewer/ServerDialog.cxx:393 vncviewer/parameters.cxx:862
 msgid "Line too long"
 msgstr "行字數過長"
 
-#: vncviewer/UserDialog.cxx:123
+#: vncviewer/UserDialog.cxx:130
 msgid "Opening password file failed"
 msgstr "開啟密碼檔失敗"
 
-#: vncviewer/UserDialog.cxx:143
+#: vncviewer/UserDialog.cxx:150
 msgid "VNC authentication"
 msgstr "VNC 認證"
 
-#: vncviewer/UserDialog.cxx:150
+#: vncviewer/UserDialog.cxx:157
 msgid "This connection is secure"
 msgstr "此連線階段安全"
 
-#: vncviewer/UserDialog.cxx:154
+#: vncviewer/UserDialog.cxx:161
 msgid "This connection is not secure"
 msgstr "此連線階段不安全"
 
-#: vncviewer/UserDialog.cxx:176
+#: vncviewer/UserDialog.cxx:183
 msgid "Username:"
 msgstr "使用者名稱："
 
-#: vncviewer/UserDialog.cxx:189
+#: vncviewer/UserDialog.cxx:196
 msgid "Password:"
 msgstr "密碼："
 
-#: vncviewer/UserDialog.cxx:197
+#: vncviewer/UserDialog.cxx:204
 msgid "Keep password for reconnect"
 msgstr "留存密碼供重新連線使用"
 
-#: vncviewer/Viewport.cxx:695
+#: vncviewer/Viewport.cxx:749
 msgctxt "ContextMenu|"
 msgid "Disconn&ect"
 msgstr "中斷連線(&E)"
 
-#: vncviewer/Viewport.cxx:698
+#: vncviewer/Viewport.cxx:752
 msgctxt "ContextMenu|"
 msgid "&Full screen"
 msgstr "全螢幕(&F)"
 
-#: vncviewer/Viewport.cxx:701
+#: vncviewer/Viewport.cxx:755
 msgctxt "ContextMenu|"
 msgid "Minimi&ze"
 msgstr "最小化(&Z)"
 
-#: vncviewer/Viewport.cxx:703
+#: vncviewer/Viewport.cxx:757
 msgctxt "ContextMenu|"
 msgid "Resize &window to session"
 msgstr "將視窗縮放至與連線階段同大小(&W)"
 
-#: vncviewer/Viewport.cxx:708
+#: vncviewer/Viewport.cxx:762
 msgctxt "ContextMenu|"
 msgid "&Ctrl"
 msgstr "&Ctrl"
 
-#: vncviewer/Viewport.cxx:711
+#: vncviewer/Viewport.cxx:765
 msgctxt "ContextMenu|"
 msgid "&Alt"
 msgstr "&Alt"
 
-#: vncviewer/Viewport.cxx:717
+#: vncviewer/Viewport.cxx:771
 #, c-format
 msgctxt "ContextMenu|"
 msgid "Send %s"
 msgstr "傳送 %s 鍵"
 
-#: vncviewer/Viewport.cxx:724
+#: vncviewer/Viewport.cxx:779
 msgctxt "ContextMenu|"
 msgid "Send Ctrl-Alt-&Del"
 msgstr "傳送 Ctrl-Alt-&Del 鍵"
 
-#: vncviewer/Viewport.cxx:727
+#: vncviewer/Viewport.cxx:782
 msgctxt "ContextMenu|"
 msgid "&Refresh screen"
 msgstr "重新整理螢幕(&R)"
 
-#: vncviewer/Viewport.cxx:730
+#: vncviewer/Viewport.cxx:785
 msgctxt "ContextMenu|"
 msgid "&Options..."
 msgstr "選項(&O)…"
 
-#: vncviewer/Viewport.cxx:732
+#: vncviewer/Viewport.cxx:787
 msgctxt "ContextMenu|"
 msgid "Connection &info..."
 msgstr "連線資訊(&I)…"
 
-#: vncviewer/Viewport.cxx:734
+#: vncviewer/Viewport.cxx:789
 msgctxt "ContextMenu|"
-msgid "About &TigerVNC viewer..."
-msgstr "關於 TigerVNC 檢視器(&T)…"
+msgid "About &TigerVNC..."
+msgstr ""
 
-#: vncviewer/Viewport.cxx:830
+#: vncviewer/Viewport.cxx:885
 msgid "VNC connection info"
 msgstr "VNC 連線資訊"
 
-#: vncviewer/Win32TouchHandler.cxx:48
+#: vncviewer/Win32TouchHandler.cxx:49
 msgid "Window is registered for touch instead of gestures"
 msgstr "視窗已被註冊用來接收觸控（而非手勢）操作"
 
-#: vncviewer/Win32TouchHandler.cxx:83
+#: vncviewer/Win32TouchHandler.cxx:84
 #, c-format
 msgid "Failed to set gesture configuration (error 0x%x)"
 msgstr "無法設定手勢設定（錯誤 0x%x）"
 
-#: vncviewer/Win32TouchHandler.cxx:95
+#: vncviewer/Win32TouchHandler.cxx:96
 #, c-format
 msgid "Failed to get gesture information (error 0x%x)"
 msgstr "無法取得手勢資訊（錯誤 0x%x）"
 
-#: vncviewer/Win32TouchHandler.cxx:360
+#: vncviewer/Win32TouchHandler.cxx:364
 #, c-format
 msgid "Invalid mouse button %d, must be a number between 1 and 7."
 msgstr "無效的滑鼠按鍵編號 %d，必須是介於 1 到 7 之間的數字。"
 
-#: vncviewer/Win32TouchHandler.cxx:425
+#: vncviewer/Win32TouchHandler.cxx:429
 #, c-format
 msgid "Unhandled key 0x%x - can't generate keyboard event."
 msgstr "未接管的按鍵 0x%x - 無法產生鍵盤事件。"
 
-#: vncviewer/XInputTouchHandler.cxx:102 vncviewer/touch.cxx:107
+#: vncviewer/XInputTouchHandler.cxx:103 vncviewer/touch.cxx:107
 #, c-format
 msgid "Unable to get X Input 2 event mask for window 0x%08lx"
 msgstr "無法取得視窗 0x%08lx 的 X Input 2 事件遮罩"
 
-#: vncviewer/XInputTouchHandler.cxx:104
+#: vncviewer/XInputTouchHandler.cxx:105
 #, c-format
 msgid "Window 0x%08lx has no X Input 2 event mask"
 msgstr "視窗 0x%08lx 沒有 X Input 2 事件遮罩"
 
-#: vncviewer/XInputTouchHandler.cxx:112 vncviewer/touch.cxx:114
+#: vncviewer/XInputTouchHandler.cxx:113 vncviewer/touch.cxx:114
 #, c-format
 msgid "Window 0x%08lx has more than one X Input 2 event mask"
 msgstr "視窗 0x%08lx 有超過一個 X Input 2 事件遮罩"
 
-#: vncviewer/XInputTouchHandler.cxx:143
+#: vncviewer/XInputTouchHandler.cxx:144
 #, c-format
 msgid "Failure grabbing device %i"
 msgstr "擷取裝置 %i 失敗"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:13
-msgid "TigerVNC Viewer"
-msgstr "TigerVNC 檢視器"
+#: vncviewer/vncviewer.desktop.in.in:3
+msgid "TigerVNC"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:14
 #: vncviewer/vncviewer.desktop.in.in:5
@@ -719,100 +708,122 @@ msgid "Connect to VNC server and display remote desktop"
 msgstr "連線到 VNC 伺服器並顯示遠端桌面"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:17
-msgid "Virtual Network Computing (VNC) is a remote display system that allows you to view and interact with a virtual desktop environment running on another computer on the network. Using VNC, you can run graphical applications on a remote machine and send only the display from these applications to your local device. This package contains a client which will enable you to connect to other desktops running a VNC server. VNC is platform-independent and supports various operating systems and architectures as both servers and clients."
-msgstr "Virtual Network Computing (VNC) 是個遠端顯示系統，讓您能檢視網路上其他電腦的虛擬桌面環境並與之互動。您可以使用 VNC 來執行圖形化的應用程式，並只回傳這些應用程式的顯示畫面到您的本地裝置。本套件包含 VNC 用戶端，讓您可以連線到其他執行著 VNC 伺服器的桌面。VNC 不受平台侷限，無論是伺服器還是用戶端，都支援各種作業系統和架構。"
+msgid ""
+"Virtual Network Computing (VNC) is a remote display system that allows you "
+"to view and interact with a virtual desktop environment running on another "
+"computer on the network. Using VNC, you can run graphical applications on a "
+"remote machine and send only the display from these applications to your "
+"local device. This package contains a client which will enable you to "
+"connect to other desktops running a VNC server. VNC is platform-independent "
+"and supports various operating systems and architectures as both servers and "
+"clients."
+msgstr ""
+"Virtual Network Computing (VNC) 是個遠端顯示系統，讓您能檢視網路上其他電腦的"
+"虛擬桌面環境並與之互動。您可以使用 VNC 來執行圖形化的應用程式，並只回傳這些應"
+"用程式的顯示畫面到您的本地裝置。本套件包含 VNC 用戶端，讓您可以連線到其他執行"
+"著 VNC 伺服器的桌面。VNC 不受平台侷限，無論是伺服器還是用戶端，都支援各種作業"
+"系統和架構。"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:23
-msgid "TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org code bases. TigerVNC started as a next-generation development effort for TightVNC on Unix and Linux platforms, but it split from its parent project in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC supports a variant of Tight encoding that is greatly accelerated by the use of the libjpeg-turbo JPEG codec."
-msgstr "TigerVNC 是以 RealVNC 4 和 X.org 程式碼為基礎打造的 VNC 高速版本。TigerVNC 原先是 TightVNC 在 Unix 和 Linux 平台上的下一代開發成果，但在 2009 年初從原本的專案中分離，讓 TigerVNC 得以專注在 Windows 平台上。TigerVNC 支援 Tight 編碼的變體版本，透過 libjpeg-turbo JPEG 編解碼器，使其速度獲得相當大的提升。"
+msgid ""
+"TigerVNC is a high-speed version of VNC based on the RealVNC 4 and X.org "
+"code bases. TigerVNC started as a next-generation development effort for "
+"TightVNC on Unix and Linux platforms, but it split from its parent project "
+"in early 2009 so that TightVNC could focus on Windows platforms. TigerVNC "
+"supports a variant of Tight encoding that is greatly accelerated by the use "
+"of the libjpeg-turbo JPEG codec."
+msgstr ""
+"TigerVNC 是以 RealVNC 4 和 X.org 程式碼為基礎打造的 VNC 高速版本。TigerVNC 原"
+"先是 TightVNC 在 Unix 和 Linux 平台上的下一代開發成果，但在 2009 年初從原本的"
+"專案中分離，讓 TigerVNC 得以專注在 Windows 平台上。TigerVNC 支援 Tight 編碼的"
+"變體版本，透過 libjpeg-turbo JPEG 編解碼器，使其速度獲得相當大的提升。"
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:33
-msgid "TigerVNC viewer connection to a CentOS machine"
-msgstr "連線至 CentOS 機器的 TigerVNC 檢視器"
+msgid "TigerVNC connection to a CentOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:37
-msgid "TigerVNC viewer connection to a macOS machine"
-msgstr "連線至 macOS 機器的 TigerVNC 檢視器"
+msgid "TigerVNC connection to a macOS machine"
+msgstr ""
 
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:41
-msgid "TigerVNC viewer connection to a Windows machine"
-msgstr "連線至 Windows 機器的 TigerVNC 檢視器"
+msgid "TigerVNC connection to a Windows machine"
+msgstr ""
 
 #. developer_name tag deprecated with Appstream 1.0
 #: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:46
-#: vncviewer/org.tigervnc.vncviewer.metainfo.xml.in:48
 msgid "The TigerVNC team"
 msgstr "TigerVNC 團隊"
 
-#: vncviewer/parameters.cxx:319 vncviewer/parameters.cxx:344
-#: vncviewer/parameters.cxx:361 vncviewer/parameters.cxx:401
-#: vncviewer/parameters.cxx:421
+#: vncviewer/parameters.cxx:385 vncviewer/parameters.cxx:410
+#: vncviewer/parameters.cxx:427 vncviewer/parameters.cxx:467
+#: vncviewer/parameters.cxx:487
 msgid "The name of the parameter is too large"
 msgstr "參數名稱過長"
 
-#: vncviewer/parameters.cxx:323 vncviewer/parameters.cxx:328
-#: vncviewer/parameters.cxx:379
+#: vncviewer/parameters.cxx:389 vncviewer/parameters.cxx:394
+#: vncviewer/parameters.cxx:445
 msgid "The parameter is too large"
 msgstr "參數過長"
 
-#: vncviewer/parameters.cxx:386 vncviewer/parameters.cxx:712
-#: vncviewer/parameters.cxx:822
+#: vncviewer/parameters.cxx:452 vncviewer/parameters.cxx:796
+#: vncviewer/parameters.cxx:908
 msgid "Invalid format or too large value"
 msgstr "格式無效或數值過大"
 
-#: vncviewer/parameters.cxx:440 vncviewer/parameters.cxx:473
+#: vncviewer/parameters.cxx:507 vncviewer/parameters.cxx:540
 msgid "Failed to create registry key"
 msgstr "無法建立登錄機碼"
 
-#: vncviewer/parameters.cxx:461 vncviewer/parameters.cxx:528
-#: vncviewer/parameters.cxx:571 vncviewer/parameters.cxx:638
+#: vncviewer/parameters.cxx:528 vncviewer/parameters.cxx:601
+#: vncviewer/parameters.cxx:645 vncviewer/parameters.cxx:723
 msgid "Failed to close registry key"
 msgstr "無法關閉登錄機碼"
 
-#: vncviewer/parameters.cxx:479 vncviewer/parameters.cxx:506
-#: vncviewer/parameters.cxx:680 vncviewer/parameters.cxx:692
+#: vncviewer/parameters.cxx:547 vncviewer/parameters.cxx:580
+#: vncviewer/parameters.cxx:765 vncviewer/parameters.cxx:777
 #, c-format
 msgid "Failed to save \"%s\": %s"
 msgstr "無法儲存「%s」：%s"
 
-#: vncviewer/parameters.cxx:489 vncviewer/parameters.cxx:520
+#: vncviewer/parameters.cxx:560 vncviewer/parameters.cxx:594
 #, c-format
 msgid "Failed to remove \"%s\": %s"
 msgstr "無法移除「%s」：%s"
 
-#: vncviewer/parameters.cxx:544 vncviewer/parameters.cxx:616
+#: vncviewer/parameters.cxx:618 vncviewer/parameters.cxx:696
 msgid "Failed to open registry key"
 msgstr "無法開啟登錄機碼"
 
-#: vncviewer/parameters.cxx:561
+#: vncviewer/parameters.cxx:635
 #, c-format
 msgid "Failed to read server history entry %d: %s"
 msgstr "無法讀取伺服器歷史記錄的第 %d 條項目：%s"
 
-#: vncviewer/parameters.cxx:597 vncviewer/parameters.cxx:627
+#: vncviewer/parameters.cxx:677 vncviewer/parameters.cxx:707
 #, c-format
 msgid "Failed to read parameter \"%s\": %s"
 msgstr "無法讀取「%s」參數：%s"
 
-#: vncviewer/parameters.cxx:661 vncviewer/parameters.cxx:740
-#: vncviewer/vncviewer.cxx:546
+#: vncviewer/parameters.cxx:746 vncviewer/parameters.cxx:824
+#: vncviewer/vncviewer.cxx:545
 msgid "Could not determine VNC config directory path"
 msgstr "無法決定 VNC 組態目錄的路徑"
 
-#: vncviewer/parameters.cxx:682 vncviewer/parameters.cxx:694
+#: vncviewer/parameters.cxx:766 vncviewer/parameters.cxx:778
 msgid "Could not encode parameter"
 msgstr "無法對參數進行編碼"
 
-#: vncviewer/parameters.cxx:785
+#: vncviewer/parameters.cxx:872
 #, c-format
 msgid "Configuration file %s is in an invalid format"
 msgstr "組態檔案 %s 格式無效"
 
-#: vncviewer/parameters.cxx:809
+#: vncviewer/parameters.cxx:895
 msgid "Invalid format"
 msgstr "格式無效"
 
-#: vncviewer/parameters.cxx:846
+#: vncviewer/parameters.cxx:939
 msgid "Unknown parameter"
 msgstr "未知參數"
 
@@ -853,23 +864,21 @@ msgid "X Input 2 (or newer) is not available."
 msgstr "不支援 X Input 2（或新版）。"
 
 #: vncviewer/touch.cxx:266
-msgid "X Input 2.2 (or newer) is not available. Touch gestures will not be supported."
+msgid ""
+"X Input 2.2 (or newer) is not available. Touch gestures will not be "
+"supported."
 msgstr "不支援 X Input 2.2（或新版）。將不支援觸控手勢。"
 
-#: vncviewer/vncviewer.cxx:104
+#: vncviewer/vncviewer.cxx:103
 #, c-format
 msgid ""
-"TigerVNC viewer v%s\n"
+"TigerVNC v%s\n"
 "Built on: %s\n"
 "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
 "See https://www.tigervnc.org for information on TigerVNC."
 msgstr ""
-"TigerVNC 檢視器 v%s\n"
-"編譯時間：%s\n"
-"著作權所有 (C) 1999-%d TigerVNC 團隊以及其他人 (詳閱 README.rst)\n"
-"前往 https://www.tigervnc.org 取得 TigerVNC 的相關資訊。"
 
-#: vncviewer/vncviewer.cxx:158
+#: vncviewer/vncviewer.cxx:157
 #, c-format
 msgid ""
 "An unexpected error occurred when communicating with the server:\n"
@@ -880,15 +889,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:174
-msgid "About TigerVNC Viewer"
-msgstr "關於 TigerVNC 檢視器"
+#: vncviewer/vncviewer.cxx:173
+msgid "About TigerVNC"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:195
+#: vncviewer/vncviewer.cxx:194
 msgid "Internal FLTK error. Exiting."
 msgstr "內部 FLTK 錯誤。退出。"
 
-#: vncviewer/vncviewer.cxx:214
+#: vncviewer/vncviewer.cxx:213
 #, c-format
 msgid ""
 "%s\n"
@@ -899,63 +908,59 @@ msgstr ""
 "\n"
 "是否嘗試重新連線？"
 
-#: vncviewer/vncviewer.cxx:245 vncviewer/vncviewer.cxx:257
+#: vncviewer/vncviewer.cxx:244 vncviewer/vncviewer.cxx:256
 #, c-format
-msgid "Error starting new TigerVNC Viewer: %s"
-msgstr "啟動新的 TigerVNC 檢視器時發生錯誤：%s"
+msgid "Error starting new connection: %s"
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:266
+#: vncviewer/vncviewer.cxx:265
 #, c-format
-msgid "Termination signal %d has been received. TigerVNC viewer will now exit."
-msgstr "接收到終止信號 %d。TigerVNC 檢視器現將結束。"
+msgid "Termination signal %d has been received. TigerVNC will now exit."
+msgstr ""
 
-#: vncviewer/vncviewer.cxx:391 vncviewer/vncviewer.desktop.in.in:3
-msgid "TigerVNC viewer"
-msgstr "TigerVNC 檢視器"
-
-#: vncviewer/vncviewer.cxx:395
+#: vncviewer/vncviewer.cxx:394
 msgid "Yes"
 msgstr "確認"
 
-#: vncviewer/vncviewer.cxx:398
+#: vncviewer/vncviewer.cxx:397
 msgid "Close"
 msgstr "關閉"
 
-#: vncviewer/vncviewer.cxx:403
+#: vncviewer/vncviewer.cxx:402
 msgid "About"
 msgstr "關於"
 
-#: vncviewer/vncviewer.cxx:406
+#: vncviewer/vncviewer.cxx:405
 msgid "Hide"
 msgstr "隱藏"
 
-#: vncviewer/vncviewer.cxx:409
+#: vncviewer/vncviewer.cxx:408
 msgid "Quit"
 msgstr "關閉"
 
-#: vncviewer/vncviewer.cxx:413
+#: vncviewer/vncviewer.cxx:412
 msgid "Services"
 msgstr "服務"
 
-#: vncviewer/vncviewer.cxx:414
+#: vncviewer/vncviewer.cxx:413
 msgid "Hide others"
 msgstr "隱藏其他"
 
-#: vncviewer/vncviewer.cxx:415
+#: vncviewer/vncviewer.cxx:414
 msgid "Show all"
 msgstr "全部顯示"
 
-#: vncviewer/vncviewer.cxx:424
+#: vncviewer/vncviewer.cxx:423
 msgctxt "SysMenu|"
 msgid "&File"
 msgstr "檔案(&F)"
 
-#: vncviewer/vncviewer.cxx:427
+#: vncviewer/vncviewer.cxx:426
 msgctxt "SysMenu|File|"
 msgid "&New Connection"
 msgstr "建立新連線(&N)"
 
-#: vncviewer/vncviewer.cxx:450
+#: vncviewer/vncviewer.cxx:449
 #, c-format
 msgid ""
 "\n"
@@ -972,24 +977,19 @@ msgstr ""
 "      %s [參數] -listen [通訊埠]\n"
 "      %s [參數] [.tigervnc 檔案]\n"
 
-#: vncviewer/vncviewer.cxx:465
+#: vncviewer/vncviewer.cxx:464
 #, c-format
 msgid ""
 "\n"
 "Options:\n"
 "\n"
 "  -display Xdisplay  - Specifies the X display for the viewer window\n"
-"  -geometry geometry - Initial position of the main VNC viewer window. See the\n"
+"  -geometry geometry - Initial position of the main TigerVNC window. See "
+"the\n"
 "                       man page for details.\n"
 msgstr ""
-"\n"
-"選項：\n"
-"\n"
-"  -display Xdisplay  - 指定檢視器視窗的 X 顯示器\n"
-"  -geometry geometry - 設定 VNC 檢視器主視窗的初始位置。\n"
-"                       詳細資訊請參閱 man 頁面。\n"
 
-#: vncviewer/vncviewer.cxx:472
+#: vncviewer/vncviewer.cxx:471
 #, c-format
 msgid ""
 "\n"
@@ -1006,73 +1006,81 @@ msgstr ""
 "參數名稱不分大小寫。可用的參數如下：\n"
 "\n"
 
-#: vncviewer/vncviewer.cxx:527
-msgid "FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
+#: vncviewer/vncviewer.cxx:526
+msgid ""
+"FullScreenAllMonitors is deprecated, set FullScreenMode to 'all' instead"
 msgstr "已棄用 FullScreenAllMonitors，請改設定 FullScreenMode 為 'all'"
 
-#: vncviewer/vncviewer.cxx:532
-msgid "DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' instead"
-msgstr "DotWhenNoCursor 選項已經過時，請改將 AlwaysCursor 設為 1，然後將 CursorType 設為「Dot」（點狀）"
+#: vncviewer/vncviewer.cxx:531
+msgid ""
+"DotWhenNoCursor is deprecated, set AlwaysCursor to 1 and CursorType to 'Dot' "
+"instead"
+msgstr ""
+"DotWhenNoCursor 選項已經過時，請改將 AlwaysCursor 設為 1，然後將 CursorType "
+"設為「Dot」（點狀）"
 
-#: vncviewer/vncviewer.cxx:553
-msgid "~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
+#: vncviewer/vncviewer.cxx:552
+msgid ""
+"~/.vnc is deprecated, please consult 'man vncviewer' for paths to migrate to."
 msgstr "~/.vnc 已廢棄，請查閱「man vncviewer」了解可以遷移到的路徑。"
 
-#: vncviewer/vncviewer.cxx:557
+#: vncviewer/vncviewer.cxx:556
 #, c-format
-msgid "%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC location."
+msgid ""
+"%%APPDATA%%\\vnc is deprecated, please switch to the %%APPDATA%%\\TigerVNC "
+"location."
 msgstr "%%APPDATA%%\\vnc 已廢棄，請改到 %%APPDATA%%\\TigerVNC 位置。"
 
-#: vncviewer/vncviewer.cxx:562
+#: vncviewer/vncviewer.cxx:561
 #, c-format
 msgid "Could not create VNC config directory \"%s\": %s"
 msgstr "無法建立 VNC 組態目錄「%s」：%s"
 
-#: vncviewer/vncviewer.cxx:568
+#: vncviewer/vncviewer.cxx:567
 msgid "Could not determine VNC data directory path"
 msgstr "無法決定 VNC 資料目錄的路徑"
 
-#: vncviewer/vncviewer.cxx:574
+#: vncviewer/vncviewer.cxx:573
 #, c-format
 msgid "Could not create VNC data directory \"%s\": %s"
 msgstr "無法建立 VNC 資料目錄「%s」：%s"
 
-#: vncviewer/vncviewer.cxx:586
+#: vncviewer/vncviewer.cxx:585
 #, c-format
 msgid "Could not create VNC state directory \"%s\": %s"
 msgstr "無法建立 VNC 狀態目錄「%s」：%s"
 
-#: vncviewer/vncviewer.cxx:703
+#: vncviewer/vncviewer.cxx:704
 #, c-format
 msgid "%s: Unrecognized option '%s'\n"
 msgstr "%s：不認識選項「%s」\n"
 
-#: vncviewer/vncviewer.cxx:705 vncviewer/vncviewer.cxx:713
+#: vncviewer/vncviewer.cxx:706 vncviewer/vncviewer.cxx:714
 #, c-format
 msgid "See '%s --help' for more information.\n"
 msgstr "參閱「%s --help」深入了解。\n"
 
-#: vncviewer/vncviewer.cxx:712
+#: vncviewer/vncviewer.cxx:713
 #, c-format
 msgid "%s: Extra argument '%s'\n"
 msgstr "%s：發現多餘引數「%s」\n"
 
 #. TRANSLATORS: "Parameters" are command line arguments, or settings
 #. from a file or the Windows registry.
-#: vncviewer/vncviewer.cxx:748 vncviewer/vncviewer.cxx:749
+#: vncviewer/vncviewer.cxx:749 vncviewer/vncviewer.cxx:750
 msgid "Parameters -listen and -via are incompatible"
 msgstr "-listen 與 -via 參數不相容"
 
-#: vncviewer/vncviewer.cxx:763
+#: vncviewer/vncviewer.cxx:764
 msgid "Unable to listen for incoming connections"
 msgstr "無法監聽連入連線"
 
-#: vncviewer/vncviewer.cxx:765
+#: vncviewer/vncviewer.cxx:766
 #, c-format
 msgid "Listening on port %d"
 msgstr "正於 %d 連線埠監聽"
 
-#: vncviewer/vncviewer.cxx:794
+#: vncviewer/vncviewer.cxx:795
 #, c-format
 msgid ""
 "Failure waiting for incoming VNC connection:\n"
@@ -1083,7 +1091,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: vncviewer/vncviewer.cxx:815
+#: vncviewer/vncviewer.cxx:816
 #, c-format
 msgid ""
 "Failure setting up encrypted tunnel:\n"
@@ -1097,6 +1105,92 @@ msgstr ""
 #: vncviewer/vncviewer.desktop.in.in:4
 msgid "Remote desktop viewer"
 msgstr "遠端桌面檢視器"
+
+#, c-format
+#~ msgid "(server default %s)"
+#~ msgstr "（伺服器預設值：%s）"
+
+#, c-format
+#~ msgid "SetDesktopSize failed: %d"
+#~ msgstr "執行 SetDesktopSize 失敗：%d"
+
+#~ msgid "Invalid SetColourMapEntries from server!"
+#~ msgstr "伺服器傳來無效的 SetColourMapEntries！"
+
+#, c-format
+#~ msgid "Invalid configuration specified for %s"
+#~ msgstr "為 %s 指定之組態無效"
+
+#, c-format
+#~ msgid "Invalid monitor index '%s'"
+#~ msgstr "顯示器索引編號「%s」無效"
+
+#, c-format
+#~ msgid "Unexpected character '%c'"
+#~ msgstr "遇到非預期字元「%c」"
+
+#~ msgid "VNC viewer: Connection details"
+#~ msgstr "VNC 檢視器：連線詳細資訊"
+
+#~ msgctxt "ContextMenu|"
+#~ msgid "About &TigerVNC viewer..."
+#~ msgstr "關於 TigerVNC 檢視器(&T)…"
+
+#~ msgid "TigerVNC Viewer"
+#~ msgstr "TigerVNC 檢視器"
+
+#~ msgid "TigerVNC viewer connection to a CentOS machine"
+#~ msgstr "連線至 CentOS 機器的 TigerVNC 檢視器"
+
+#~ msgid "TigerVNC viewer connection to a macOS machine"
+#~ msgstr "連線至 macOS 機器的 TigerVNC 檢視器"
+
+#~ msgid "TigerVNC viewer connection to a Windows machine"
+#~ msgstr "連線至 Windows 機器的 TigerVNC 檢視器"
+
+#, c-format
+#~ msgid ""
+#~ "TigerVNC viewer v%s\n"
+#~ "Built on: %s\n"
+#~ "Copyright (C) 1999-%d TigerVNC team and many others (see README.rst)\n"
+#~ "See https://www.tigervnc.org for information on TigerVNC."
+#~ msgstr ""
+#~ "TigerVNC 檢視器 v%s\n"
+#~ "編譯時間：%s\n"
+#~ "著作權所有 (C) 1999-%d TigerVNC 團隊以及其他人 (詳閱 README.rst)\n"
+#~ "前往 https://www.tigervnc.org 取得 TigerVNC 的相關資訊。"
+
+#~ msgid "About TigerVNC Viewer"
+#~ msgstr "關於 TigerVNC 檢視器"
+
+#, c-format
+#~ msgid "Error starting new TigerVNC Viewer: %s"
+#~ msgstr "啟動新的 TigerVNC 檢視器時發生錯誤：%s"
+
+#, c-format
+#~ msgid ""
+#~ "Termination signal %d has been received. TigerVNC viewer will now exit."
+#~ msgstr "接收到終止信號 %d。TigerVNC 檢視器現將結束。"
+
+#~ msgid "TigerVNC viewer"
+#~ msgstr "TigerVNC 檢視器"
+
+#, c-format
+#~ msgid ""
+#~ "\n"
+#~ "Options:\n"
+#~ "\n"
+#~ "  -display Xdisplay  - Specifies the X display for the viewer window\n"
+#~ "  -geometry geometry - Initial position of the main VNC viewer window. "
+#~ "See the\n"
+#~ "                       man page for details.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "選項：\n"
+#~ "\n"
+#~ "  -display Xdisplay  - 指定檢視器視窗的 X 顯示器\n"
+#~ "  -geometry geometry - 設定 VNC 檢視器主視窗的初始位置。\n"
+#~ "                       詳細資訊請參閱 man 頁面。\n"
 
 #~ msgid "Show dot when no cursor"
 #~ msgstr "若無游標則改顯示一個點"
@@ -1177,7 +1271,8 @@ msgstr "遠端桌面檢視器"
 #~ msgid "The parameter %s was too large to read from the registry"
 #~ msgstr "參數 %s 過長以至於無法從登錄表讀取"
 
-#~ msgid "Failed to write configuration file, can't obtain home directory path."
+#~ msgid ""
+#~ "Failed to write configuration file, can't obtain home directory path."
 #~ msgstr "寫入組態檔案失敗，無法取得家目錄路徑。"
 
 #~ msgid "Failed to write configuration file, can't open %s: %s"
@@ -1189,7 +1284,8 @@ msgstr "遠端桌面檢視器"
 #~ msgid "Unknown parameter %s on line %d in file %s"
 #~ msgstr "檔案 %s 中第 %d 行發現不明參數 %s"
 
-#~ msgid "Could not create VNC home directory: can't obtain home directory path."
+#~ msgid ""
+#~ "Could not create VNC home directory: can't obtain home directory path."
 #~ msgstr "無法建立 VNC 家目錄：無法取得家目錄路徑。"
 
 #~ msgid "tigervnc"

--- a/vncviewer/OptionsDialog.cxx
+++ b/vncviewer/OptionsDialog.cxx
@@ -62,6 +62,7 @@ std::map<OptionsCallback*, void*> OptionsDialog::callbacks;
 static std::set<OptionsDialog *> instances;
 
 OptionsDialog::OptionsDialog()
+  // TRANSLATORS: Title of the viewer options dialog window
   : Fl_Window(580, 420, _("TigerVNC options"))
 {
   int x, y;
@@ -95,11 +96,13 @@ OptionsDialog::OptionsDialog()
   x = w() - BUTTON_WIDTH * 2 - INNER_MARGIN - OUTER_MARGIN;
   y = h() - BUTTON_HEIGHT - OUTER_MARGIN;
 
+  // TRANSLATORS: Button that dismisses the dialog without saving
   button = new Fl_Button(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, _("Cancel"));
   button->callback(this->handleCancel, this);
 
   x += BUTTON_WIDTH + INNER_MARGIN;
 
+  // TRANSLATORS: Button that confirms the dialog and applies changes
   button = new Fl_Return_Button(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, _("OK"));
   button->callback(this->handleOK, this);
 
@@ -500,6 +503,7 @@ void OptionsDialog::storeOptions(void)
 
 void OptionsDialog::createCompressionPage(int tx, int ty, int tw, int th)
 {
+  // TRANSLATORS: Tab heading for settings controlling image compression
   Fl_Group *group = new Fl_Group(tx, ty, tw, th, _("Compression"));
 
   int orig_tx, orig_ty;
@@ -513,6 +517,7 @@ void OptionsDialog::createCompressionPage(int tx, int ty, int tw, int th)
   half_width = (full_width - INNER_MARGIN) / 2;
 
   /* AutoSelect checkbox */
+  // TRANSLATORS: Option to automatically pick the best compression settings
   autoselectCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                      CHECK_MIN_WIDTH,
                                                      CHECK_HEIGHT,
@@ -526,6 +531,7 @@ void OptionsDialog::createCompressionPage(int tx, int ty, int tw, int th)
 
   /* VNC encoding box */
   ty += GROUP_LABEL_OFFSET;
+  // TRANSLATORS: Label for a group of encoding method radio buttons
   encodingGroup = new Fl_Group(tx, ty, half_width, 0,
                                 _("Preferred encoding"));
   encodingGroup->box(FL_FLAT_BOX);
@@ -588,6 +594,7 @@ void OptionsDialog::createCompressionPage(int tx, int ty, int tw, int th)
 
   /* Color box */
   ty += GROUP_LABEL_OFFSET;
+  // TRANSLATORS: Label for a group of color quality radio buttons
   colorlevelGroup = new Fl_Group(tx, ty, half_width, 0, _("Color level"));
   colorlevelGroup->labelfont(FL_BOLD);
   colorlevelGroup->box(FL_FLAT_BOX);
@@ -597,6 +604,7 @@ void OptionsDialog::createCompressionPage(int tx, int ty, int tw, int th)
     tx += INDENT;
     ty += TIGHT_MARGIN;
 
+    // TRANSLATORS: Highest color quality
     fullcolorCheckbox = new Fl_Round_Button(LBLRIGHT(tx, ty,
                                                      RADIO_MIN_WIDTH,
                                                      RADIO_HEIGHT,
@@ -604,6 +612,7 @@ void OptionsDialog::createCompressionPage(int tx, int ty, int tw, int th)
     fullcolorCheckbox->type(FL_RADIO_BUTTON);
     ty += RADIO_HEIGHT + TIGHT_MARGIN;
 
+    // TRANSLATORS: Medium color quality
     mediumcolorCheckbox = new Fl_Round_Button(LBLRIGHT(tx, ty,
                                                        RADIO_MIN_WIDTH,
                                                        RADIO_HEIGHT,
@@ -611,6 +620,7 @@ void OptionsDialog::createCompressionPage(int tx, int ty, int tw, int th)
     mediumcolorCheckbox->type(FL_RADIO_BUTTON);
     ty += RADIO_HEIGHT + TIGHT_MARGIN;
 
+    // TRANSLATORS: Low color quality
     lowcolorCheckbox = new Fl_Round_Button(LBLRIGHT(tx, ty,
                                                     RADIO_MIN_WIDTH,
                                                     RADIO_HEIGHT,
@@ -618,6 +628,7 @@ void OptionsDialog::createCompressionPage(int tx, int ty, int tw, int th)
     lowcolorCheckbox->type(FL_RADIO_BUTTON);
     ty += RADIO_HEIGHT + TIGHT_MARGIN;
 
+    // TRANSLATORS: Very low color quality
     verylowcolorCheckbox = new Fl_Round_Button(LBLRIGHT(tx, ty,
                                                         RADIO_MIN_WIDTH,
                                                         RADIO_HEIGHT,
@@ -640,6 +651,7 @@ void OptionsDialog::createCompressionPage(int tx, int ty, int tw, int th)
   ty = (col1_ty > col2_ty ? col1_ty : col2_ty) + INNER_MARGIN;
 
   /* Checkboxes */
+  // TRANSLATORS: Enable manual entry of a compression level
   compressionCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                      CHECK_MIN_WIDTH,
                                                      CHECK_HEIGHT,
@@ -648,12 +660,14 @@ void OptionsDialog::createCompressionPage(int tx, int ty, int tw, int th)
   compressionCheckbox->callback(handleCompression, this);
   ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
+  // TRANSLATORS: Label for the numeric compression level input field
   compressionInput = new Fl_Int_Input(tx + INDENT, ty,
                                       INPUT_HEIGHT, INPUT_HEIGHT,
                                       _("level (0=fast, 9=best)"));
   compressionInput->align(FL_ALIGN_RIGHT);
   ty += INPUT_HEIGHT + INNER_MARGIN;
 
+  // TRANSLATORS: Enable use of JPEG compression
   jpegCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                               CHECK_MIN_WIDTH,
                                               CHECK_HEIGHT,
@@ -662,6 +676,7 @@ void OptionsDialog::createCompressionPage(int tx, int ty, int tw, int th)
   jpegCheckbox->callback(handleJpeg, this);
   ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
+  // TRANSLATORS: Label for JPEG quality numeric input field
   jpegInput = new Fl_Int_Input(tx + INDENT, ty,
                                INPUT_HEIGHT, INPUT_HEIGHT,
                                _("quality (0=poor, 9=best)"));
@@ -675,6 +690,7 @@ void OptionsDialog::createCompressionPage(int tx, int ty, int tw, int th)
 void OptionsDialog::createSecurityPage(int tx, int ty, int tw, int th)
 {
 #if defined(HAVE_GNUTLS) || defined(HAVE_NETTLE)
+  // TRANSLATORS: Tab heading for encryption and authentication settings
   Fl_Group *group = new Fl_Group(tx, ty, tw, th, _("Security"));
 
   int orig_tx;
@@ -689,6 +705,7 @@ void OptionsDialog::createSecurityPage(int tx, int ty, int tw, int th)
 
   /* Encryption */
   ty += GROUP_LABEL_OFFSET;
+  // TRANSLATORS: Label for the encryption options section
   encryptionGroup = new Fl_Group(tx, ty, width, 0, _("Encryption"));
   encryptionGroup->labelfont(FL_BOLD);
   encryptionGroup->box(FL_FLAT_BOX);
@@ -698,6 +715,7 @@ void OptionsDialog::createSecurityPage(int tx, int ty, int tw, int th)
     tx += INDENT;
     ty += TIGHT_MARGIN;
 
+    // TRANSLATORS: No encryption will be used
     encNoneCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                    CHECK_MIN_WIDTH,
                                                    CHECK_HEIGHT,
@@ -705,12 +723,14 @@ void OptionsDialog::createSecurityPage(int tx, int ty, int tw, int th)
     ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
 #ifdef HAVE_GNUTLS
+    // TRANSLATORS: Use TLS encryption without verifying the server
     encTLSCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                   CHECK_MIN_WIDTH,
                                                   CHECK_HEIGHT,
                                                   _("TLS with anonymous certificates")));
     ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
+    // TRANSLATORS: Use TLS encryption with X509 certificates
     encX509Checkbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                    CHECK_MIN_WIDTH,
                                                    CHECK_HEIGHT,
@@ -719,13 +739,15 @@ void OptionsDialog::createSecurityPage(int tx, int ty, int tw, int th)
     ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
     ty += INPUT_LABEL_OFFSET;
-    caInput = new Fl_Input(tx + INDENT, ty, 
+    // TRANSLATORS: Field for specifying the CA certificate file
+    caInput = new Fl_Input(tx + INDENT, ty,
                            width - INDENT * 2, INPUT_HEIGHT,
                            _("Path to X509 CA certificate"));
     caInput->align(FL_ALIGN_LEFT | FL_ALIGN_TOP);
     ty += INPUT_HEIGHT + TIGHT_MARGIN;
 
     ty += INPUT_LABEL_OFFSET;
+    // TRANSLATORS: Field for specifying the certificate revocation list
     crlInput = new Fl_Input(tx + INDENT, ty,
                             width - INDENT * 2, INPUT_HEIGHT,
                             _("Path to X509 CRL file"));
@@ -756,6 +778,7 @@ void OptionsDialog::createSecurityPage(int tx, int ty, int tw, int th)
 
   /* Authentication */
   ty += GROUP_LABEL_OFFSET;
+  // TRANSLATORS: Label for the authentication options section
   authenticationGroup = new Fl_Group(tx, ty, width, 0, _("Authentication"));
   authenticationGroup->labelfont(FL_BOLD);
   authenticationGroup->box(FL_FLAT_BOX);
@@ -765,18 +788,21 @@ void OptionsDialog::createSecurityPage(int tx, int ty, int tw, int th)
     tx += INDENT;
     ty += TIGHT_MARGIN;
 
+    // TRANSLATORS: No authentication required
     authNoneCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                     CHECK_MIN_WIDTH,
                                                     CHECK_HEIGHT,
                                                     _("None")));
     ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
+    // TRANSLATORS: Traditional VNC password authentication
     authVncCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                    CHECK_MIN_WIDTH,
                                                    CHECK_HEIGHT,
                                                    _("Standard VNC (insecure without encryption)")));
     ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
+    // TRANSLATORS: Authenticate using username and password
     authPlainCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                      CHECK_MIN_WIDTH,
                                                      CHECK_HEIGHT,
@@ -808,6 +834,7 @@ void OptionsDialog::createSecurityPage(int tx, int ty, int tw, int th)
 
 void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
 {
+  // TRANSLATORS: Tab heading for keyboard and mouse settings
   Fl_Group *group = new Fl_Group(tx, ty, tw, th, _("Input"));
 
   int orig_tx;
@@ -818,6 +845,7 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
 
   width = tw - OUTER_MARGIN * 2;
 
+  // TRANSLATORS: Disable sending mouse and keyboard events to the server
   viewOnlyCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                   CHECK_MIN_WIDTH,
                                                   CHECK_HEIGHT,
@@ -828,6 +856,7 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
 
   /* Mouse */
   ty += GROUP_LABEL_OFFSET;
+  // TRANSLATORS: Label for mouse related options
   mouseGroup = new Fl_Group(tx, ty, width, 0, _("Mouse"));
   mouseGroup->labelfont(FL_BOLD);
   mouseGroup->box(FL_FLAT_BOX);
@@ -837,12 +866,14 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
     tx += INDENT;
     ty += TIGHT_MARGIN;
 
+    // TRANSLATORS: Option to emulate a middle mouse button
     emulateMBCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                      CHECK_MIN_WIDTH,
                                                      CHECK_HEIGHT,
                                                      _("Emulate middle mouse button")));
     ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
+    // TRANSLATORS: Show a local mouse cursor when the server does not provide one
     alwaysCursorCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                        CHECK_MIN_WIDTH,
                                                        CHECK_HEIGHT,
@@ -851,9 +882,12 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
     ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
     /* Cursor type */
+    // TRANSLATORS: Choice of cursor appearance used when showing a local cursor
     cursorTypeChoice = new Fl_Choice(LBLLEFT(tx, ty, 150, CHOICE_HEIGHT, _("Cursor type")));
 
+    // TRANSLATORS: Simple dot shaped cursor
     fltk_menu_add(cursorTypeChoice, _("Dot"), 0, nullptr, nullptr, 0);
+    // TRANSLATORS: Use the operating system's default cursor
     fltk_menu_add(cursorTypeChoice, _("System"), 0, nullptr, nullptr, 0);
 
     fltk_adjust_choice(cursorTypeChoice);
@@ -874,6 +908,7 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
 
   /* Keyboard */
   ty += GROUP_LABEL_OFFSET;
+  // TRANSLATORS: Label for keyboard related options
   keyboardGroup = new Fl_Group(tx, ty, width, 0, _("Keyboard"));
   keyboardGroup->labelfont(FL_BOLD);
   keyboardGroup->box(FL_FLAT_BOX);
@@ -883,6 +918,7 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
     tx += INDENT;
     ty += TIGHT_MARGIN;
 
+    // TRANSLATORS: Pass keys like Alt-Tab directly to the server when in full screen
     systemKeysCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                       CHECK_MIN_WIDTH,
                                                       CHECK_HEIGHT,
@@ -890,8 +926,10 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
     systemKeysCheckbox->callback(handleSystemKeys, this);
     ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
+    // TRANSLATORS: Choice of key that will pop up the menu while full screen
     menuKeyChoice = new Fl_Choice(LBLLEFT(tx, ty, 150, CHOICE_HEIGHT, _("Menu key")));
 
+    // TRANSLATORS: No menu key configured
     fltk_menu_add(menuKeyChoice, _("None"), 0, nullptr, nullptr, FL_MENU_DIVIDER);
     for (int idx = 0; idx < getMenuKeySymbolCount(); idx++)
       fltk_menu_add(menuKeyChoice, getMenuKeySymbols()[idx].name, 0, nullptr, nullptr, 0);
@@ -913,6 +951,7 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
 
   /* Clipboard */
   ty += GROUP_LABEL_OFFSET;
+  // TRANSLATORS: Label for clipboard related settings
   clipboardGroup = new Fl_Group(tx, ty, width, 0, _("Clipboard"));
   clipboardGroup->labelfont(FL_BOLD);
   clipboardGroup->box(FL_FLAT_BOX);
@@ -922,6 +961,7 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
     tx += INDENT;
     ty += TIGHT_MARGIN;
 
+    // TRANSLATORS: Allow the server to update the local clipboard
     acceptClipboardCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                            CHECK_MIN_WIDTH,
                                                            CHECK_HEIGHT,
@@ -930,6 +970,7 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
     ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
 #if !defined(WIN32) && !defined(__APPLE__)
+    // TRANSLATORS: Also update the primary selection on X11 systems
     setPrimaryCheckbox = new Fl_Check_Button(LBLRIGHT(tx + INDENT, ty,
                                                       CHECK_MIN_WIDTH,
                                                       CHECK_HEIGHT,
@@ -937,6 +978,7 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
     ty += CHECK_HEIGHT + TIGHT_MARGIN;
 #endif
 
+    // TRANSLATORS: Send clipboard contents to the server
     sendClipboardCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                          CHECK_MIN_WIDTH,
                                                          CHECK_HEIGHT,
@@ -945,6 +987,7 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
     ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
 #if !defined(WIN32) && !defined(__APPLE__)
+    // TRANSLATORS: Send the primary X11 selection as clipboard data
     sendPrimaryCheckbox = new Fl_Check_Button(LBLRIGHT(tx + INDENT, ty,
                                                        CHECK_MIN_WIDTH,
                                                        CHECK_HEIGHT,
@@ -969,6 +1012,7 @@ void OptionsDialog::createInputPage(int tx, int ty, int tw, int th)
 
 void OptionsDialog::createDisplayPage(int tx, int ty, int tw, int th)
 {
+  // TRANSLATORS: Tab heading for display related settings
   Fl_Group *group = new Fl_Group(tx, ty, tw, th, _("Display"));
 
   int orig_tx;
@@ -983,6 +1027,7 @@ void OptionsDialog::createDisplayPage(int tx, int ty, int tw, int th)
 
   /* Display mode */
   ty += GROUP_LABEL_OFFSET;
+  // TRANSLATORS: Label for the screen mode selection section
   displayModeGroup = new Fl_Group(tx, ty, width, 0, _("Display mode"));
   displayModeGroup->labelfont(FL_BOLD);
   displayModeGroup->box(FL_FLAT_BOX);
@@ -993,6 +1038,7 @@ void OptionsDialog::createDisplayPage(int tx, int ty, int tw, int th)
     ty += TIGHT_MARGIN;
     width -= INDENT;
 
+    // TRANSLATORS: Run the viewer in a window
     windowedButton = new Fl_Round_Button(LBLRIGHT(tx, ty,
                                                   RADIO_MIN_WIDTH,
                                                   RADIO_HEIGHT,
@@ -1001,6 +1047,7 @@ void OptionsDialog::createDisplayPage(int tx, int ty, int tw, int th)
     windowedButton->callback(handleFullScreenMode, this);
     ty += RADIO_HEIGHT + TIGHT_MARGIN;
 
+    // TRANSLATORS: Full screen on the monitor currently displaying the window
     currentMonitorButton = new Fl_Round_Button(LBLRIGHT(tx, ty,
                                                         RADIO_MIN_WIDTH,
                                                         RADIO_HEIGHT,
@@ -1009,6 +1056,7 @@ void OptionsDialog::createDisplayPage(int tx, int ty, int tw, int th)
     currentMonitorButton->callback(handleFullScreenMode, this);
     ty += RADIO_HEIGHT + TIGHT_MARGIN;
 
+    // TRANSLATORS: Full screen spanning all monitors
     allMonitorsButton = new Fl_Round_Button(LBLRIGHT(tx, ty,
                                             RADIO_MIN_WIDTH,
                                             RADIO_HEIGHT,
@@ -1017,6 +1065,7 @@ void OptionsDialog::createDisplayPage(int tx, int ty, int tw, int th)
     allMonitorsButton->callback(handleFullScreenMode, this);
     ty += RADIO_HEIGHT + TIGHT_MARGIN;
 
+    // TRANSLATORS: Full screen only on the monitors chosen below
     selectedMonitorsButton = new Fl_Round_Button(LBLRIGHT(tx, ty,
                                                  RADIO_MIN_WIDTH,
                                                  RADIO_HEIGHT,
@@ -1049,17 +1098,20 @@ void OptionsDialog::createDisplayPage(int tx, int ty, int tw, int th)
 
 void OptionsDialog::createMiscPage(int tx, int ty, int tw, int th)
 {
+  // TRANSLATORS: Tab heading for various other settings
   Fl_Group *group = new Fl_Group(tx, ty, tw, th, _("Miscellaneous"));
 
   tx += OUTER_MARGIN;
   ty += OUTER_MARGIN;
 
+  // TRANSLATORS: Allow multiple viewers to be connected simultaneously
   sharedCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                   CHECK_MIN_WIDTH,
                                                   CHECK_HEIGHT,
                                                   _("Shared (don't disconnect other viewers)")));
   ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
+  // TRANSLATORS: Ask whether to reconnect if the connection drops
   reconnectCheckbox = new Fl_Check_Button(LBLRIGHT(tx, ty,
                                                   CHECK_MIN_WIDTH,
                                                   CHECK_HEIGHT,


### PR DESCRIPTION
## Summary
- annotate vncviewer/OptionsDialog strings with `// TRANSLATORS:` comments
- regenerate translation template and merge with existing `.po` files

## Testing
- `msgfmt --check po/es.po`

------
https://chatgpt.com/codex/tasks/task_e_6847e68c428c832aa1d7c03bdc068241