### PR TITLE
Handle invalid screen layout

### DIFF
--- a/vncviewer/CConn.cxx
+++ b/vncviewer/CConn.cxx
@@ -40,6 +40,8 @@
 #include <rfb/Security.h>
 #include <rfb/fenceTypes.h>
 #include <rfb/screenTypes.h>
+#include <rfb/ScreenSet.h>
+#include <stdexcept>
 
 #include <network/TcpSocket.h>
 #ifndef WIN32
@@ -312,7 +314,22 @@ void CConn::setExtendedDesktopSize(unsigned reason, unsigned result,
                                    int w, int h,
                                    const rfb::ScreenSet& layout)
 {
-  CConnection::setExtendedDesktopSize(reason, result, w, h, layout);
+  try {
+    CConnection::setExtendedDesktopSize(reason, result, w, h, layout);
+  } catch (std::invalid_argument&) {
+    char buffer[2048];
+    layout.print(buffer, sizeof(buffer));
+    vlog.error("Invalid screen layout from server:");
+    vlog.error("%s", buffer);
+    rfb::ScreenSet fallback;
+    fallback.add_screen(rfb::Screen(0, 0, 0, w, h, 0));
+    server.setDimensions(w ? w : 1, h ? h : 1, fallback);
+    showMsgBox(static_cast<rfb::MsgBoxFlags>(rfb::MsgBoxFlags::M_OK |
+                                             rfb::MsgBoxFlags::M_ICONWARNING),
+               _( "Invalid screen layout" ),
+               _( "The server sent an invalid screen configuration. "
+                  "Using a fallback layout." ));
+  }
 
   if (reason == rfb::reasonClient)
     desktop->setDesktopSizeDone(result);


### PR DESCRIPTION
## Summary
- ensure invalid desktop layouts from the server don't abort connection
- add fallback path for `serverInit` and `setExtendedDesktopSize`
- inform user when a bad layout is received
- include `<stdexcept>` and qualify `ScreenSet`/`Screen` to fix build on Windows

## Testing
- `cmake -S . -B build` *(fails: Could not find Pixman)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_684803004f38832aa88ac3d37d65f8e9