### PR TITLE
Fix Windows build includes

### DIFF
--- a/vncviewer/CConn.h
+++ b/vncviewer/CConn.h
@@ -21,6 +21,10 @@
 #define __CCONN_H__
 
 #include <FL/Fl.H>
+#ifdef _WIN32
+#include <windows.h>
+#include <mmsystem.h>
+#endif
 
 #include <rfb/CConnection.h>
 

--- a/vncviewer/DesktopWindow.cxx
+++ b/vncviewer/DesktopWindow.cxx
@@ -45,6 +45,7 @@
 #include "Viewport.h"
 #include "touch.h"
 #include "VideoRecorder.h"
+#include "PlatformPixelBuffer.h"
 
 #include <FL/Fl.H>
 #include <FL/Fl_Image_Surface.H>

--- a/vncviewer/VideoRecorder.h
+++ b/vncviewer/VideoRecorder.h
@@ -1,6 +1,8 @@
 #ifndef __VIDEORECORDER_H__
 #define __VIDEORECORDER_H__
 
+#include <cstdint>
+
 #if defined(HAVE_H264) && defined(H264_LIBAV)
 extern "C" {
 #include <libavformat/avformat.h>


### PR DESCRIPTION
## Summary
- include <cstdint> for uint8_t in VideoRecorder
- include PlatformPixelBuffer in DesktopWindow
- include Windows headers in CConn

## Testing
- `cmake -S . -B build` *(fails: Could NOT find FLTK, GMP, PAM, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68493f1ff134832aa754c3e6e789efb9