### PR TITLE
Fix Windows build errors

### DIFF
--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -1037,7 +1037,8 @@ int DesktopWindow::fltkHandle(int event)
     // not be resized to cover the new screen. A timer makes sense
     // also on other systems, to make sure that whatever desktop
     // environment has a chance to deal with things before we do.
-    updateMonitors();
+    for (auto *dw : instances)
+      dw->updateMonitors();
     Fl::remove_timeout(reconfigureFullscreen);
     Fl::add_timeout(0.5, reconfigureFullscreen);
   }

--- a/vncviewer/KeyboardWin32.cxx
+++ b/vncviewer/KeyboardWin32.cxx
@@ -33,6 +33,7 @@
 #include <vector>
 
 #include <core/LogWriter.h>
+#include <core/string.h>
 
 #define XK_MISCELLANY
 #define XK_XKB_KEYS


### PR DESCRIPTION
## Summary
- use `updateMonitors()` on all DesktopWindow instances during screen change
- include `core/string.h` in `KeyboardWin32.cxx`

## Testing
- `cmake -S . -B build -GNinja` *(fails: Could not find Pixman)*

------
https://chatgpt.com/codex/tasks/task_e_6849038b9fe4832a8a8f033c52ff1c76