### PR TITLE
Modernize Windows resources

### DIFF
--- a/win/winvnc/winvnc4.exe.manifest
+++ b/win/winvnc/winvnc4.exe.manifest
@@ -19,4 +19,15 @@
      />
    </dependentAssembly>
 </dependency>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+      <dpiAware>true/pm</dpiAware>
+    </windowsSettings>
+  </application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 and later -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
 </assembly>

--- a/win/winvnc/winvnc4.exe.manifest64
+++ b/win/winvnc/winvnc4.exe.manifest64
@@ -19,4 +19,15 @@
      />
    </dependentAssembly>
 </dependency>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+      <dpiAware>true/pm</dpiAware>
+    </windowsSettings>
+  </application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 and later -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
 </assembly>


### PR DESCRIPTION
## Summary
- restore original winvnc.ico to avoid binary diff
- add DPI-awareness and Windows 10+ compatibility settings in manifests

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6849088d06a4832aad1f67ca35ab5b30