### PR TITLE
Add session recording feature

### DIFF
--- a/vncviewer/CMakeLists.txt
+++ b/vncviewer/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(vncviewer
   Surface.cxx
   OptionsDialog.cxx
   PlatformPixelBuffer.cxx
+  VideoRecorder.cxx
   Viewport.cxx
   parameters.cxx
   touch.cxx

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -44,6 +44,7 @@
 #include "Surface.h"
 #include "Viewport.h"
 #include "touch.h"
+#include "VideoRecorder.h"
 
 #include <FL/Fl.H>
 #include <FL/Fl_Image_Surface.H>
@@ -117,7 +118,7 @@ DesktopWindow::DesktopWindow(int w, int h, CConn* cc_)
     pendingRemoteResize(false), lastResize({0, 0}),
     keyboardGrabbed(false), mouseGrabbed(false),
     statsLastUpdates(0), statsLastPixels(0), statsLastPosition(0),
-    statsGraph(nullptr)
+    statsGraph(nullptr), recorder(nullptr)
 {
   Fl_Group* group;
 
@@ -142,6 +143,9 @@ DesktopWindow::DesktopWindow(int w, int h, CConn* cc_)
   setName();
 
   OptionsDialog::addCallback(handleOptions, this);
+
+  if (recordFile.getValueStr() != "")
+    startRecording();
 
   // Some events need to be caught globally
   if (instances.size() == 0)
@@ -290,6 +294,8 @@ DesktopWindow::~DesktopWindow()
 
   OptionsDialog::removeCallback(handleOptions);
 
+  stopRecording();
+
   delete overlay;
   delete offscreen;
 
@@ -367,6 +373,8 @@ void DesktopWindow::updateWindow()
   }
 
   viewport->updateWindow();
+
+  recordFrame();
 }
 
 
@@ -1795,4 +1803,45 @@ void DesktopWindow::handleStatsTimeout(void *data)
                statsWidth, statsHeight);
 
   Fl::repeat_timeout(0.5, handleStatsTimeout, data);
+}
+
+void DesktopWindow::startRecording()
+{
+#ifdef HAVE_H264
+  if (!recorder)
+  {
+    recorder = new VideoRecorder();
+    PlatformPixelBuffer *fb = viewport->getFrameBuffer();
+    core::Rect r = fb->getRect();
+    if (!recorder->start(recordFile.getValueStr().c_str(), r.width(), r.height())) {
+      delete recorder;
+      recorder = nullptr;
+    }
+  }
+#endif
+}
+
+void DesktopWindow::stopRecording()
+{
+#ifdef HAVE_H264
+  if (recorder) {
+    recorder->stop();
+    delete recorder;
+    recorder = nullptr;
+  }
+#endif
+}
+
+void DesktopWindow::recordFrame()
+{
+#ifdef HAVE_H264
+  if (!recorder)
+    return;
+
+  PlatformPixelBuffer *fb = viewport->getFrameBuffer();
+  core::Rect r = fb->getRect();
+  int stride;
+  const uint8_t *ptr = fb->getBuffer(r, &stride);
+  recorder->addFrame(ptr, r.width(), r.height(), stride * (fb->getPF().bpp/8));
+#endif
 }

--- a/vncviewer/DesktopWindow.h
+++ b/vncviewer/DesktopWindow.h
@@ -36,6 +36,7 @@ class Surface;
 class Viewport;
 
 class Fl_Scrollbar;
+class VideoRecorder;
 
 class DesktopWindow : public Fl_Window {
 public:
@@ -83,6 +84,11 @@ public:
   int handle(int event) override;
 
   void fullscreen_on();
+
+  void startRecording();
+  void stopRecording();
+  void recordFrame();
+  bool isRecording() const { return recorder != nullptr; }
 
 private:
   static void menuOverlay(void *data);
@@ -160,6 +166,8 @@ private:
   unsigned statsLastPosition;
 
   Surface *statsGraph;
+
+  VideoRecorder *recorder;
 };
 
 #endif

