### PR TITLE
Fix viewer build when ffmpeg missing

### DIFF
--- a/vncviewer/CConn.cxx
+++ b/vncviewer/CConn.cxx
@@ -102,7 +102,7 @@ CConn::CConn(const char* vncServerName, network::Socket* socket=nullptr)
   if (!noJpeg)
     setQualityLevel(::qualityLevel);
 
-  if (enableAudio) {
+  if (::enableAudio) {
 #ifdef HAVE_PULSEAUDIO
     pa_sample_spec ss = { PA_SAMPLE_S16LE, 2, 44100 };
     int err;
@@ -115,7 +115,7 @@ CConn::CConn(const char* vncServerName, network::Socket* socket=nullptr)
 #endif
   }
 
-  setEnableAudio(enableAudio);
+  setEnableAudio(::enableAudio);
 
   if(sock == nullptr) {
     try {

--- a/vncviewer/VideoRecorder.cxx
+++ b/vncviewer/VideoRecorder.cxx
@@ -4,7 +4,7 @@
 
 #include "VideoRecorder.h"
 
-#ifdef HAVE_H264
+#if defined(HAVE_H264) && defined(H264_LIBAV)
 #include <stdexcept>
 
 VideoRecorder::VideoRecorder()
@@ -132,4 +132,4 @@ void VideoRecorder::stop()
   frameCounter = 0;
 }
 
-#endif // HAVE_H264
+#endif // HAVE_H264 && H264_LIBAV

--- a/vncviewer/VideoRecorder.h
+++ b/vncviewer/VideoRecorder.h
@@ -1,7 +1,7 @@
 #ifndef __VIDEORECORDER_H__
 #define __VIDEORECORDER_H__
 
-#ifdef HAVE_H264
+#if defined(HAVE_H264) && defined(H264_LIBAV)
 extern "C" {
 #include <libavformat/avformat.h>
 #include <libavcodec/avcodec.h>
@@ -33,6 +33,7 @@ public:
   void addFrame(const uint8_t *, int, int, int) {}
   void stop() {}
 };
+
 #endif
 
 #endif


### PR DESCRIPTION
## Summary
- guard the FFmpeg based recorder behind H264_LIBAV
- use the global enableAudio variable when initializing audio playback

## Testing
- `cmake -S . -B build` *(fails: could not find PAM development files)*

------
https://chatgpt.com/codex/tasks/task_e_684912fe8158832aa32465ceb44bef77