### PR TITLE
Drop AX privilege shim for macOS 10.9+

### DIFF
--- a/release/Info.plist.in
+++ b/release/Info.plist.in
@@ -26,10 +26,12 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>@VERSION@</string>
-	<key>CFBundleVersion</key>
-	<string>@VERSION@f@BUILD@</string>
-	<key>LSRequiresCarbon</key>
-	<true/>
+        <key>CFBundleVersion</key>
+        <string>@VERSION@f@BUILD@</string>
+        <key>LSMinimumSystemVersion</key>
+        <string>10.9</string>
+        <key>LSRequiresCarbon</key>
+        <true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright (C) 1999-2025 TigerVNC team and many others (see README.rst)</string>
 </dict>

--- a/vncviewer/cocoa.mm
+++ b/vncviewer/cocoa.mm
@@ -21,7 +21,6 @@
 #endif
 
 #include <assert.h>
-#include <dlfcn.h>
 
 #include <FL/Fl_Window.H>
 #include <FL/x.H>
@@ -52,27 +51,6 @@ bool cocoa_is_trusted(bool prompt)
 
   Boolean trusted;
 
-#if !defined(MAC_OS_X_VERSION_10_9) || MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_9
-  // FIXME: Raise system requirements so this isn't needed
-  void *lib;
-  typedef Boolean (*AXIsProcessTrustedWithOptionsRef)(CFDictionaryRef);
-  AXIsProcessTrustedWithOptionsRef AXIsProcessTrustedWithOptions;
-  CFStringRef kAXTrustedCheckOptionPrompt;
-
-  lib = dlopen(nullptr, 0);
-  if (lib == nullptr)
-    return false;
-
-  AXIsProcessTrustedWithOptions =
-    (AXIsProcessTrustedWithOptionsRef)dlsym(lib, "AXIsProcessTrustedWithOptions");
-
-  dlclose(lib);
-
-  if (AXIsProcessTrustedWithOptions == nullptr)
-    return false;
-
-  kAXTrustedCheckOptionPrompt = CFSTR("AXTrustedCheckOptionPrompt");
-#endif
 
   keys[0] = kAXTrustedCheckOptionPrompt;
   values[0] = prompt ? kCFBooleanTrue : kCFBooleanFalse;


### PR DESCRIPTION
## Summary
- require macOS 10.9 or newer in the bundle metadata
- remove runtime resolution of `AXIsProcessTrustedWithOptions`

## Testing
- `cmake .. && make` *(fails: Could not find Pixman)*

------
https://chatgpt.com/codex/tasks/task_e_6848fe6f7768832ab0b956eac245aa0b