--- a/vncviewer/OptionsDialog.cxx
+++ b/vncviewer/OptionsDialog.cxx
@@ -55,6 +55,7 @@
 #include <FL/Fl_Return_Button.H>
 #include <FL/Fl_Round_Button.H>
 #include <FL/Fl_Int_Input.H>
+#include <FL/Fl_Input.H>
 #include <FL/Fl_Choice.H>
 #include <FL/Fl_Box.H>
 
@@ -365,6 +366,7 @@ void OptionsDialog::loadOptions(void)
   /* Misc. */
   sharedCheckbox->value(shared);
   reconnectCheckbox->value(reconnectOnError);
+  recordInput->value(recordFile.getValueStr().c_str());
   alwaysCursorCheckbox->value(alwaysCursor);
   if (cursorType == "system") {
     cursorTypeChoice->value(1);
@@ -519,6 +521,7 @@ void OptionsDialog::storeOptions(void)
   /* Misc. */
   shared.setParam(sharedCheckbox->value());
   reconnectOnError.setParam(reconnectCheckbox->value());
+  recordFile.setParam(recordInput->value());
   alwaysCursor.setParam(alwaysCursorCheckbox->value());
 
   if (cursorTypeChoice->value() == 1) {
@@ -1195,6 +1198,13 @@ void OptionsDialog::createMiscPage(int tx, int ty, int tw, int th)
                                                   CHECK_MIN_WIDTH,
                                                   CHECK_HEIGHT,
                                                   _("Ask to reconnect on connection errors")));
+  ty += CHECK_HEIGHT + TIGHT_MARGIN;
+
+  // TRANSLATORS: File to record the session to
+  recordInput = new Fl_Input(LBLRIGHT(tx, ty,
+                                          CHECK_MIN_WIDTH,
+                                          CHECK_HEIGHT,
+                                          _("Record file")));
   ty += CHECK_HEIGHT + TIGHT_MARGIN;
 
   group->end();

--- a/vncviewer/OptionsDialog.h
+++ b/vncviewer/OptionsDialog.h
@@ -151,6 +151,7 @@ protected:
   /* Misc. */
   Fl_Check_Button *sharedCheckbox;
   Fl_Check_Button *reconnectCheckbox;
+  Fl_Input *recordInput;
 
 private:
   static int fltk_event_handler(int event);

