### PR TITLE
Support combined Windows installer

### DIFF
--- a/release/CMakeLists.txt
+++ b/release/CMakeLists.txt
@@ -8,15 +8,24 @@
 
 if(WIN32)
 
-if(CMAKE_SIZEOF_VOID_P MATCHES 8)
-  set(INST_SUFFIX 64)
-  set(INST_DEFS -DWIN64)
+option(COMBINED_INSTALLER "Build combined 32/64-bit installer" OFF)
+set(WIN32_BINARY_DIR ${CMAKE_BINARY_DIR} CACHE PATH "Directory containing 32-bit build")
+set(WIN64_BINARY_DIR ${CMAKE_BINARY_DIR} CACHE PATH "Directory containing 64-bit build")
+
+if(COMBINED_INSTALLER)
+  set(INST_SUFFIX "")
+  set(INST_DEFS "")
+else()
+  if(CMAKE_SIZEOF_VOID_P MATCHES 8)
+    set(INST_SUFFIX 64)
+    set(INST_DEFS -DWIN64)
+  endif()
 endif()
 
 configure_file(tigervnc.iss.in tigervnc.iss)
 
 add_custom_command(OUTPUT ${CMAKE_PROJECT_NAME}${INST_SUFFIX}-${VERSION}.exe
-  COMMAND iscc -o. ${INST_DEFS} -F${CMAKE_PROJECT_NAME}${INST_SUFFIX}-${VERSION} tigervnc.iss
+  COMMAND iscc -DW32="${WIN32_BINARY_DIR}" -DW64="${WIN64_BINARY_DIR}" -o. ${INST_DEFS} -F${CMAKE_PROJECT_NAME}${INST_SUFFIX}-${VERSION} tigervnc.iss
   DEPENDS vncviewer tigervnc.iss)
 add_custom_target(installer DEPENDS ${CMAKE_PROJECT_NAME}${INST_SUFFIX}-${VERSION}.exe)
 
@@ -24,7 +33,7 @@ if(BUILD_WINVNC)
   configure_file(winvnc.iss.in winvnc.iss)
 
   add_custom_command(OUTPUT ${CMAKE_PROJECT_NAME}${INST_SUFFIX}-winvnc-${VERSION}.exe
-    COMMAND iscc -o. ${INST_DEFS} -F${CMAKE_PROJECT_NAME}${INST_SUFFIX}-winvnc-${VERSION} winvnc.iss
+    COMMAND iscc -DW32="${WIN32_BINARY_DIR}" -DW64="${WIN64_BINARY_DIR}" -o. ${INST_DEFS} -F${CMAKE_PROJECT_NAME}${INST_SUFFIX}-winvnc-${VERSION} winvnc.iss
     DEPENDS winvnc4 wm_hooks vncconfig winvnc.iss)
   add_custom_target(winvnc_installer DEPENDS ${CMAKE_PROJECT_NAME}${INST_SUFFIX}-winvnc-${VERSION}.exe)
 endif()

--- a/release/tigervnc.iss.in
+++ b/release/tigervnc.iss.in
@@ -1,7 +1,5 @@
 [Setup]
-#ifdef WIN64
 ArchitecturesInstallIn64BitMode=x64
-#endif
 AppName=TigerVNC
 AppVerName=TigerVNC @VERSION@ (@BUILD@)
 AppVersion=@VERSION@
@@ -12,7 +10,8 @@ DefaultGroupName=TigerVNC
 LicenseFile=@CMAKE_SOURCE_DIR@\LICENCE.TXT
 
 [Files]
-Source: "@CMAKE_BINARY_DIR@\vncviewer\vncviewer.exe"; DestDir: "{app}"; Flags: ignoreversion restartreplace; 
+Source: "@WIN32_BINARY_DIR@\vncviewer\vncviewer.exe"; DestDir: "{app}"; Flags: ignoreversion restartreplace; Check: not IsWin64
+Source: "@WIN64_BINARY_DIR@\vncviewer\vncviewer.exe"; DestDir: "{app}"; Flags: ignoreversion restartreplace; Check: IsWin64
 Source: "@CMAKE_SOURCE_DIR@\README.rst"; DestDir: "{app}"; Flags: ignoreversion
 Source: "@CMAKE_SOURCE_DIR@\LICENCE.TXT"; DestDir: "{app}"; Flags: ignoreversion
 
