### PR TITLE
Fix viewer/readme shortcuts in Windows installer

### DIFF
--- a/release/tigervnc.iss.in
+++ b/release/tigervnc.iss.in
@@ -28,6 +28,6 @@ Source: "@CMAKE_SOURCE_DIR@\LICENCE.TXT"; DestDir: "{app}"; Flags: ignoreversion
 Name: "{group}\TigerVNC"; FileName: "{app}\vncviewer.exe";
 Name: "{group}\Listening TigerVNC"; FileName: "{app}\vncviewer.exe"; Parameters: "-listen";
 
-Name: "{group}\License"; FileName: "write.exe"; Parameters: "LICENCE.TXT"; WorkingDir: "{app}"; Flags: "useapppaths"
-Name: "{group}\Read Me"; FileName: "write.exe"; Parameters: "README.rst"; WorkingDir: "{app}"; Flags: "useapppaths"
+Name: "{group}\License"; FileName: "notepad.exe"; Parameters: "LICENCE.TXT"; WorkingDir: "{app}"; Flags: "useapppaths"
+Name: "{group}\Read Me"; FileName: "notepad.exe"; Parameters: "README.rst"; WorkingDir: "{app}"; Flags: "useapppaths"
 Name: "{group}\Uninstall TigerVNC"; FileName: "{uninstallexe}"; WorkingDir: "{app}";

--- a/release/winvnc.iss.in
+++ b/release/winvnc.iss.in
@@ -33,8 +33,8 @@ Name: "{group}\VNC server (Service-Mode)\Register VNC service"; FileName: "{app}
 Name: "{group}\VNC server (Service-Mode)\Unregister VNC service"; FileName: "{app}\winvnc4.exe"; Parameters: "-unregister";
 Name: "{group}\VNC server (Service-Mode)\Start VNC service"; FileName: "{app}\winvnc4.exe"; Parameters: "-noconsole -start";
 Name: "{group}\VNC server (Service-Mode)\Stop VNC service"; FileName: "{app}\winvnc4.exe"; Parameters: "-noconsole -stop";
-Name: "{group}\License"; FileName: "write.exe"; Parameters: "LICENCE.TXT"; WorkingDir: "{app}"; Flags: "useapppaths"
-Name: "{group}\Read me"; FileName: "write.exe"; Parameters: "README.rst"; WorkingDir: "{app}"; Flags: "useapppaths"
+Name: "{group}\License"; FileName: "notepad.exe"; Parameters: "LICENCE.TXT"; WorkingDir: "{app}"; Flags: "useapppaths"
+Name: "{group}\Read me"; FileName: "notepad.exe"; Parameters: "README.rst"; WorkingDir: "{app}"; Flags: "useapppaths"
 Name: "{group}\Uninstall TigerVNC server"; FileName: "{uninstallexe}"; WorkingDir: "{app}";
 
 [Tasks]


### PR DESCRIPTION
## Summary
- update installer scripts to open text files with Notepad

## Testing
- `cmake -S . -B build -D CMAKE_BUILD_TYPE=Release` *(fails: Could not find Pixman)*
- `innoextract -e is.exe` *(fails: Stream error while parsing setup headers)*

------
https://chatgpt.com/codex/tasks/task_e_6847f41fd7a0832aa22d4db79fa72940