--- a/vncviewer/VideoRecorder.cxx
+++ b/vncviewer/VideoRecorder.cxx
@@ -1,0 +1,135 @@
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "VideoRecorder.h"
+
+#ifdef HAVE_H264
+#include <stdexcept>
+
+VideoRecorder::VideoRecorder()
+  : fmt(nullptr), codec(nullptr), stream(nullptr),
+    sws(nullptr), frame(nullptr), frameCounter(0) {}
+
+VideoRecorder::~VideoRecorder()
+{
+  stop();
+}
+
+bool VideoRecorder::start(const char *filename, int width, int height)
+{
+  if (fmt)
+    return false;
+
+  if (avformat_alloc_output_context2(&fmt, nullptr, nullptr, filename) < 0 || !fmt)
+    return false;
+
+  AVCodec *enc = avcodec_find_encoder(AV_CODEC_ID_MPEG4);
+  if (!enc)
+    return false;
+
+  stream = avformat_new_stream(fmt, enc);
+  if (!stream)
+    return false;
+
+  codec = avcodec_alloc_context3(enc);
+  if (!codec)
+    return false;
+
+  codec->width = width;
+  codec->height = height;
+  codec->time_base = {1,30};
+  codec->framerate = {30,1};
+  codec->pix_fmt = AV_PIX_FMT_YUV420P;
+  if (fmt->oformat->flags & AVFMT_GLOBALHEADER)
+    codec->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+
+  if (avcodec_open2(codec, enc, nullptr) < 0)
+    return false;
+
+  if (avcodec_parameters_from_context(stream->codecpar, codec) < 0)
+    return false;
+
+  if (avio_open(&fmt->pb, filename, AVIO_FLAG_WRITE) < 0)
+    return false;
+
+  if (avformat_write_header(fmt, nullptr) < 0)
+    return false;
+
+  frame = av_frame_alloc();
+  if (!frame)
+    return false;
+  frame->format = codec->pix_fmt;
+  frame->width = width;
+  frame->height = height;
+  if (av_frame_get_buffer(frame, 0) < 0)
+    return false;
+
+  sws = sws_getContext(width, height, AV_PIX_FMT_BGRA,
+                       width, height, codec->pix_fmt,
+                       SWS_BILINEAR, nullptr, nullptr, nullptr);
+  if (!sws)
+    return false;
+
+  frameCounter = 0;
+  return true;
+}
+
+void VideoRecorder::addFrame(const uint8_t *data, int width, int height, int stride)
+{
+  if (!fmt)
+    return;
+
+  const uint8_t *srcSlice[1] = { data };
+  int srcStride[1] = { stride };
+
+  sws_scale(sws, srcSlice, srcStride, 0, height, frame->data, frame->linesize);
+
+  frame->pts = frameCounter++;
+
+  AVPacket pkt;
+  av_init_packet(&pkt);
+  pkt.data = nullptr;
+  pkt.size = 0;
+
+  if (avcodec_send_frame(codec, frame) >= 0) {
+    while (avcodec_receive_packet(codec, &pkt) == 0) {
+      av_packet_rescale_ts(&pkt, codec->time_base, stream->time_base);
+      pkt.stream_index = stream->index;
+      av_interleaved_write_frame(fmt, &pkt);
+      av_packet_unref(&pkt);
+    }
+  }
+}
+
+void VideoRecorder::stop()
+{
+  if (!fmt)
+    return;
+
+  AVPacket pkt;
+  avcodec_send_frame(codec, nullptr);
+  while (avcodec_receive_packet(codec, &pkt) == 0) {
+    av_packet_rescale_ts(&pkt, codec->time_base, stream->time_base);
+    pkt.stream_index = stream->index;
+    av_interleaved_write_frame(fmt, &pkt);
+    av_packet_unref(&pkt);
+  }
+
+  av_write_trailer(fmt);
+
+  avcodec_free_context(&codec);
+  sws_freeContext(sws);
+  av_frame_free(&frame);
+  avio_closep(&fmt->pb);
+  avformat_free_context(fmt);
+
+  fmt = nullptr;
+  codec = nullptr;
+  stream = nullptr;
+  sws = nullptr;
+  frame = nullptr;
+  frameCounter = 0;
+}
+
+#endif // HAVE_H264

--- a/vncviewer/VideoRecorder.h
+++ b/vncviewer/VideoRecorder.h
@@ -1,0 +1,38 @@
+#ifndef __VIDEORECORDER_H__
+#define __VIDEORECORDER_H__
+
+#ifdef HAVE_H264
+extern "C" {
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
+#include <libswscale/swscale.h>
+#include <libavutil/imgutils.h>
+}
+
+class VideoRecorder {
+public:
+  VideoRecorder();
+  ~VideoRecorder();
+
+  bool start(const char *filename, int width, int height);
+  void addFrame(const uint8_t *data, int width, int height, int stride);
+  void stop();
+
+private:
+  AVFormatContext *fmt;
+  AVCodecContext *codec;
+  AVStream *stream;
+  SwsContext *sws;
+  AVFrame *frame;
+  int frameCounter;
+};
+#else
+class VideoRecorder {
+public:
+  bool start(const char *, int, int) { return false; }
+  void addFrame(const uint8_t *, int, int, int) {}
+  void stop() {}
+};
+#endif
+
+#endif

--- a/vncviewer/Viewport.cxx
+++ b/vncviewer/Viewport.cxx
@@ -78,7 +78,8 @@ static core::LogWriter vlog("Viewport");
 
 enum { ID_DISCONNECT, ID_FULLSCREEN, ID_MINIMIZE, ID_RESIZE,
        ID_CTRL, ID_ALT, ID_MENUKEY, ID_CTRLALTDEL,
-       ID_REFRESH, ID_OPTIONS, ID_INFO, ID_ABOUT };
+       ID_REFRESH, ID_RECORD_START, ID_RECORD_STOP,
+       ID_OPTIONS, ID_INFO, ID_ABOUT };
 
 // Used for fake key presses from the menu
 static const int FAKE_CTRL_KEY_CODE = 0x10001;
