### PR TITLE
Improve winvnc code quality

### DIFF
--- a/win/winvnc/QueryConnectDialog.cxx
+++ b/win/winvnc/QueryConnectDialog.cxx
@@ -86,9 +86,7 @@ void QueryConnectDialog::initDialog() {
 }
 
 void QueryConnectDialog::setCountdownLabel() {
-  char buf[16];
-  sprintf(buf, "%d", countdown);
-  setItemString(IDC_QUERY_COUNTDOWN, buf);
+  setItemString(IDC_QUERY_COUNTDOWN, std::to_string(countdown).c_str());
 }
 
 BOOL QueryConnectDialog::dialogProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {

--- a/win/winvnc/VNCServerService.cxx
+++ b/win/winvnc/VNCServerService.cxx
@@ -62,6 +62,14 @@ VNCServerService::VNCServerService()
   logParams.setParam("*:EventLog:0,Connections:EventLog:100");
 }
 
+VNCServerService::~VNCServerService() {
+  if (sasLibrary != nullptr) {
+    FreeLibrary(sasLibrary);
+    sasLibrary = nullptr;
+    _SendSAS = nullptr;
+  }
+}
+
 
 //////////////////////////////////////////////////////////////////////////////
 

--- a/win/winvnc/VNCServerService.h
+++ b/win/winvnc/VNCServerService.h
@@ -27,6 +27,7 @@ namespace winvnc {
   class VNCServerService : public rfb::win32::Service {
   public:
     VNCServerService();
+    virtual ~VNCServerService();
 
     DWORD serviceMain(int argc, char* argv[]) override;
     void stop() override;

--- a/win/winvnc/VNCServerWin32.h
+++ b/win/winvnc/VNCServerWin32.h
@@ -27,6 +27,7 @@
 #include <rfb_win32/SocketManager.h>
 #include <winvnc/QueryConnectDialog.h>
 #include <winvnc/ManagedListener.h>
+#include <memory>
 
 namespace core {
     class Mutex;
@@ -106,15 +107,15 @@ namespace winvnc {
     Command command;
     const void* commandData;
     int commandDataLen;
-    core::Mutex* commandLock;
-    core::Condition* commandSig;
+    std::unique_ptr<core::Mutex> commandLock;
+    std::unique_ptr<core::Condition> commandSig;
     rfb::win32::Handle commandEvent;
     rfb::win32::Handle sessionEvent;
 
     // VNCServerWin32 Server-internal state
     rfb::win32::SDisplay desktop;
     rfb::VNCServerST vncServer;
-    core::Mutex* runLock;
+    std::unique_ptr<core::Mutex> runLock;
     DWORD thread_id;
     bool runServer;
     bool isDesktopStarted;


### PR DESCRIPTION
## Summary
- check CreateEvent failures in `VNCServerWin32`
- use `std::unique_ptr` for mutex and condition members
- avoid `sprintf` in `QueryConnectDialog`
- release `sas.dll` when the service exits

## Testing
- `cmake -S . -B build` *(fails: Could not find Pixman)*

------
https://chatgpt.com/codex/tasks/task_e_6848c358f264832abca217ddeca37ef8