### PR TITLE
Fix WebSocketSocket for mingw builds

### DIFF
--- a/common/network/WebSocketSocket.cxx
+++ b/common/network/WebSocketSocket.cxx
@@ -1,4 +1,6 @@
 #include "WebSocketSocket.h"
+#include <rdr/FdInStream.h>
+#include <rdr/FdOutStream.h>
 #include <openssl/sha.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -85,8 +87,9 @@ bool WebSocketSocket::WSInStream::fillBuffer()
   ensureSpace(len);
   p = in->getptr(pos + len);
   const uint8_t *data = p + pos;
+  uint8_t *dst = const_cast<uint8_t*>(end);
   for (size_t i = 0; i < len; i++)
-    end[i] = data[i] ^ (masked ? mask[i % 4] : 0);
+    dst[i] = data[i] ^ (masked ? mask[i % 4] : 0);
   in->setptr(pos + len);
   end += len;
   (void)b1; // ignore opcode


### PR DESCRIPTION
## Summary
- include FdInStream/FdOutStream to avoid incomplete type errors
- copy WebSocket payload using writable buffer pointer

## Testing
- `cmake -S . -B build -DHAVE_PAM_H=1 -DHAVE_PAM_START=1 -DPAM_LIBS=pam`
- `cmake --build build`
- `ctest --test-dir tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_68490c477444832aa506ef360ba1dd0a