### PR TITLE
Enable FLTK 1.4 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libfltk1.3-dev fluid gettext appstream
+          sudo apt-get install -y libfltk1.4-dev fluid gettext appstream
           sudo apt-get install -y libpixman-1-dev libjpeg-turbo8-dev
           sudo apt-get install -y libgnutls28-dev nettle-dev libgmp-dev
           sudo apt-get install -y libxtst-dev libxdamage-dev libxfixes-dev libxrandr-dev libpam-dev

--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -17,7 +17,7 @@ Development kits for the following packages:
 
 -- pixman
 
--- FLTK 1.3.3 or later
+-- FLTK 1.3.3 or later (1.4 is supported)
 
 -- If building TLS support:
    * GnuTLS 3.x

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,7 +322,7 @@ if(BUILD_VIEWER)
     set(CMAKE_REQUIRED_INCLUDES ${FLTK_INCLUDE_DIR})
     set(CMAKE_REQUIRED_LIBRARIES ${FLTK_LIBRARIES})
 
-    check_cxx_source_compiles("#include <FL/Fl.H>\n#if FL_MAJOR_VERSION != 1 || FL_MINOR_VERSION != 3\n#error Wrong FLTK version\n#endif\nint main(int, char**) { return 0; }" OK_FLTK_VERSION)
+    check_cxx_source_compiles("#include <FL/Fl.H>\n#if FL_MAJOR_VERSION != 1 || (FL_MINOR_VERSION != 3 && FL_MINOR_VERSION != 4)\n#error Wrong FLTK version\n#endif\nint main(int, char**) { return 0; }" OK_FLTK_VERSION)
     if(NOT OK_FLTK_VERSION)
       message(FATAL_ERROR "Incompatible version of FLTK")
     endif()

--- a/contrib/packages/deb/ubuntu-focal/debian/control
+++ b/contrib/packages/deb/ubuntu-focal/debian/control
@@ -26,7 +26,7 @@ Build-Depends:
  libxrandr-dev,
  libxdamage-dev,
  libxfixes-dev,
- libfltk1.3-dev,
+ libfltk1.4-dev | libfltk1.3-dev,
  xorg-server-source,
  xserver-xorg-dev,
  openjdk-8-jdk,

--- a/contrib/packages/deb/ubuntu-jammy/debian/control
+++ b/contrib/packages/deb/ubuntu-jammy/debian/control
@@ -23,7 +23,7 @@ Build-Depends:
  libpng-dev,
  libxrandr-dev,
  libxdamage-dev,
- libfltk1.3-dev,
+ libfltk1.4-dev | libfltk1.3-dev,
  xorg-server-source,
  xserver-xorg-dev,
  openjdk-8-jdk,

--- a/contrib/packages/deb/ubuntu-noble/debian/control
+++ b/contrib/packages/deb/ubuntu-noble/debian/control
@@ -25,7 +25,7 @@ Build-Depends:
  libpng-dev,
  libxrandr-dev,
  libxdamage-dev,
- libfltk1.3-dev,
+ libfltk1.4-dev | libfltk1.3-dev,
  xorg-server-source,
  xserver-xorg-dev,
  openjdk-8-jdk,


### PR DESCRIPTION
## Summary
- allow FLTK minor version 4 in CMake check
- note FLTK 1.4 support in BUILDING.txt
- update Debian packaging and CI to prefer libfltk1.4-dev

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Debug` after building FLTK 1.4
- `make -j2`

------
https://chatgpt.com/codex/tasks/task_e_6847f4292278832a9a3d7f9243a58332