### PR TITLE
Fix Windows build links

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,8 @@ if (ENABLE_NETTLE)
     add_definitions("-DHAVE_NETTLE")
   endif()
 endif()
+# Check for OpenSSL library
+find_package(OpenSSL REQUIRED)
 
 # Check for PAM library
 if(UNIX AND NOT APPLE)

--- a/common/network/CMakeLists.txt
+++ b/common/network/CMakeLists.txt
@@ -10,6 +10,10 @@ endif()
 
 target_include_directories(network PUBLIC ${CMAKE_SOURCE_DIR}/common)
 target_link_libraries(network core rdr)
+if(OPENSSL_FOUND)
+  target_include_directories(network SYSTEM PUBLIC ${OPENSSL_INCLUDE_DIR})
+  target_link_libraries(network ${OPENSSL_CRYPTO_LIBRARY})
+endif()
 
 if(WIN32)
 	target_link_libraries(network ws2_32)

--- a/vncviewer/CMakeLists.txt
+++ b/vncviewer/CMakeLists.txt
@@ -58,6 +58,7 @@ target_link_libraries(vncviewer ${FLTK_LIBRARIES} ${GETTEXT_LIBRARIES})
 
 if(WIN32)
   target_link_libraries(vncviewer msimg32)
+  target_link_libraries(vncviewer winmm)
 elseif(APPLE)
   target_link_libraries(vncviewer "-framework Cocoa")
   target_link_libraries(vncviewer "-framework Carbon")


### PR DESCRIPTION
## Summary
- link network library with OpenSSL for SHA1
- add WinMM for Windows audio
- require OpenSSL during configuration

## Testing
- `cmake -S . -B build` *(fails: Could not find PAM development files)*

------
https://chatgpt.com/codex/tasks/task_e_684923497464832aba88609c35272372