### PR TITLE
Fix cursor buffer allocation

### DIFF
--- a/unix/xserver/hw/vnc/XserverDesktop.cc
+++ b/unix/xserver/hw/vnc/XserverDesktop.cc
@@ -245,7 +245,8 @@ void XserverDesktop::setCursor(int width, int height, int hotX, int hotY,
   uint8_t *out;
   const unsigned char *in;
 
-  cursorData = new uint8_t[width * height * 4];
+  size_t data_len = (size_t)width * height * 4;
+  cursorData = new uint8_t[data_len];
 
   // Un-premultiply alpha
   in = rgbaData;

--- a/unix/xserver/hw/vnc/vncHooks.c
+++ b/unix/xserver/hw/vnc/vncHooks.c
@@ -1194,7 +1194,8 @@ static void vncHooksSetCursor(DeviceIntPtr dev, ScreenPtr screen,
     hotX = cursor->bits->xhot;
     hotY = cursor->bits->yhot;
 
-    rgbaData = malloc(width * height * 4);
+    size_t data_len = (size_t)width * height * 4;
+    rgbaData = malloc(data_len);
     if (rgbaData == NULL)
       goto out;
 


### PR DESCRIPTION
## Summary
- allocate cursor arrays using `size_t` to avoid truncation for large cursors

## Testing
- `cmake -S . -B build` *(fails: Could not find PAM development files)*

------
https://chatgpt.com/codex/tasks/task_e_6847f4855b38832a8c0ac111c0b54a42