### PR TITLE
Update apt-get steps in Dockerfiles

### DIFF
--- a/.github/containers/focal/Dockerfile
+++ b/.github/containers/focal/Dockerfile
@@ -2,8 +2,9 @@ FROM ubuntu:focal
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install packaging-dev equivs
+RUN apt-get update && \
+    apt-get install -y packaging-dev equivs && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN useradd -s /bin/bash -m deb
 RUN echo >> /etc/sudoers

--- a/.github/containers/jammy/Dockerfile
+++ b/.github/containers/jammy/Dockerfile
@@ -2,8 +2,9 @@ FROM ubuntu:jammy
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install packaging-dev equivs
+RUN apt-get update && \
+    apt-get install -y packaging-dev equivs && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN useradd -s /bin/bash -m deb
 RUN echo >> /etc/sudoers

--- a/.github/containers/noble/Dockerfile
+++ b/.github/containers/noble/Dockerfile
@@ -2,8 +2,9 @@ FROM ubuntu:noble
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -y install packaging-dev equivs
+RUN apt-get update && \
+    apt-get install -y packaging-dev equivs && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN useradd -s /bin/bash -m deb
 RUN echo >> /etc/sudoers


### PR DESCRIPTION
## Summary
- consolidate apt-get update/install commands in Ubuntu Dockerfiles

## Testing
- `bash -n .github/containers/*/build.sh`
- `bash .github/containers/focal/build.sh` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847e72a8208832ab1c2aa8423172498