@@ -20,7 +19,8 @@ Source: "@CMAKE_SOURCE_DIR@\LICENCE.TXT"; DestDir: "{app}"; Flags: ignoreversion
 #define Lang
 #sub AddLanguage
   #define Lang = FileRead(LINGUAS)
-  Source: "@CMAKE_BINARY_DIR@\po\{#Lang}.mo"; DestDir: "{app}\locale\{#Lang}\LC_MESSAGES"; DestName: "tigervnc.mo"; Flags: ignoreversion
+  Source: "@WIN32_BINARY_DIR@\po\{#Lang}.mo"; DestDir: "{app}\locale\{#Lang}\LC_MESSAGES"; DestName: "tigervnc.mo"; Flags: ignoreversion; Check: not IsWin64
+  Source: "@WIN64_BINARY_DIR@\po\{#Lang}.mo"; DestDir: "{app}\locale\{#Lang}\LC_MESSAGES"; DestName: "tigervnc.mo"; Flags: ignoreversion; Check: IsWin64
 #endsub
 #for {LINGUAS = FileOpen("@CMAKE_SOURCE_DIR@\po\LINGUAS"); !FileEof(LINGUAS); ""} AddLanguage
 

--- a/release/winvnc.iss.in
+++ b/release/winvnc.iss.in
@@ -1,7 +1,5 @@
 [Setup]
-#ifdef WIN64
 ArchitecturesInstallIn64BitMode=x64
-#endif
 AppName=TigerVNC server
 AppVerName=TigerVNC server v@VERSION@ (@BUILD@)
 AppVersion=@VERSION@
@@ -17,9 +15,12 @@ LicenseFile=@CMAKE_SOURCE_DIR@\LICENCE.TXT
 Name: "{sys}\config\systemprofile\Desktop"
 
 [Files]
-Source: "@CMAKE_BINARY_DIR@\win\winvnc\winvnc4.exe"; DestDir: "{app}"; Flags: ignoreversion restartreplace; 
-Source: "@CMAKE_BINARY_DIR@\win\wm_hooks\wm_hooks.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace; 
-Source: "@CMAKE_BINARY_DIR@\win\vncconfig\vncconfig.exe"; DestDir: "{app}"; Flags: ignoreversion restartreplace; 
+Source: "@WIN32_BINARY_DIR@\win\winvnc\winvnc4.exe"; DestDir: "{app}"; Flags: ignoreversion restartreplace; Check: not IsWin64
+Source: "@WIN64_BINARY_DIR@\win\winvnc\winvnc4.exe"; DestDir: "{app}"; Flags: ignoreversion restartreplace; Check: IsWin64
+Source: "@WIN32_BINARY_DIR@\win\wm_hooks\wm_hooks.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace; Check: not IsWin64
+Source: "@WIN64_BINARY_DIR@\win\wm_hooks\wm_hooks.dll"; DestDir: "{app}"; Flags: ignoreversion restartreplace; Check: IsWin64
+Source: "@WIN32_BINARY_DIR@\win\vncconfig\vncconfig.exe"; DestDir: "{app}"; Flags: ignoreversion restartreplace; Check: not IsWin64
+Source: "@WIN64_BINARY_DIR@\win\vncconfig\vncconfig.exe"; DestDir: "{app}"; Flags: ignoreversion restartreplace; Check: IsWin64
 Source: "@CMAKE_SOURCE_DIR@\README.rst"; DestDir: "{app}"; Flags: ignoreversion
 Source: "@CMAKE_SOURCE_DIR@\LICENCE.TXT"; DestDir: "{app}"; Flags: ignoreversion
 


### PR DESCRIPTION
## Summary
- allow cross-arch packaging in Inno Setup scripts
- install the right binaries depending on Windows bitness
- add COMBINED_INSTALLER option to release scripts

## Testing
- `cmake -S . -B build` *(fails: Could not find Pixman)*

------
https://chatgpt.com/codex/tasks/task_e_6847f4777e14832aa89561ee4a2b9914