@@ -782,6 +783,14 @@ void Viewport::initContextMenu()
   fltk_menu_add(contextMenu, p_("ContextMenu|", "&Refresh screen"),
                 0, nullptr, (void*)ID_REFRESH, FL_MENU_DIVIDER);
 
+  DesktopWindow *dw = (DesktopWindow*)window();
+  fltk_menu_add(contextMenu, p_("ContextMenu|", "Start recording"),
+                0, nullptr, (void*)ID_RECORD_START,
+                dw->isRecording()?FL_MENU_INVISIBLE:0);
+  fltk_menu_add(contextMenu, p_("ContextMenu|", "Stop recording"),
+                0, nullptr, (void*)ID_RECORD_STOP,
+                dw->isRecording()?0:FL_MENU_INVISIBLE);
+
   fltk_menu_add(contextMenu, p_("ContextMenu|", "&Options..."),
                 0, nullptr, (void*)ID_OPTIONS, 0);
   fltk_menu_add(contextMenu, p_("ContextMenu|", "Connection &info..."),
@@ -875,6 +884,12 @@ void Viewport::popupContextMenu()
     break;
   case ID_REFRESH:
     cc->refreshFramebuffer();
+    break;
+  case ID_RECORD_START:
+    ((DesktopWindow*)window())->startRecording();
+    break;
+  case ID_RECORD_STOP:
+    ((DesktopWindow*)window())->stopRecording();
     break;
   case ID_OPTIONS:
     OptionsDialog::showDialog();

--- a/vncviewer/Viewport.h
+++ b/vncviewer/Viewport.h
@@ -45,6 +45,8 @@ public:
   // Most efficient format (from Viewport's point of view)
   const rfb::PixelFormat &getPreferredPF();
 
+  PlatformPixelBuffer* getFrameBuffer() { return frameBuffer; }
+
   // Flush updates to screen
   void updateWindow();
 

--- a/vncviewer/parameters.cxx
+++ b/vncviewer/parameters.cxx
@@ -96,6 +96,11 @@ core::StringParameter
 core::AliasParameter
   passwd("passwd", "Alias for PasswordFile", &passwordFile);
 
+core::StringParameter
+  recordFile("Record",
+             "Record session to video file",
+             "");
+
 core::BoolParameter
   autoSelect("AutoSelect",
              "Auto select pixel format and encoding. Default if "
@@ -258,6 +263,7 @@ static core::VoidParameter* parameterArray[] = {
   /* Misc. */
   &reconnectOnError,
   &shared,
+  &recordFile,
   /* Compression */
   &autoSelect,
   &fullColour,

--- a/vncviewer/parameters.h
+++ b/vncviewer/parameters.h
@@ -83,6 +83,8 @@ extern core::BoolParameter reconnectOnError;
 extern core::StringParameter via;
 #endif
 
+extern core::StringParameter recordFile;
+
 void saveViewerParameters(const char *filename, const char *servername=nullptr);
 char* loadViewerParameters(const char *filename);
 

--- a/vncviewer/vncviewer.man
+++ b/vncviewer/vncviewer.man
@@ -279,6 +279,10 @@ JPEG quality level. 0 = Low, 9 = High. May be adjusted automatically if
 \fB-AutoSelect\fP is turned on. Default is 8.
 .
 .TP
+.B \-Record \fIfile\fP
+Record the session to the specified video file using FFmpeg.
+.
+.TP
 .B \-ReconnectOnError
 Display a dialog with any error and offer the possibility to retry
 establishing the connection. In case this is off no dialog to


### PR DESCRIPTION
## Summary
- add `-Record` parameter for recording sessions
- allow editing the record path in options dialog
- support start/stop recording via the context menu
- capture frames in `DesktopWindow` and encode with FFmpeg
- document new option in manual

## Testing
- `cmake ..` *(fails: Could not find PAM development files)*
- `make -j2` *(fails: build error in H264LibavDecoderContext.cxx)*

------
https://chatgpt.com/codex/tasks/task_e_684903e5e5c8832aa7081b8536398262