### PR TITLE
Fix viewer build includes

### DIFF
--- a/vncviewer/CConn.cxx
+++ b/vncviewer/CConn.cxx
@@ -61,6 +61,8 @@
 #include "vncviewer.h"
 
 #ifdef WIN32
+#include <windows.h>
+#include <mmsystem.h>
 #include "win32.h"
 #endif
 

--- a/vncviewer/CConn.h
+++ b/vncviewer/CConn.h
@@ -24,6 +24,11 @@
 
 #include <rfb/CConnection.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#include <mmsystem.h>
+#endif
+
 #include "UserDialog.h"
 
 namespace network { class Socket; }

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -43,6 +43,7 @@
 #include "CConn.h"
 #include "Surface.h"
 #include "Viewport.h"
+#include "PlatformPixelBuffer.h"
 #include "touch.h"
 #include "VideoRecorder.h"
 

--- a/vncviewer/VideoRecorder.h
+++ b/vncviewer/VideoRecorder.h
@@ -1,6 +1,8 @@
 #ifndef __VIDEORECORDER_H__
 #define __VIDEORECORDER_H__
 
+#include <cstdint>
+
 #if defined(HAVE_H264) && defined(H264_LIBAV)
 extern "C" {
 #include <libavformat/avformat.h>


### PR DESCRIPTION
## Summary
- include `<cstdint>` in VideoRecorder headers
- include PlatformPixelBuffer in DesktopWindow
- include Windows multimedia headers for audio support

## Testing
- `cmake -S . -B build` *(fails: Could not find Pixman)*
- `cmake --build build` *(fails: No rule to make target)*
- `ctest --test-dir tests/unit` *(reports no tests found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6849158e6fa8832a88851d043f60dac9